### PR TITLE
Remove Redirecting Logs to File from 1.1.1

### DIFF
--- a/munit/v/1.1.1/logging-in-munit.adoc
+++ b/munit/v/1.1.1/logging-in-munit.adoc
@@ -39,42 +39,6 @@ TIP: The configuration file must reside in the classpath to work correctly. Pref
 
 NOTE: If you don't create a `log4j2-test.xml` file, Mule looks for a file called `log4j2.xml`. For additional information about the priority in which the log configuration files are selected, see link:/mule-user-guide/v/3.7/logging-in-mule[Logging in Mule].
 
-== Redirecting Logs to a File
-
-To redirect logs to a file, modify the log4j2-test.xml configuration file.
-
-For example, if you want to log all the `INFO` level messages to a file called `test.log`,
-add the following to log4j2-test.xml:
-
-[source,xml,linenums]
-----
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
-    <Appenders>
-      <File name="LogFile" fileName="logs/test.log"> <!--1-->
-        <PatternLayout>
-          <Pattern>[%p] %d %m%n</Pattern> <!--2-->
-        </PatternLayout>
-      </File>
-    </Appenders>
-    <Loggers>
-          ...
-        <AsyncLogger name="com.mulesoft" level="INFO"/>
-        <AsyncRoot level="INFO">
-            <AppenderRef ref="LogFile"/> <!--3-->
-        </AsyncRoot>
-    </Loggers>
-</Configuration>
-----
-<1> Declare a File Appender that writes logs in the `logs/test.log` file.
-<2> Define the printing pattern, in this case an example log would be `[INFO] 2016-03-15 17:21:27,450 Done`.
-<3> Specify which log level to write to the file.
-
-This creates a folder called `logs` and a log file inside of it called `test.log`
-where all the MUnit logs with `INFO` level are appended.
-
-For more information, see link:https://logging.apache.org/log4j/2.x/manual/appenders.html#FileAppender[Apache's File Appender documentation].
-
 == See Also
 
 * link:http://training.mulesoft.com[MuleSoft Training]


### PR DESCRIPTION
"Redirecting Logs to File" should only appear in 1.2.0