### PR TITLE
Update mule-maven-plugin groupId to new location

### DIFF
--- a/mule-user-guide/v/3.7/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.7/mule-maven-plugin.adoc
@@ -25,7 +25,7 @@ Edit your `settings.xml` or project file to include the following:
 [source, xml, linenums]
 ----
 <plugin>
-  <groupId>org.mule.tools</groupId>
+  <groupId>org.mule.tools.maven</groupId>
   <artifactId>mule-maven-plugin</artifactId>
   <version>2.0</version>
 </plugin>


### PR DESCRIPTION
Appears to be a small oversight in updating this value as its correct in all subsequent examples.