### PR TITLE
Replace “ quotes with machine-readable " character

### DIFF
--- a/anypoint-platform-for-apis/v/latest/api-auto-discovery.adoc
+++ b/anypoint-platform-for-apis/v/latest/api-auto-discovery.adoc
@@ -26,7 +26,7 @@ The `api-platform-gw` Global Element contains the information you need to regis
 
 [source, xml, linenums]
 ----
-<api-platform-gw:api id="myAPI" apiName="myAPI" version=“1.0.0” flowRef=“flow_api" create="true">
+<api-platform-gw:api id="myAPI" apiName="myAPI" version="1.0.0" flowRef="flow_api" create="true">
    <api-platform-gw:description>This is a test API</api-platform-gw:description>
    <api-platform-gw:tag>tag1</api-platform-gw:tag>
    <api-platform-gw:tag>tag2</api-platform-gw:tag>


### PR DESCRIPTION
Copy-pasting XML from the documentation will not be recognized by Anypoint Studio due to the use of the wrong quote character. This potentially is happening in other places in the documentation (a global search/replace would resolve).