### PR TITLE
Update installing-anypoint-runtime-manager-on-premises-edition.adoc

### DIFF
--- a/anypoint-platform-on-premises/v/1.1.0/installing-anypoint-runtime-manager-on-premises-edition.adoc
+++ b/anypoint-platform-on-premises/v/1.1.0/installing-anypoint-runtime-manager-on-premises-edition.adoc
@@ -199,7 +199,7 @@ Once you have Docker and Compose installed, you need to perform the following st
 
 The package is a .zip file that contains all of the configuration and installation scripts needed to run ARM.
 
-* To obtain the installation ZIP file for Anypoint Docker Setup, contact MuleSoft support.
+* To obtain the installation ZIP file for Anypoint Docker Setup, contact your Account Representative.
 
 === Downloading the ARM Docker Images
 


### PR DESCRIPTION
The current enablement process for the on-prem platform is not done via support, but pre-sales or services, I've updated the documentation to reflect this