### PR TITLE
Update connector-certification-program-guidelines.adoc

### DIFF
--- a/anypoint-connector-devkit/v/3.7/connector-certification-program-guidelines.adoc
+++ b/anypoint-connector-devkit/v/3.7/connector-certification-program-guidelines.adoc
@@ -2,47 +2,23 @@
 :keywords: connector, certification, devkit, program guidelines
 
 
-The sections below describe the specific details necessary for connector certification.
+The sections below describe the specific details necessary for connector certification. For a full overview of the process, visit link:https://www.mulesoft.com/platform/cloud-connectors/certified[this page].
 
 == What is MuleSoft connector certification program?
 
 MuleSoft’s connector certification program guides you through the process of creating an enterprise-grade connector that is ready for certification by MuleSoft. Once certified, the connector will be made available through the Anypoint Exchange for discovery and use for our customers and developers.
 
-== Benefits to partners and developers
-
-[width="100%",cols="20%,80%a" ,options="header"]
-|===
-a|
-Category
-
- a|
-Details
-
-| Sales |
-* Referrals from MuleSoft
-** Listing within Anypoint Exchange informs MuleSoft sales team of connector availability
-* Revenue from your connector(s)
-| Support | * MuleSoft will take first line of support
-| Marketing |  * MuleSoft Certified badge for your connector(s)
-* Page for your connector(s) in Anypoint Exchange
-* Lead generation through Anypoint Exchange
-* Featured in Anypoint Exchange Newsletter
-* Starter marketing pack of how to’s
-** Case study, press release, demand gen kit for your company to use in your marketing
-| Product | * Be among the first to learn about MuleSoft product updates and releases
-|===
 
 == Before you begin
 Before embarking on the certification program, please consider the following and make sure you can adhere to the below requirements:
 
-* Keep a connector current and secure. Re-certify the connector at least once a year.
+* Connector must be kept current and secure, and recertified at least once a year.
 * Connector must be built and distributed for the enterprise version of the MuleSoft Software or MuleSoft Service.
 * All transaction for the connector will take place between the customer and the partner, not through MuleSoft.
-* Connector must be a fully-functional, production-ready, enterprise-grade application/protocol connector (i.e. it’s a connector that connects Mule ESB with an external system)
+* Connector must be a fully-functional, production-ready, enterprise-grade application/protocol connector (i.e. it’s a connector that connects Mule with an external system)
 * Code must be ready for deployment into a continuous integration environment. Code should be able to be compiled from command line without importing private repos. Credential should be provided separately and able to be set at compile time. In addition, sandbox credential for your connector is required for certification.
 * Connector must only use third party libraries that are open source or owned by you. No third-party, non-distributable libraries will be accepted.
-* If a similar connector already exists on link:https://www.mulesoft.com/exchange[Anypoint Exchange], you can still submit your connector, but you need to justify why additional connector should exist.
-
+* If a similar connector already exists on link:https://www.mulesoft.com/exchange[Anypoint Exchange], you can still submit your connector granted that it provides additional functionality superior to the existing connector. 
 
 
 
@@ -53,7 +29,7 @@ Partners or developers are required to provide *full support* for the connector(
 * Partner will exercise best effort to resolve technical support issues for customers within *five business days.*
 
 == Pricing for your connector
-Partners or developers will have sole discretion to decide whether you make your connectors available for free or with fees. However, all connectors must be available for use at no cost for design time in Anypoint Studio. While not mandatory, we recommend providing a trial period of your connector for customers.
+Partners or developers will have sole discretion to decide whether you make your connectors available for free or for a fee. However, all connectors must be available at no cost within Anypoint Studio. While not mandatory, we recommend providing a trial of your connector (for design and deployment) for customers.
 
 [width="100%",cols="20%,80%",options="header"]
 |===
@@ -64,8 +40,8 @@ Category
 Details
 
 | Free |Connector will be available for download and use for free to customers through Anypoint Exchange.
-| Paid |Connector will be available for download and use for free to customers through Anypoint Exchange only within Anypoint Studio. The connector will not run (in deployment) without credentials. Customers will need to purchase the connector directly from the partner. The pricing of the connector will be determined by the partner.
+| Paid |Connector will be available for download and use for free to customers through Anypoint Exchange only within Anypoint Studio. The connector will not run in deployment without credentials. Customers will need to purchase the connector directly from the partner. The pricing of the connector will be determined by the partner.
 |===
 
 == Development and certification
-Please share with us which connector you want to develop and get certified by filling out link:https://developer.mulesoft.com/lp/submit-connector[this form.] We will contact you with further information.
+Please share with us which connector you want to develop and get certified by filling out link:https://www.mulesoft.com/platform/cloud-connectors/certified[this form.] We will contact you with further information.


### PR DESCRIPTION
updating the form so that it doesn't have redundant info as the overview page. also linked the new overview page up top. 