### PR TITLE
Fix of cron examples

### DIFF
--- a/mule-user-guide/v/3.7/poll-schedulers.adoc
+++ b/mule-user-guide/v/3.7/poll-schedulers.adoc
@@ -157,14 +157,14 @@ Here are a few examples of typical Cron expressions:
 [width="100%",cols="50%,50%",options="header",]
 |====
 |Expression |Behavior
-|0 0 12 * * ? |Poll at 12pm (noon) every day
-|0 15 10 ? * * |Poll at 10:15am every day
-|0 15 10 * * ? |Poll at 10:15am every day
-|0 15 10 * * ? * |Poll at 10:15am every day
-|0 15 10 * * ? 2005 |Poll at 10:15am every day during the year 2005
-|0 * 14 * * ? |Poll every minute starting at 2pm and ending at 2:59pm, every day
-|0 0/5 14 * * ? |Poll every 5 minutes starting at 2pm and ending at 2:55pm, every day
-|1 1 1 1,7 * |Poll the first day of January and the first day of June, every year (in the first second of the first minute of the first hour)
+|0 12 * * ? |Poll at 12pm (noon) every day
+|15 10 ? * * |Poll at 10:15am every day
+|15 10 * * ? |Poll at 10:15am every day
+|15 10 * * ? * |Poll at 10:15am every day
+|15 10 * * * 2005 |Poll at 10:15am every day during the year 2005
+|* 14 * * ? |Poll every minute starting at 2pm and ending at 2:59pm, every day
+|0-55/5 14 * * ? |Poll every 5 minutes starting at 2pm and ending at 2:55pm, every day
+|1 1 1 1,6 * |Poll the first day of January and the first day of June, every year (in the first second of the first minute of the first hour)
 |====
 
 ....


### PR DESCRIPTION
Original examples were not using a proper cron notation, "human description" didn't map properly the cron expression. Changes have been validated with cron translators and cron expression validators.