### PR TITLE
Added example of using MuleEventContext

### DIFF
--- a/mule-user-guide/v/3.7/using-the-mule-client.adoc
+++ b/mule-user-guide/v/3.7/using-the-mule-client.adoc
@@ -173,6 +173,24 @@ http://www.mulesoft.org/docs/site/current/apidocs/org/mule/api/MuleEventContext.
 
 and call the send/dispatch/request methods on the context instead.
 
+[source, java, linenums]
+----
+import org.mule.api.MuleEventContext;
+import org.mule.api.lifecycle.Callable;
+
+public class MyComponent implements Callable {
+
+	@Override
+	public Object onCall(MuleEventContext eventContext) throws Exception {
+
+    // instead of using MuleClient use the MuleEventContext
+    // to get the client of current context
+    eventContext.getMuleContext().getClient().dispatch("vm://queue1", null);
+
+	}
+}
+----
+
 To gain access to the `MuleEventContext`inside your flowss, you can implement the
 
 http://www.mulesoft.org/docs/site/current/apidocs/org/mule/api/lifecycle/Callable.html[org.mule.api.lifecycle.Callable]


### PR DESCRIPTION
instead of using MuleClient for section When Not to Use the Mule Client