### PR TITLE
Notes on schedule changes

### DIFF
--- a/cloudhub/v/latest/managing-schedules.adoc
+++ b/cloudhub/v/latest/managing-schedules.adoc
@@ -88,6 +88,7 @@ image:SchedulesLogs.png[SchedulesLogs]
 ====
 * While CloudHub supports polling frequencies in seconds, you may see discrepancies of a few seconds between individual polling calls. Setting a polling frequency higher than once in 10 seconds is not recommended.
 * If a scheduled job is missed (not triggered) one or more times because the application is down, CloudHub triggers the job once as soon as the application restarts.
+* Cloudhub scheduler reads a schedule job configuration every time it is run. This means that if you change schedule time the change is not immediate. The job will exexcute as it was already scheduled and only then the scheduler will pick up the next settings for the next run. So, to have your changes applied immediately, *run your jobs every time you make a change to their schedules*.
 ====
 
 == See Also


### PR DESCRIPTION
Adding a clarification that schedule changes do not affect immediately but after the next schedule run (with previous setting)