### PR TITLE
Update mvn command for project creation

### DIFF
--- a/mule-user-guide/v/3.7/maven-tools-for-mule-esb.adoc
+++ b/mule-user-guide/v/3.7/maven-tools-for-mule-esb.adoc
@@ -63,7 +63,7 @@ Maven Tools for Mule ESB makes it extremely easy to create a Mule application, b
 
 [source, code, linenums]
 ----
-mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-achetype-mule-app -DarchetypeVersion=1.0 -DgroupId=org.mycompany.app -DartifactId=mule-app -Dversion=1.0-SNAPSHOT -DmuleVersion=3.5.0 -Dpackage=org.mycompany.app -Dtransports=http,jms,vm,file,ftp -Dmodules=db,xml,jersey,json,ws
+mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-archetype-mule-app -DarchetypeVersion=1.1 -DgroupId=org.mycompany.app -DartifactId=mule-app -Dversion=1.0.0-SNAPSHOT -DmuleVersion=3.7.0 -Dpackage=org.mycompany.app -Dtransports=http,jms,vm,file,ftp -Dmodules=db,xml,jersey,json,ws
 ----
 
 Parameters used:
@@ -110,7 +110,7 @@ To create a domain, run the following command:
 
 [source, code, linenums]
 ----
-mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-achetype-mule-domain -DarchetypeVersion=1.0 -DgroupId=org.mycompany.domain -DartifactId=mule-domain -Dversion=1.0-SNAPSHOT -Dpackage=org.mycompany.domain
+mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-archetype-mule-domain -DarchetypeVersion=1.1 -DgroupId=org.mycompany.domain -DartifactId=mule-domain -Dversion=1.0.0-SNAPSHOT -Dpackage=org.mycompany.domain
 ----
 
 Parameters used:
@@ -136,7 +136,7 @@ To create a Maven project that includes the domain and all of the applications t
 
 [source, code, linenums]
 ----
-mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-achetype-mule-domain-bundle -DarchetypeVersion=1.0 -DgroupId=com.mycompany -DartifactId=mule-project -Dversion=1.0-SNAPSHOT -Dpackage=com.mycompany
+mvn archetype:generate -DarchetypeGroupId=org.mule.tools.maven -DarchetypeArtifactId=maven-achetype-mule-domain-bundle -DarchetypeVersion=1.1 -DgroupId=com.mycompany -DartifactId=mule-project -Dversion=1.0.0-SNAPSHOT -Dpackage=com.mycompany
 ----
 
 This command creates a Maven multi-module project with the following modules:


### PR DESCRIPTION
Updating muleVersion to 3.7.0 and archetypeVersion 1.1.

Note: the mule-domain-bundle is still misspelled as "achetype" instead of "archetype" in 1.1 (see -DarchetypeArtifactId=maven-achetype-mule-domain-bundle)