### PR TITLE
Fixed the mule-agent installation instructions for 1.2.0

### DIFF
--- a/anypoint-platform-on-premises/v/1.0/installing-anypoint-on-premises.adoc
+++ b/anypoint-platform-on-premises/v/1.0/installing-anypoint-on-premises.adoc
@@ -323,9 +323,20 @@ For details on managing API Platform, see link:/anypoint-platform-administration
 [[download_agent]]
 === Downloading Mule Agent for Anypoint Platform On-Prem
 
-To add a server to your on-premise Anypoint Platform, you need to https://s3.amazonaws.com/mulesoft-fileshare/onprem-test/agent-setup-onPrem.jar[download] and install the on-premise version of the agent.
+To add a server to your on-premise Anypoint Platform, you need to http://mule-agent.s3.amazonaws.com/1.2.0/mule-agent-1.2.0.zip[download] and install the agent.
 
-The on-premise agent download consists of an installer script, `agent-setup-onPrem.jar`. Place this file in `<MULE_HOME>/bin`. You will run it from this location after completing the required steps in API Platform, as described below.
+. Unzip the ` mule-agent-[VERSION].zip` to the `$MULE_HOME/bin` folder.
++
+[INFO]
+====
+The agent zip file contains these 3 files - the `amc_setup` files install the Mule agent plugin.
+
+* `amc_setup` - Mac and Linux installation file
+* `amc_setup.bat` - Windows installation file
+* `agent-setup-<version>.jar` - Called by the installation files
+====
+
+You will run it from this location after completing the required steps in API Platform, as described below.
 
 === Obtaining the Token for Your Server
 
@@ -339,16 +350,16 @@ A sample command looks like:
 
 [code, bash, linenums]
 ----
-java -jar agent-setup.jar -H 9658e868-[redacted]-d84e1116b585---1 server-name
+./amc_setup -H 9658e868-[redacted]-d84e1116b585---1 server-name
 ----
 
-Copy the _token_ (not the full command) to your clipboard. On the machine where your Mule server resides open a terminal and go to `$MULE_HOME/bin`. Here you should have placed your copy of the Mule agent on-premise installer, `agent-setup-onPrem.jar` (see <<download_agent,above>>).
+Copy the command to your clipboard. On the machine where your Mule server resides open a terminal and go to `$MULE_HOME/bin`. Here you should have placed your copy of the Mule agent installer (see <<download_agent,above>>).
 
-In the `$MULE_HOME/bin` directory, run the following command:
+In the `$MULE_HOME/bin` directory, paste the given command and append the following parameters:
 
 [code, bash, linenums]
 ----
-java -jar agent-setup.jar -A http://$DOCKER_IP_ADDRESS:8080/hybrid/api/v1 -W "wss://<Anypoint Platform host>:8443/mule" -C https://<AnypointPlatform host>/accounts -F https://<Anypoint Platform host>/apiplatform-H  <token><server name>
+./amc_setup -H <token> <server name> -A http://$DOCKER_IP_ADDRESS:8080/hybrid/api/v1 -W "wss://<Anypoint Platform host>:8443/mule" -C https://<AnypointPlatform host>/accounts -F https://<Anypoint Platform host>/apiplatform
 ----
 
 Where:


### PR DESCRIPTION
Changed the Mule Agent Installer, to point to the latest version 1.2.0, and modified the installation steps to make them more straightforward.