### PR TITLE
typo fix

### DIFF
--- a/mule-user-guide/v/3.7/modularizing-your-configuration-files-for-team-development.adoc
+++ b/mule-user-guide/v/3.7/modularizing-your-configuration-files-for-team-development.adoc
@@ -5,8 +5,8 @@ Though it may seem convenient to keep all your Mule configuration in one place, 
 
 Mule offers two options for loading several configuration files:
 
-*side-by-side: provide a list of independent configuration files to load, +
- *imported: have one configuration file import several others, which in-turn can import other files.
+* side-by-side: provide a list of independent configuration files to load, +
+* imported: have one configuration file import several others, which in-turn can import other files.
 
 In practice, it is common to use both approaches simultaneously.
 
@@ -14,11 +14,11 @@ Don't forget that all the configuration files end up loaded in the same context;
 
 How can you determine what constitutes good separation lines between configuration fragments? Here are a few rules of thumb:
 
-*Business domains usually form a natural border that can be used to separated configuration elements +
- *Keeping together elements that have similar reasons for change reduces the risk of impacting unrelated aspects of your application +
- *Technical aspects, like administrative components, security or Spring beans configuration, define good lines of demarcation +
- *Extracting a side-by-side transport configuration (connectors and endpoints) facilitates functional testing (discussed in section 3). Note that it is not intended to take care of environment specific transport configuration, which is dealt with properties files (discussed later on) +
- *And, last but not least, re-use across teams and projects (also discussed later on)
+* Business domains usually form a natural border that can be used to separate configuration elements +
+* Keeping together elements that have similar reasons for change reduces the risk of impacting unrelated aspects of your application +
+* Technical aspects, like administrative components, security or Spring beans configuration, define good lines of demarcation +
+* Extracting a side-by-side transport configuration (connectors and endpoints) facilitates functional testing (discussed in section 3). Note that it is not intended to take care of environment specific transport configuration, which is dealt with properties files (discussed later on) +
+* Last but not least, re-use across teams and projects (also discussed later on)
 
 == Imported configuration files
 


### PR DESCRIPTION
change "can be used to separated" to "can be used to separate".

The bullet-list formatting seems strange - doesn't render well as it is. Fixed that.

Removed "And" from bullet point line 21 - cannot start sentences with "and"