### PR TITLE
Added Authorization Filter

### DIFF
--- a/mule-user-guide/v/3.7/configuring-the-spring-security-manager.adoc
+++ b/mule-user-guide/v/3.7/configuring-the-spring-security-manager.adoc
@@ -77,14 +77,22 @@ Security filters can be configured on an object to either authenticate inbound r
 
 [source,xml, linenums]
 ----
-<mule-ss:http-security-filter realm="mule-realm"/>
+<http:basic-security-filter realm="mule-realm"/>
 ----
 
 When a request is received, the authentication header is read from the request and authenticated against all security providers on the Security Manager. If you only want to validate on certain providers, you can supply a comma-separated list of security provider names.
 
 [source,xml, linenums]
 ----
-<mule-ss:http-security-filter realm="mule-realm" securityProviders="default,another"/>
+<http:basic-security-filter realm="mule-realm" securityProviders="default,another"/>
 ----
 
 The `realm` is an optional attribute required by some servers. You only need to set this attribute if required by the server on the other end.
+
+Also you may have noticed that we specificed some roles for the users in the example but haven't used it for filtering. If you want to filter requests based on the user's role you should add an authorization filter after the security filter providing a comma separated list of the authorized roles with the special syntax shown below.
+
+[source,xml, linenums]
+----
+<http:basic-security-filter realm="mule-realm" />
+<mule-ss:authorization-filter requiredAuthorities="#{ {'ROLE_ADMIN', 'ROLE_ANON'} }" />
+----


### PR DESCRIPTION
Authorization filter, part of the _mule-ss_ schema was totally absent of the documentation.
Also, updated the security filters code lines to use the new _http:basic-security-filter_ and be consistent with the main example above.