### PR TITLE
Remove _images ref from images and fix anchor links to be consistent

### DIFF
--- a/mule-user-guide/v/3.6/profiling-mule.adoc
+++ b/mule-user-guide/v/3.6/profiling-mule.adoc
@@ -1,7 +1,7 @@
 = Profiling Mule
 :keywords: anypoint studio, esb, profiling, yourkit, monitoring, performance, memory, cpu, tuning
 
-Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#_profiling_using_the_profiler_pack[profiling using the profiler pack] or link:#_profiling_with_the_yourkit_agent[profiling with the YourKit agent]. Both methods are described below.
+Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#profiling-using-the-profiler-pack[profiling using the profiler pack] or link:#profiling-with-the-yourkit-agent[profiling with the YourKit agent]. Both methods are described below.
 
 NOTE: There are multiple Java profiler options available. If you're not using YourKit, visit your respective profiler's documentation to understand how to hook into the Mule-Java process.
 
@@ -55,15 +55,15 @@ NOTE: Steps above can vary in a Windows environment. Check the YourKit documenta
 . Launch YourKit on your local machine.
 . In Monitor Remote Applications, click Connect to remote application.
 +
-image:_images/monitor-remote-apps.png[width=500]
+image:monitor-remote-apps.png[width=500]
 . Setup your server username and password.
 . Configure the SSH authentication.
 +
-image:_images/yourkit-auth.png[width=500]
+image:yourkit-auth.png[width=500]
 . Click OK.
 . After scanning for available applications, the YourKit should now be hooked up to your Mule instance.
 +
-image:_images/yourkit-hooked-up.png[width=1000]
+image:yourkit-hooked-up.png[width=1000]
 
 == Profiling with the Profiler Pack
 

--- a/mule-user-guide/v/3.7/profiling-mule.adoc
+++ b/mule-user-guide/v/3.7/profiling-mule.adoc
@@ -1,7 +1,7 @@
 = Profiling Mule
 :keywords: anypoint studio, esb, profiling, yourkit, monitoring, performance, memory, cpu, tuning
 
-Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#_profiling_using_the_profiler_pack[profiling using the profiler pack] or link:#_profiling_with_the_yourkit_agent[profiling with the YourKit agent]. Both methods are described below.
+Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#profiling-using-the-profiler-pack[profiling using the profiler pack] or link:#profiling-with-the-yourkit-agent[profiling with the YourKit agent]. Both methods are described below.
 
 NOTE: There are multiple Java profiler options available. If you're not using YourKit, visit your respective profiler's documentation to understand how to hook into the Mule-Java process.
 
@@ -55,15 +55,15 @@ NOTE: Steps above can vary in a Windows environment. Check the YourKit documenta
 . Launch YourKit on your local machine.
 . In Monitor Remote Applications, click Connect to remote application.
 +
-image:_images/monitor-remote-apps.png[width=500]
+image:monitor-remote-apps.png[width=500]
 . Setup your server username and password.
 . Configure the SSH authentication.
 +
-image:_images/yourkit-auth.png[width=500]
+image:yourkit-auth.png[width=500]
 . Click OK.
 . After scanning for available applications, the YourKit should now be hooked up to your Mule instance.
 +
-image:_images/yourkit-hooked-up.png[width=1000]
+image:yourkit-hooked-up.png[width=1000]
 
 == Profiling with the Profiler Pack
 

--- a/mule-user-guide/v/3.8-m1/profiling-mule.adoc
+++ b/mule-user-guide/v/3.8-m1/profiling-mule.adoc
@@ -1,7 +1,7 @@
 = Profiling Mule
 :keywords: anypoint studio, esb, profiling, yourkit, monitoring, performance, memory, cpu, tuning
 
-Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#_profiling_with_the_profiler_pack[profiling using the profiler pack], link:#_profiling_with_the_yourkit_agent[profiling with the YourKit agent], or link:#_hooking_mule_into_the_yourkit_agent[hooking Mule into the YourKit agent]. These methods are described below.
+Profiling Mule can be useful in helping you identify memory leaks in your custom Mule ESB extensions. https://www.yourkit.com/[YourKit] is a commonly used Java profiler for analyzing JVM performance. Hooking into YourKit can be achieved by link:#profiling-with-the-profiler-pack[profiling using the profiler pack], link:#profiling-with-the-yourkit-agent[profiling with the YourKit agent], or link:#hooking-mule-into-the-yourkit-agent[hooking Mule into the YourKit agent]. These methods are described below.
 
 == Profiling with the YourKit Agent
 
@@ -53,15 +53,15 @@ NOTE: Steps above can vary in a Windows environment. Check the YourKit documenta
 . Launch YourKit on your local machine.
 . In Monitor Remote Applications, click Connect to remote application.
 +
-image:_images/monitor-remote-apps.png[width=500]
+image:monitor-remote-apps.png[width=500]
 . Setup your server username and password.
 . Configure the SSH authentication.
 +
-image:_images/yourkit-auth.png[width=500]
+image:yourkit-auth.png[width=500]
 . Click OK.
 . After scanning for available applications, the YourKit should now be hooked up to your Mule instance.
 +
-image:_images/yourkit-hooked-up.png[width=1000]
+image:yourkit-hooked-up.png[width=1000]
 
 == Profiling with the Profiler Pack
 


### PR DESCRIPTION
Remove _images ref from images and fix anchor links to be consistent with how the site build.

@george-hoffer A few mistakes I made in refing links and images. Corrected here.