### PR TITLE
URL needs to be fixed

### DIFF
--- a/mule-user-guide/v/3.7/mule-object-stores.adoc
+++ b/mule-user-guide/v/3.7/mule-object-stores.adoc
@@ -144,4 +144,4 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 ** link:http://mulesoft.github.io/objectstore-connector/1.3.3/apidocs/mule/objectstore-config.html[Object Store module], available as a Mule extension.
 ** link:http://mulesoft.github.io/objectstore-connector/[Object Store API].
 * Learn about the link:/cloudhub/managing-application-data-with-object-stores[CloudHub implementation of object stores].
-* link:/mule-user-guide/v/3.7/object-store-module-reference[Object Store Module Reference]
+* link:/mule-user-guide/v/3.7/object-store-module-reference BROKEN! [Object Store Module Reference]


### PR DESCRIPTION
URL pointed out should go to: https://docs.mulesoft.com/mule-user-guide/v/3.7/object-store-module-reference ,but adds .adoc at the end.
Don't know the fix, maybe two exist?