### PR TITLE
Add "Important" note to Oracle EBS Connector user manual

### DIFF
--- a/mule-user-guide/v/3.7/oracle-ebs-connector-user-guide.adoc
+++ b/mule-user-guide/v/3.7/oracle-ebs-connector-user-guide.adoc
@@ -48,6 +48,9 @@ Oracle EBS Connector 1.0 is compatible with:
 |*Java* |7
 |===
 
+[IMPORTANT]
+Please note that this connector only supports EBS version 12.1.x with SOA Gateway. Due to licensing changes by Oracle, version 12.2.x does not ship with SOA Gateway and will not work with this connector.
+
 == Connector Architecture
 
 Oracle EBS offers different technologies or products to address various types of integrations. Listed below are the most widely used for integration with enterprise applications:


### PR DESCRIPTION
...explaining why version 12.2.x is not supported.