### PR TITLE
Analytics chart removed from API Platform dashboard (landing page)

### DIFF
--- a/anypoint-platform-for-apis/v/latest/viewing-api-analytics.adoc
+++ b/anypoint-platform-for-apis/v/latest/viewing-api-analytics.adoc
@@ -5,25 +5,9 @@ Access the Analytics dashboard for your Anypoint Platform for APIs organization 
 
 image:api-gateway-apis.png[api-gateway-apis.png]
 
-== Accessing the Top 5 APIs Chart
-
-Organization Administrators, API Creators, and API Version Owners can view a snapshot of the latest activity for your organization's five most-called APIs at the top of the API Administration page. Note that if you don't have any APIs yet in your organization, this chart does not appear.
-
-image:top5.png[top5]
-
-Once you have data to display, the Anypoint Platform rolls together all the API calls made to all versions of an API and combines them into a single line of data. Each of your top five APIs is represented by a different color.
-
-On this chart, you can:
-
-* Hover over the items in the legend to highlight a single API.
-* Hover over a peak to view a tooltip with details about the total number of API requests received for that collection time.
-* Change the zoom by clicking the links underneath the chart title. You can view data for the last hour, three hours, day, week, or month.
-
-To toggle this chart on or off, press Command + Shift + A.
-
 == Accessing the Analytics Dashboards
 
-As an Organization Administrator, you have access to the Analytics Dashboards for your organization. Go to *http://anypoint.mulesoft.com/analytics[anypoint.mulesoft.com/analytics]* to access your Analytics Dashboards. You can also navigate to the overview dashboard by clicking the *Analytics>* link above the Top 5 APIs chart on your API Administration page.
+As an Organization Administrator, you have access to the Analytics Dashboards for your organization. Go to *http://anypoint.mulesoft.com/analytics[anypoint.mulesoft.com/analytics]* to access your Analytics Dashboards. You can also navigate to the overview dashboard by clicking the *Analytics* option on the top-right menu.
 
 image:AnalyticsLink.png[AnalyticsLink]
 


### PR DESCRIPTION
As part of the removal of Analytics chart, also the way to go to Analytics site has changed. Now the user has to select *Analytics* on the top right menu. So the image under `Accessing the Analytics Dashboards` has to be updated.
The following image can be used to replace the mentioned one: ` image:AnalyticsLink.png[AnalyticsLink]`, if team feels that meets the docs standards.
![analyticslink](https://cloud.githubusercontent.com/assets/2364692/13007246/a9f2ddb4-d16d-11e5-875f-e18a2191ea28.png)