### PR TITLE
Update mule-expression-language-date-and-time-functions.adoc

### DIFF
--- a/mule-user-guide/v/3.7/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.7/mule-expression-language-date-and-time-functions.adoc
@@ -329,7 +329,7 @@ Equivalent to: link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.
 Equivalent to: link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#add-int-int-[calendar.add(Calendar.MINUTE, add);] |DateTime
 |plusHours(int add) |Returns the DateTime with the given amount of hours added (or subtracted if it is a negative value).  +
 Equivalent to: link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#add-int-int-[calendar.add(Calendar.HOUR_OF_DAY, add);] |DateTime
-|plusDay(int add) |Returns the DateTime with the given amount of days added (or subtracted if it is a negative value).  +
+|plusDays(int add) |Returns the DateTime with the given amount of days added (or subtracted if it is a negative value).  +
 Equivalent to: link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#add-int-int-[calendar.add(Calendar.DAY_OF_YEAR, add);] |DateTime
 |plusWeeks(int add) |Returns the DateTime with the given amount of weeks added (or subtracted if it is a negative value). |DateTime
 |plusMonths(int add) |Returns the DateTime with the given amount of months added (or subtracted if it is a negative value).  +


### PR DESCRIPTION
Changing the method definition:
plusDay(int add)

with the correct one:
plusDays(int add)

The final 's' was missing, in this page there are examples of the use of that function with the right sintaxis