### PR TITLE
Update ftp-transport-reference.adoc

### DIFF
--- a/mule-user-guide/v/3.7/ftp-transport-reference.adoc
+++ b/mule-user-guide/v/3.7/ftp-transport-reference.adoc
@@ -130,9 +130,9 @@ This example shows how to pick only certain files on the FTP server. You do this
        http://www.mulesoft.org/schema/mule/ftp http://www.mulesoft.org/schema/mule/ftp/3.6/mule-ftp.xsd">
 
     <flow name="fileFilter">
-        <ftp:inbound-endpoint host="localhost" port="21" path="/" user="theUser" password="secret"/>
+        <ftp:inbound-endpoint host="localhost" port="21" path="/" user="theUser" password="secret">
             <file:filename-wildcard-filter pattern="*.txt,*.xml"/>
-        </ftp:endpoint>
+        </ftp:inbound-endpoint>
         <file:outbound-endpoint path="/some/directory" outputPattern="#[header:originalFilename]"/>
     </flow>
 </mule>


### PR DESCRIPTION
Filename wildcard filter syntax fixed