### PR TITLE
update from .bundle to .zip file

### DIFF
--- a/anypoint-platform-for-apis/v/latest/managing-api-versions.adoc
+++ b/anypoint-platform-for-apis/v/latest/managing-api-versions.adoc
@@ -22,7 +22,7 @@ You will find the export button on your API version page:
 
 image:export.jpeg[export]
 
-The exported .bundle file will include the following:
+The exported .zip file will include the following:
 
 * API name
 * API version name


### PR DESCRIPTION
.bundle is no longer the file extension for exporting APIs.