### PR TITLE
Remove duplicate word: "idea".

### DIFF
--- a/mule-user-guide/v/3.7/flow-processing-strategies.adoc
+++ b/mule-user-guide/v/3.7/flow-processing-strategies.adoc
@@ -328,7 +328,7 @@ If our example flow has two outbound HTTP request calls, the total time the list
 
 To achieve a target of 1000 TPS, you would need to configure 500 listener threads. It's not ideal that this tuning is required out of the box, but what is worse is that this tuning is often short-lived, because if the client concurrency increases, not only does the TPS not increase, but the response time increases relative to the increase in concurrency. On the other hand, if the processing time increases to 1s, then the maximum TPS of the tuned flow is 500 TPS regardless of how many clients there are.
 
-One solution to this is to always tune using a very high number of threads to plan for all eventualities, but this isn’t a good idea idea because threads consume resources, there is a direct memory buffer per thread, and depending on the operating systems in use, there can be overhead associated with using a large number of threads concurrently.
+One solution to this is to always tune using a very high number of threads to plan for all eventualities, but this isn’t a good idea because threads consume resources, there is a direct memory buffer per thread, and depending on the operating systems in use, there can be overhead associated with using a large number of threads concurrently.
 
 For reference the TPS calculation with non-blocking would be:
 


### PR DESCRIPTION
The word idea was duplicated within Mule User Guide > Flow Processing Strategy docs. https://developer.mulesoft.com/docs/display/current/Flow+Processing+Strategies.