### PR TITLE
Update creating-or-disbanding-a-cluster.adoc

### DIFF
--- a/mule-management-console/v/3.7/creating-or-disbanding-a-cluster.adoc
+++ b/mule-management-console/v/3.7/creating-or-disbanding-a-cluster.adoc
@@ -5,6 +5,9 @@ You can use the Management Console to create one or more clusters. A cluster may
 [NOTE]
 When you create a cluster, all the nodes that you select for the cluster must implement the same agent version and the same Mule ESB version. If you need to upgrade a server so that it matches the Mule ESB version of the other cluster nodes, first unregister the server, then upgrade it to the required version of Mule. Then you can create the cluster with the upgraded server (and the other servers) as nodes.
 
+[NOTE]
+You are only able to create a cluster when the license on at least one of the registered ESB servers is either a Trial License (which offers full functionality for a limited time) or a Platinum license, which is needed for clustering. If this isn't the case the option *New Cluster* will be grayed out from the drop-down menu.
+
 [TIP]
 You can also create and disband clusters programmatically using the Management Console link:/mule-management-console/v/3.7/rest-api-reference[REST API].
 
@@ -16,7 +19,7 @@ Follow these steps to create a cluster:
 
 . Bring up the *All servers* pane. To do so, click the *Servers* tab, and if necessary, click *All* in the left-hand navigation pane. Clicking *All* displays the servers registered in all groups. You may need to click *All* if you're currently viewing the servers registered in a specific group such as Development or Test.
 
-. From the *All servers* pane, click the *Add* drowp-down menu (upper-right toolbar), then select *New Cluster* from the menu options.
+. From the *All servers* pane, click the *Add* drop-down menu (upper-right toolbar), then select *New Cluster* from the menu options.
 +
 image:new.cluster.png[new.cluster]
 


### PR DESCRIPTION
Added information on the availability of the *New Cluster* option, which isn't available when the correct license isn't applied to one or more of the available servers.