### PR TITLE
DataWeave reference change on input directive

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
@@ -295,12 +295,32 @@ Valid types are:
 [WARNING]
 When using DataWeave in Anypoint Studio, it's not necessary to declare any input directives for any of the components of the Mule Message that arrive at the DataWeave transformer (Payload, flow variables, and input/outbound properties) nor for any system variables. These are already implicitly recognized as inputs and can be referenced anywhere in the DataWeave body without a need to include them in the header as their type is known from the Mule metadata.
 
-When defining an input of type CSV, there are a few optional parameters you can add to the input directive to customize how the data is parsed.
+When defining an input of type CSV, there are a few optional parameters you can  add to the input directive to customize how the data is parsed. These are not defined in the DataWeave script but on the Transform Message XML element instead:
 
-* `header`: Boolean that defines if the first line in the data contains headers
-* `separator`: Character that separates fields, `','` by default
-* `quote`: Character that defines quoted text, `" "` by default
-* `escape`: Character that escapes quotes, `\` by default
+[source,xml,linenums]
+---------------------------------------------------------------------
+<dw:transform-message metadata:id="33a08359-5085-47d3-aa5f-c7dd98bb9c61"
+			doc:name="Transform Message">
+			<dw:input-payloa
+			  <!-- Boolean that defines if the first line in the data contains headers -->
+				<dw:reader-property name="header" value="false" />
+				<!-- Character that separates fields, `','` by default -->
+				<dw:reader-property name="separator" value="," />
+				<!-- Character that defines quoted text, `" "` by default -->
+				<dw:reader-property name="quote" value="&quot;" />
+				<!-- Character that escapes quotes, `\` by default -->
+				<dw:reader-property name="escape" value="\" />
+			</dw:input-payload>
+			<dw:set-payload> 
+      <![CDATA[
+        %dw 1.0
+        %output application/java
+        ---
+        // Your transformation script goes here
+      ]]>
+      </dw:set-payload>
+</dw:transform-message>
+---------------------------------------------------------------------
 
 If you want to parse CSV inputs with custom modifiers, you must do this via Anypoint Studio. Either add the attributes to the project's XML, or through the graphical interface, by selecting the element from the tree view in the input section and clicking the gear icon. See link:/mule-user-guide/v/3.7/using-dataweave-in-studio#parsing-csv-inputs[Using DataWeave in Studio] for more details.
 


### PR DESCRIPTION
Input directive optional parameters for CSV do not work any more.
They have been replaced by XML reader-property elements.
I have made the change.