### PR TITLE
Remove -DargLine and ensure argument being set equals property to be …

### DIFF
--- a/mule-user-guide/v/3.7/munit-database-server.adoc
+++ b/mule-user-guide/v/3.7/munit-database-server.adoc
@@ -254,4 +254,4 @@ This is use in combination with the Mule property placeholder, shown below with 
 In the example above, the use of `${env}` allows us to leverage execution environments. So for example we can define two separate properties files, `mule.test.properties` and `mule.prod.properties`, containing the same properties with values according to the environment we wish to use.
 
 [TIP]
-To run your test from Maven and issue the env parameter from the command line, you can run: `mvn -DargLine="-Dmule.env=test" clean test`.
+To run your test from Maven and issue the env parameter from the command line, you can run: `mvn -Denv=test clean test`.


### PR DESCRIPTION
Assume the property placeholder is:

```xml
<!-- reference to all property files -->
<context:property-placeholder location="common.properties, servers-${env}.properties"/>
```

Running:
```
  mvn -DargLine="-Dmule.env=dev" clean test
```

Produces:
```
org.springframework.beans.factory.BeanInitializationException:
Could not load properties;
nested exception is java.io.FileNotFoundException:
class path resource [servers-${env}.properties] cannot be opened because it does not exist
```

Correct command:
  ```
  mvn -Denv=dev clean test
  ```