### PR TITLE
Update the Warning section related to the usage of activemq-all jar

### DIFF
--- a/mule-user-guide/v/3.7/activemq-integration.adoc
+++ b/mule-user-guide/v/3.7/activemq-integration.adoc
@@ -30,29 +30,31 @@ Also copy the JAR files you need to the Mule lib directory (`$MULE_HOME/lib/user
 
 [WARNING]
 ====
-Adding link:https://repository.apache.org/content/repositories/releases/org/apache/activemq/activemq-all/[ActiveMq-all.jar] will create conflicts with other dependencies, so please add only the jar files you need in relation to what you need ActiveMQ for:
+The usage of link:https://repository.apache.org/content/repositories/releases/org/apache/activemq/activemq-all/[activemq-all-x.x.x.jar] creates conflicts with other dependencies, most notably with log4j, so please only add the jar files required by the deployment mode you have chosen for ActiveMQ:
 
 *JARs for Embedded ActiveMQ*:
-
-apache-activemq-5.8.0/lib/activemq-kahadb-store-5.8.0.jar
-
-apache-activemq-5.8.0/lib/activemq-protobuf-1.1.jar
-apache-activemq-5.8.0/lib/activemq-openwire-legacy-5.8.0.jar
-apache-activemq-5.8.0/lib/hawtbuf-1.9.jar
-apache-activemq-5.8.0/lib/activemq-broker-5.8.0.jar
-apache-activemq-5.8.0/lib/activemq-client-5.8.0.jar
-
+....
+apache-activemq-5.12.0/lib/activemq-broker-5.12.0.jar
+apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
+apache-activemq-5.12.0/lib/activemq-kahadb-store-5.12.0.jar
+apache-activemq-5.12.0/lib/activemq-openwire-legacy-5.12.0.jar
+apache-activemq-5.12.0/lib/activemq-protobuf-1.1.jar
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
+....
 *JARs for External ActiveMQ*:
-
-apache-activemq-5.8.0/lib/activemq-client-5.8.0.jar
-apache-activemq-5.8.0/lib/hawtbuf-1.9.jar
-
+....
+apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
+....
 *JARs for Failover ActiveMQ*:
-
-apache-activemq-5.8.0/lib/activemq-client-5.8.0.jar
-apache-activemq-5.8.0/lib/hawtbuf-1.9.jar
-
-To include these .jar files in your project, simply right-click on your project and select *build path* > *add external archives*.
+....
+apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
+....
+To include these .jar files in your project, simply right-click on your project and select *Build Path* > *Add External Archives...*
 ====
 
 Mule initializes the ActiveMQ connector with the default instance of the ActiveMQ connection factory and establishes a TCP connection to the remote standalone broker running on local host and listening on port 61616.


### PR DESCRIPTION
The file geronimo-j2ee-management_1.1_spec-1.0.1.jar is no longer bundled with Mule runtime since release 3.6.0