### PR TITLE
Update evaluating-mule-high-availability-clusters-demo.adoc

### DIFF
--- a/mule-user-guide/v/3.7/evaluating-mule-high-availability-clusters-demo.adoc
+++ b/mule-user-guide/v/3.7/evaluating-mule-high-availability-clusters-demo.adoc
@@ -41,7 +41,7 @@ In an *active-active* model, no one server in the cluster acts as the primary se
 
 *Resource Coordination*: Mule ESB automatically coordinates access to each resource (such as a file server or a database table) to prevent utilization conflicts.
 
-*Scalability*: Add or subtract Mule instances from your cluster to efficiently manage increases or decreases in load. You can also scale each instance _internally_ to maximize its processing effeciency. In other words, a single Mule instance can take advantage of the increased processing power offered by multiple nodes within the cluster, even though that instance continues to act as a single node within the parent cluster.
+*Scalability*: Add or subtract Mule instances from your cluster to efficiently manage increases or decreases in load. You can also scale each instance _internally_ to maximize its processing effeciency. In other words, a single Mule instance can take advantage of the increased processing power offered by multiple cores servicing this newly enhanced mule instance, even though that instance continues to act as a single node within the parent cluster.
 
 == Using the Demo to Explore HA
 


### PR DESCRIPTION
The scalability benefit bullet item should be changed to explain the possibility of scaling internally to a single member of a cluster, by taking advantage of added cores to service a single instance / node.