### PR TITLE
Added CSV Output Modifiers

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
@@ -333,6 +333,23 @@ When set to *elements*, whenever there's a key:value pair that has a null value,
 When set to *attributes*, whenever there's an XML attribute with a null value, it will be skipped.
 When set to *everywhere*, it will apply this rule to both elements and attributes.
 
+===== CSV Output Formatting
+
+When defining an output of type CSV, there are a few optional parameters you can add to the output directive to customize how the data will be parsed:
+
+[options="header"]
+|=======================
+|Parameter|Type|Default|Description
+|separator|char|,|Character that separates one field from another
+|encoding|string| |The character set to be used for the output
+|quote|char|"|Character that delimites the field values
+|escape|char| \ |Character used to escape occurrences of the separator or quote character within field values
+|bufferSize|number| |
+|ignoreEmptyLine|bool| |
+|header|bool|true|Indicates if the first line of the output shall contain field names
+|quoteValues|bool|false|Indicates if every value should be quoted whether or not it contains special characters within
+|=======================
+
 ==== Define Constant Directive
 
 You can define a constant in the header, you can then reference it (or its child elements, if any exist) in the DataWeave body.


### PR DESCRIPTION
I have added a table with optional CSV Output modifiers for DataWeave as they were not documented elsewhere.
This is handy information that users would like to have.
I was missing some defaults information, like the default character set or buffer size.
This pull request is associated to documentation JIRA issue DOCS-1478