### PR TITLE
Release v2.1.9

### DIFF
--- a/mule-user-guide/v/3.7/microsoft-sharepoint-2013-connector.adoc
+++ b/mule-user-guide/v/3.7/microsoft-sharepoint-2013-connector.adoc
@@ -2,6 +2,7 @@
 :keywords: anypoint studio, esb, connector, endpoint, microsoft, sharepoint, share point, intranet
 
 *Select*
+*Latest version: 2.1.9*
 
 Microsoft SharePoint is a web application platform for content and document management, intranet portals, collaboration, extranets, websites, and enterprise search.
 
@@ -34,12 +35,16 @@ Supported Microsoft SharePoint versions:
 The Microsoft SharePoint connector supports different authentication schemes based on which +
 Microsoft SharePoint that you access:
 
-* Supported Microsoft SharePoint authentication on-premise: +
-** NTLM
-** Claims-based authentication
-* Supported Microsoft SharePoint authentication online:
-** Claims-based authentication
+Supported Microsoft SharePoint authentication on-premise:
+
+* NTLM
+* Claims-based authentication against Microsoft ADFS
 * Unsupported authentication: Kerberos
+
+Supported Microsoft SharePoint Online authentication:
+
+* Microsoft Online (Office 365) managed users
+* Microsoft Online (Office 365) federated users against Microsoft ADFS
 
 ==== Claims-Based Authentication
 


### PR DESCRIPTION
Release Notes to be reviewed by Derek:
- The Online and Claims connections did not run on Java 8. This version adds support for Java 8 (in Mule 3.7+) and re-adds support for older Mule versions from 3.5+. Java 7 or greater is required for all Mule versions.