### PR TITLE
Added links to DecimalFormat and DateTimeFormatter

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
@@ -2061,6 +2061,8 @@ Coerce the given value to the specified type.
 
 Any simple types can be coerced to string. If formatting is required (such as for a number or date) the format schema property can be used.
 
+Date and number format schemas are based on Java https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter] and https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html[DecimalFormat].
+
 .Transform
 [source,DataWeave, linenums]
 ----------------------------------------------------------------------
@@ -2088,6 +2090,8 @@ Any simple types can be coerced to string. If formatting is required (such as fo
 
 A string can be coerced to number. If the given number has a specific format the schema property can be used.
 
+Any format pattern accepted by https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html[DecimalFormat] is allowed.
+
 .Transform
 [source,DataWeave, linenums]
 ----------------------------------------------------------------------
@@ -2113,6 +2117,8 @@ A string can be coerced to number. If the given number has a specific format the
 ==== Coerce to date
 
 Date types can be coerced from string or number.
+
+Any format pattern accepted by https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[DateTimeFormatter] is allowed.
 
 .Transform
 [source,DataWeave,linenums]


### PR DESCRIPTION
An explanation of accepted patterns in `{format: ... }` is missing on the docs. That feature it's based in Java classes; the link to JavaDocs was added.