### PR TITLE
Fixing default reference

### DIFF
--- a/mule-user-guide/v/3.8-m1/tls-configuration.adoc
+++ b/mule-user-guide/v/3.8-m1/tls-configuration.adoc
@@ -251,18 +251,17 @@ Setting the 'insecure' property to 'true' renders connections vulnerable to atta
 |algorithm |The algorithm used in the key store (default SunX509) |Optional
 |===
 
-== Cipher Suite Behavior
+== Protocol & Cipher Suite Behavior
 
-Whenever a TLS comunication takes place with between two systems, a negotiation determines which cipher suite will be used out of the list of those that are enabled on both ends. The following logic determines how this list of enabled cipher suites is defined:
+Whenever a TLS comunication takes place with between two systems, a negotiation determines which protocol and cipher suite will be used out of the list of those that are enabled on both ends. The following logic determines how this list of enabled protocols and cipher suites is defined:
 
-* If nothing is configured, you will use the list of cipher suites that are available by default with your Java environment.
-* If you have a <<Global TLS configuration>> file, the list you define in its 'enabledCipherSuites' property will be used instead.
+* If nothing is configured, you will use the list of protocols and cipher suites that are available by default with your Java environment.
+* If you have a <<Global TLS configuration>> file, the lists you define in its 'enabledProtocols' and 'enabledCipherSuites' property will be used instead.
+
+* In your 'tls:context' element, you can include the 'enabledProtocol' and 'enabledCipherSuites' properties and select a subset of the protocols and cipher suites that are included in your global TLS configuration file. You cannot reference protocols or cipher suites here that are not included in your global TLS configuration file (if one is present).
 +
 [TIP]
-Note that this property supports adding the value "default", which falls back on the default cipher suites of your Java environment
-
-* In your 'tls:context' element, you can include the 'enabledCipherSuites' property and select a subset of the cipher suites that are included in your global TLS configuration file. You cannot reference cipher suites here that are not included in your global TLS configuration file.
-
+Note that this property supports adding the value "default", which falls back on the default protocols and cipher suites of your <<Global TLS configuration>> or Java environment, depending on whether the former is present.
 
 
 == See Also


### PR DESCRIPTION
Moved the default tip to the right place and added protocol to the Behaviour section. Feel free to edit.