### PR TITLE
A stray single 's' was removed (this caused invalid json).

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
@@ -13,7 +13,7 @@ This example shows a simple mapping from JSON to XML
 [source,json,linenums]
 ----
 {
-  "title": "Java 8 in Action: Lambdas, Streams, and functional-style programming",s
+  "title": "Java 8 in Action: Lambdas, Streams, and functional-style programming",
   "author": "Mario Fusco",
   "year": 2014
 }


### PR DESCRIPTION
The very first example had a stray 's' for the input JSON data, I copied/pasted a few times thinking I was doing something wrong until I saw the 's'. I expected the JSON to be valid - hopefully I'm rightfully so in thinking :)