### PR TITLE
Fixing mule agent install link to the latest version

### DIFF
--- a/cloudhub/v/latest/managing-applications-and-servers-in-the-cloud-and-on-premises.adoc
+++ b/cloudhub/v/latest/managing-applications-and-servers-in-the-cloud-and-on-premises.adoc
@@ -191,7 +191,7 @@ The `amc_setup` command described above resides in `$MULE_HOME/bin`. If you do 
 /opt/mule-3.7.0/bin/amc_setup --mule-home /opt/mule-3.7.0 -H ...
 ----
 
-The `amc_setup` script actually invokes the link:/cloudhub/the-mule-agent[Mule agent] installation script, which has several useful parameters for configuring security and proxies. For details on the options, see *Installation Options* in link:/mule-agent/v/1.1.1/installing-mule-agent[Installing Mule Agent].
+The `amc_setup` script actually invokes the link:/cloudhub/the-mule-agent[Mule agent] installation script, which has several useful parameters for configuring security and proxies. For details on the options, see *Installation Options* in link:/mule-agent/v/1.2.0/installing-mule-agent[Installing Mule Agent].
 
 ==== About the Server Registration Token
 


### PR DESCRIPTION
Fixing mule agent install link to the latest version, now 1.2.0. Is there a URL that always redirects to the latest version so we don't need to change this again for the next agent release?