### PR TITLE
Use full xml example property-placeholder

### DIFF
--- a/mule-user-guide/v/3.5/configuring-properties.adoc
+++ b/mule-user-guide/v/3.5/configuring-properties.adoc
@@ -30,11 +30,19 @@ http://contextproperty-placeholder/[<context:property-placeholder]>:
 
 [source, xml, linenums]
 ----
-xmlns:context="http://www.springframework.org/schema/context"
-xsi:schemaLocation="http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
 
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:context="http://www.springframework.org/schema/context"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+ 
 <context:property-placeholder location="smtp.properties"/>
+
+<flow name="myProject_flow1">
+    <logger message="${propertyFromFile}" doc:name="System Property Set in Property File"/>
+</flow>
 ----
 
 where the contents of `smtp.properties` is:

--- a/mule-user-guide/v/3.6/configuring-properties.adoc
+++ b/mule-user-guide/v/3.6/configuring-properties.adoc
@@ -42,11 +42,16 @@ To load properties from a file, you can use the standard Spring element +
 
 [source,xml, linenums]
 ----
-xmlns:context="http://www.springframework.org/schema/context"
-xsi:schemaLocation="http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-4.1.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:context="http://www.springframework.org/schema/context"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
  
 <context:property-placeholder location="smtp.properties"/>
+
 <flow name="myProject_flow1">
     <logger message="${propertyFromFile}" doc:name="System Property Set in Property File"/>
 </flow>

--- a/mule-user-guide/v/3.7/configuring-properties.adoc
+++ b/mule-user-guide/v/3.7/configuring-properties.adoc
@@ -42,11 +42,16 @@ To load properties from a file, you can use the standard Spring element +
 
 [source,xml, linenums]
 ----
-xmlns:context="http://www.springframework.org/schema/context"
-xsi:schemaLocation="http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-4.1.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:context="http://www.springframework.org/schema/context"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
  
 <context:property-placeholder location="smtp.properties"/>
+
 <flow name="myProject_flow1">
     <logger message="${propertyFromFile}" doc:name="System Property Set in Property File"/>
 </flow>

--- a/mule-user-guide/v/3.8-m1/configuring-properties.adoc
+++ b/mule-user-guide/v/3.8-m1/configuring-properties.adoc
@@ -42,11 +42,16 @@ To load properties from a file, you can use the standard Spring element +
 
 [source,xml, linenums]
 ----
-xmlns:context="http://www.springframework.org/schema/context"
-xsi:schemaLocation="http://www.springframework.org/schema/context
-http://www.springframework.org/schema/context/spring-context-4.1.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:context="http://www.springframework.org/schema/context"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
  
 <context:property-placeholder location="smtp.properties"/>
+
 <flow name="myProject_flow1">
     <logger message="${propertyFromFile}" doc:name="System Property Set in Property File"/>
 </flow>


### PR DESCRIPTION
Use full xml example property-placeholder. The current xmlns placement isn't clear to a non-spring user.