### PR TITLE
Correction of a few typo's

### DIFF
--- a/mule-user-guide/v/3.2/mulesoft-enterprise-java-connector-for-sap-reference.adoc
+++ b/mule-user-guide/v/3.2/mulesoft-enterprise-java-connector-for-sap-reference.adoc
@@ -391,7 +391,7 @@ If the `rfcType` is configured to *srfc*, or it is not provided (thus defaulting
 
 === Example of a Default In-memory TID Store
 
-To configure an In-memory TID Store sucessfully, you must understand the following:
+To configure an In-memory TID Store successfully, you must understand the following:
 
 . The In-memory TID Store won't work as expected if you have multiple Mule ESB instances that share the same *program id*. (This is because the SAP gateway load-balances across all registered SAP servers that share the same *program id*).
 . The `rfcType` in the `<sap:inbound-endpoint .../>` should be *trfc* or *qrfc*

--- a/mule-user-guide/v/3.3/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.3/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.3/cache-scope.adoc
+++ b/mule-user-guide/v/3.3/cache-scope.adoc
@@ -195,7 +195,7 @@ image:select_object_store.png[select_object_store]
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.3/mule-application-architecture.adoc
+++ b/mule-user-guide/v/3.3/mule-application-architecture.adoc
@@ -289,7 +289,7 @@ The application can then “roll back” (i.e., undo) all the successully comple
 
 Sometimes, in addition to rolling back all the steps in the original, failed processing instance, the application can recover the original message and reprocess it from the beginning. Since all traces of the previous, failed attempt have been erased, a single message ultimately produces a only single set of results.
 
-Typically, transactionality is difficult to implement for Mule flows that transfer processing control across threads, which occurs for most types of branch processing. However, certain measures (such as the use of VM endpoints at the beginning and end of each child flow that does not run on the main flow’s thread) can ensure that each of these child flows executes successfully _as a unit_, although this architecture does not ensure that each message processor within one of these child flows completes its task sucessfully. For details see: Two Queue Example.
+Typically, transactionality is difficult to implement for Mule flows that transfer processing control across threads, which occurs for most types of branch processing. However, certain measures (such as the use of VM endpoints at the beginning and end of each child flow that does not run on the main flow’s thread) can ensure that each of these child flows executes successfully _as a unit_, although this architecture does not ensure that each message processor within one of these child flows completes its task successfully. For details see: Two Queue Example.
 ====
 
 

--- a/mule-user-guide/v/3.3/mulesoft-enterprise-java-connector-for-sap-reference.adoc
+++ b/mule-user-guide/v/3.3/mulesoft-enterprise-java-connector-for-sap-reference.adoc
@@ -557,7 +557,7 @@ If the `rfcType` is configured to *srfc*, or it is not provided (thus defaulting
 
 ====== Example of a Default In-memory TID Store
 
-To configure an In-memory TID Store sucessfully, you must understand the following:
+To configure an In-memory TID Store successfully, you must understand the following:
 
 . The In-memory TID Store won't work as expected if you have multiple Mule ESB instances that share the same *program id*. (This is because the SAP gateway load-balances across all registered SAP servers that share the same *program id*).
 . The `rfcType` in the `<sap:inbound-endpoint .../>` should be *trfc* or *qrfc*

--- a/mule-user-guide/v/3.4/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.4/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.4/cache-scope.adoc
+++ b/mule-user-guide/v/3.4/cache-scope.adoc
@@ -205,7 +205,7 @@ Configure the settings of your new object store. If you selected a custom-object
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two number preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two number preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.4/mulesoft-enterprise-java-connector-for-sap-reference.adoc
+++ b/mule-user-guide/v/3.4/mulesoft-enterprise-java-connector-for-sap-reference.adoc
@@ -437,7 +437,7 @@ If the `rfcType` is configured to *srfc*, or it is not provided (thus defaulting
 
 ====== Example of a Default In-memory TID Store
 
-To configure an In-memory TID Store sucessfully, you must understand the following:
+To configure an In-memory TID Store successfully, you must understand the following:
 
 . The In-memory TID Store won't work as expected if you have multiple Mule ESB instances that share the same *program id*. (This is because the SAP gateway load-balances across all registered SAP servers that share the same *program id*).
 . The `rfcType` in the `<sap:inbound-endpoint .../>` should be *trfc* or *qrfc*

--- a/mule-user-guide/v/3.5/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.5/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.5/cache-scope.adoc
+++ b/mule-user-guide/v/3.5/cache-scope.adoc
@@ -313,7 +313,7 @@ There are two message processors for invalidating caches:
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.5/installing-anypoint-enterprise-security.adoc
+++ b/mule-user-guide/v/3.5/installing-anypoint-enterprise-security.adoc
@@ -105,7 +105,7 @@ If you don't have access to the MuleSoft Enterprise Maven customer repository (h
 
 == See Also
 
-* Refer to the [Anypoint Enterprise Security Release Notes] for details about waht is included wiht version 1.2.
+* Refer to the [Anypoint Enterprise Security Release Notes] for details about what is included wiht version 1.2.
 
 * Explore features of Anypoint Enterprise Security; use menu in left-nav bar to access feature-specific pages.
 

--- a/mule-user-guide/v/3.5/mule-expression-language-tips.adoc
+++ b/mule-user-guide/v/3.5/mule-expression-language-tips.adoc
@@ -346,7 +346,7 @@ If you need to manipulate the registry in Java class, you can access it through 
 
 [width=100%,cols=",",options=:header]
 |===
-|Expression |When the value of `something` is... |...and the value of `abc` is... |...MEL sucessfully evaluates the expression.
+|Expression |When the value of `something` is... |...and the value of `abc` is... |...MEL successfully evaluates the expression.
 |`#[payload.something.abc == 'b']` |`'something'` |`'null'` ^|✔
 |`#[payload.something.abc == 'b']` |`'false'` |`'abc'` ^a|*X*
 

--- a/mule-user-guide/v/3.6/authentication-in-http-requests.adoc
+++ b/mule-user-guide/v/3.6/authentication-in-http-requests.adoc
@@ -1,5 +1,5 @@
 = Authentication in HTTP Requests
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth, basic auth, digest
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth, basic auth, digest
 
 The link:/mule-user-guide/v/3.6/http-request-connector[HTTP Request Connector] supports four types of authentication:
 

--- a/mule-user-guide/v/3.6/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.6/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.6/cache-scope.adoc
+++ b/mule-user-guide/v/3.6/cache-scope.adoc
@@ -320,7 +320,7 @@ There are two message processors for invalidating caches:
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.6/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.6/http-listener-connector.adoc
@@ -910,7 +910,7 @@ If you wish, you can prevent outbound properties from being passed on as headers
 
 In the HTTP Listener Connector's properties editor, on the *Response Settings* section, tick the box labeled *Disable Properties* to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response mesages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response messages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
 
 ....
 [tab,title="XML Editor"]
@@ -918,7 +918,7 @@ Keep in mind that this only affects responses when the execution of the flow is 
 
 Add a `http:response-builder` as a child element of the `http:listener`, in this child element, set the attribute `disablePropertiesAsHeaders="true"` to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response mesages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response messages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
 
 For example:
 [source,xml, linenums]

--- a/mule-user-guide/v/3.7/2-creating-a-cluster.adoc
+++ b/mule-user-guide/v/3.7/2-creating-a-cluster.adoc
@@ -16,7 +16,7 @@ image:mmc_login.png[mmc_login]
 
 . The management console displays a *Mule ESB Enterprise - Quick Start* screen; click the red X icon image:red-x-icon.png[red-x-icon] in the upper-right corner to close.
 
-. The management console presents the *Dashboard* tab by default; cick the *Server* tab.
+. The management console presents the *Dashboard* tab by default; click the *Server* tab.
 
 . Click *Add*, then select *New Server*.
 +

--- a/mule-user-guide/v/3.7/4-applying-load-to-the-cluster.adoc
+++ b/mule-user-guide/v/3.7/4-applying-load-to-the-cluster.adoc
@@ -40,7 +40,7 @@ image:before_flowAnalysis.png[before_flowAnalysis]
 +
 image:before_timeToComplete.png[before_timeToComplete]
 
-. In the *Control Panel*, in the field labelled *Number of widgets to send*, enter a number between 50 and 100 to indicate the number of “widgets” the Web app should send to the **cluster-demo-app**.
+. In the *Control Panel*, in the field labeled *Number of widgets to send*, enter a number between 50 and 100 to indicate the number of “widgets” the Web app should send to the **cluster-demo-app**.
 +
 image:control_panel.png[control_panel]
 

--- a/mule-user-guide/v/3.7/5-witnessing-failover.adoc
+++ b/mule-user-guide/v/3.7/5-witnessing-failover.adoc
@@ -11,7 +11,7 @@ Read through all the steps in this procedure before beginning. To witness failov
 
 . Ensure that you have the following three windows or tabs open on your screen:
 
-.. a brower window or tab which displays the WidgetUI at http://localhost:8080/widgetUI/
+.. a browser window or tab which displays the WidgetUI at http://localhost:8080/widgetUI/
 
 .. a browser window or tab which displays the Mule Management Console at http://localhost:8585/mmc/#dashboard
 

--- a/mule-user-guide/v/3.7/activemq-integration.adoc
+++ b/mule-user-guide/v/3.7/activemq-integration.adoc
@@ -39,19 +39,19 @@ apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
 apache-activemq-5.12.0/lib/activemq-kahadb-store-5.12.0.jar
 apache-activemq-5.12.0/lib/activemq-openwire-legacy-5.12.0.jar
 apache-activemq-5.12.0/lib/activemq-protobuf-1.1.jar
-apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar
 apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
 ....
 *JARs for External ActiveMQ*:
 ....
 apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
-apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar
 apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
 ....
 *JARs for Failover ActiveMQ*:
 ....
 apache-activemq-5.12.0/lib/activemq-client-5.12.0.jar
-apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar 
+apache-activemq-5.12.0/lib/geronimo-j2ee-management_1.1_spec-1.0.1.jar
 apache-activemq-5.12.0/lib/hawtbuf-1.11.jar
 ....
 To include these .jar files in your project, simply right-click on your project and select *Build Path* > *Add External Archives...*
@@ -127,14 +127,14 @@ The activemq-connector element configures an ActiveMQ version of the JMS connect
 |Name |Type |Required |Default |Description
 |connectionFactory-ref |string |no |  |Optional reference to the connection factory. A default connection factory is provided for vendor-specific JMS configurations.
 |redeliveryHandlerFactory-ref |string |no |  |Reference to the redelivery handler.
-|acknowledgementMode |enumeration |no |AUTO_ACKNOWLEDGE |The acknowledgement mode to use: AUTO_ACKNOWLEDGE, CLIENT_ACKNOWLEDGE, or DUPS_OK_ACKNOWLEDGE.
+|acknowledgementMode |enumeration |no |AUTO_ACKNOWLEDGE |The acknowledgment mode to use: AUTO_ACKNOWLEDGE, CLIENT_ACKNOWLEDGE, or DUPS_OK_ACKNOWLEDGE.
 |clientId |string |no |  |The ID of the JMS client.
 |durable |boolean |no |  |Whether to make all topic subscribers durable.
 |noLocal |boolean |no |  |If set to true, a subscriber will not receive messages that were published by its own connection.
-|persistentDelivery |boolean |no |  |If set to true, the JMS provider logs the message to stable storage as it is sent so that it can be recovered if delivery is unsuccessful. A client marks a message as persistent if it feels that the application will have problems if the message is lost in transit. A client marks a message as non-persistent if an occasional lost message is tolerable. Clients use delivery mode to tell a JMS provider how to balance message transport reliability/throughput. Delivery mode only covers the transport of the message to its destination. Retention of a message at the destination until its receipt is acknowledged is not guaranteed by a PERSISTENT delivery mode. Clients should assume that message retention policies are set administratively. Message retention policy governs the reliability of message delivery from destination to message consumer. For example, if a client's message storage space is exhausted, some messages as defined by a site specific message retention policy may be dropped. A message is guaranteed to be delivered once-and-only-once by a JMS Provider if the delivery mode of the messge is persistent and if the destination has a sufficient message retention policy.
+|persistentDelivery |boolean |no |  |If set to true, the JMS provider logs the message to stable storage as it is sent so that it can be recovered if delivery is unsuccessful. A client marks a message as persistent if it feels that the application will have problems if the message is lost in transit. A client marks a message as non-persistent if an occasional lost message is tolerable. Clients use delivery mode to tell a JMS provider how to balance message transport reliability/throughput. Delivery mode only covers the transport of the message to its destination. Retention of a message at the destination until its receipt is acknowledged is not guaranteed by a PERSISTENT delivery mode. Clients should assume that message retention policies are set administratively. Message retention policy governs the reliability of message delivery from destination to message consumer. For example, if a client's message storage space is exhausted, some messages as defined by a site specific message retention policy may be dropped. A message is guaranteed to be delivered once-and-only-once by a JMS Provider if the delivery mode of the message is persistent and if the destination has a sufficient message retention policy.
 |honorQosHeaders |boolean |no |  |If set to true, the message's QoS headers are honored. If false (the default), the connector settings override the message headers.
 |maxRedelivery |integer |no |  |The maximum number of times to try to redeliver a message. Use -1 to accept messages with any redelivery count.
-|cacheJmsSessions |boolean |no |true |Whether to cache and re-use the JMS session and producer object instead of recreating them for each request. The default behaviour is to cache JMS Sessions and Producers (previous to 3.6, the default behaviuor was to not cache them). NOTE: This is NOT supported with XA transactions or JMS 1.0.2b.
+|cacheJmsSessions |boolean |no |true |Whether to cache and re-use the JMS session and producer object instead of recreating them for each request. The default behavior is to cache JMS Sessions and Producers (previous to 3.6, the default behavior was to not cache them). NOTE: This is NOT supported with XA transactions or JMS 1.0.2b.
 |eagerConsumer |boolean |no |  |Whether to create a consumer right when the connection is created instead of using lazy instantiation in the poll loop.
 |specification |enumeration |no |1.0.2b |The JMS specification to use: 1.0.2b (the default) or 1.1
 |username |string |no |  |The user name for the connection
@@ -170,7 +170,7 @@ The activemq-xa-connector element configures an ActiveMQ version of the JMS conn
 |Name |Type |Required |Default |Description
 |connectionFactory-ref |string |no |  |Optional reference to the connection factory. A default connection factory is provided for vendor-specific JMS configurations.
 |redeliveryHandlerFactory-ref |string |no |  |Reference to the redelivery handler.
-|acknowledgementMode |enumeration |no |AUTO_ACKNOWLEDGE |The acknowledgement mode to use: AUTO_ACKNOWLEDGE, CLIENT_ACKNOWLEDGE, or DUPS_OK_ACKNOWLEDGE.
+|acknowledgementMode |enumeration |no |AUTO_ACKNOWLEDGE |The acknowledgment mode to use: AUTO_ACKNOWLEDGE, CLIENT_ACKNOWLEDGE, or DUPS_OK_ACKNOWLEDGE.
 |clientId |string |no |  |The ID of the JMS client.
 |durable |boolean |no |  |Whether to make all topic subscribers durable.
 |noLocal |boolean |no |  |If set to true, a subscriber will not receive messages that were published by its own connection.

--- a/mule-user-guide/v/3.7/amazon-s3-connector.adoc
+++ b/mule-user-guide/v/3.7/amazon-s3-connector.adoc
@@ -159,7 +159,7 @@ For the operations to work, you need to enable or update the subset of the overa
 * Create Object Presigned URI
 * Delete Bucket
 * Delete Bucket Cross Origin Configuration
-* Delete Buckt Lifecycle Configuration
+* Delete Bucket Lifecycle Configuration
 * Delete Bucket Policy
 * Delete Bucket Tagging Configuration
 * Delete Bucket Website Configuration

--- a/mule-user-guide/v/3.7/amazon-sns-connector.adoc
+++ b/mule-user-guide/v/3.7/amazon-sns-connector.adoc
@@ -215,7 +215,7 @@ Listed below are the few common use cases for the connector:
 Use the *Test Connection* feature to validate the connection to the AWS SNS topic.
 
 . Open the *Amazon SNS Global Element Configuration*.
-. Click the *Test Connection* button. If Topic Arn or the Region Endpoint are invalid, you will get an eeror message.
+. Click the *Test Connection* button. If Topic Arn or the Region Endpoint are invalid, you will get an error message.
 +
 image:sns_wrong_region.png[Wrong Topic Region Endpoint]
 +

--- a/mule-user-guide/v/3.7/amazon-sqs-connector.adoc
+++ b/mule-user-guide/v/3.7/amazon-sqs-connector.adoc
@@ -417,7 +417,7 @@ http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee
 			doc:name="Display Message" />
         <logger message="Deleting message with handle : #[header:inbound:sqs.message.receipt.handle]" level="INFO" doc:name="Display Message Handle"/>
         <sqs:delete-message config-ref="Amazon_SQS_Configuration" doc:name="Delete Message"/>
-        <logger message="Message deleted sucessfully from queue." level="INFO" doc:name="Logger"/>
+        <logger message="Message deleted successfully from queue." level="INFO" doc:name="Logger"/>
 	</flow>
 </mule>
 

--- a/mule-user-guide/v/3.7/authentication-in-http-requests.adoc
+++ b/mule-user-guide/v/3.7/authentication-in-http-requests.adoc
@@ -608,7 +608,7 @@ This function provides access to OAuth authorization information from a token ma
 
 ==== Examples
 
-In the table below is a set of examples showing you how to retreive information from a Token Manager. These expressions can be used in any building block in your flow that you place after the HTTP Request Connector that handles your OAuth authentication.
+In the table below is a set of examples showing you how to retrieve information from a Token Manager. These expressions can be used in any building block in your flow that you place after the HTTP Request Connector that handles your OAuth authentication.
 
 [width="99a",cols="50a,50a",options="header"]
 |===
@@ -617,7 +617,7 @@ In the table below is a set of examples showing you how to retreive information 
 | `oauthContext(‘Token_Manager_Config’, ‘Peter’).accessToken` |accessToken value for the RO identified with the id ‘Peter’
 |`oauthContext(‘Token_Manager_Config’).refreshToken` |refreshToken value
 | `oauthContext(‘Token_Manager_Config’).expiresIn` |expires in value
-| `oauthContext(‘Token_Manager_Config’).state` |state used for the authrorization URL
+| `oauthContext(‘Token_Manager_Config’).state` |state used for the authorization URL
 | `oauthContext(‘Token_Manager_Config’).`
 `tokenResponseParameters.‘a_custom_param_name’`
 |custom parameter extracted from the token URL response

--- a/mule-user-guide/v/3.7/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.7/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.7/cache-scope.adoc
+++ b/mule-user-guide/v/3.7/cache-scope.adoc
@@ -320,7 +320,7 @@ There are two message processors for invalidating caches:
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -368,7 +368,7 @@ This sample gives you a clear reference of how the incoming data is structured a
 ]
 ----
 
-. As in the previous case, in the input section you can see a tree that describes the data structure. As there's no metadata about the desired output, there isn't anything specified in the output section. In this example we will build the DataWeave code manually, as waht we need to do requires more advanced features than what the UI can provide. In the DataWeave code, change the output directive from the default `application/java` to `application/json`.
+. As in the previous case, in the input section you can see a tree that describes the data structure. As there's no metadata about the desired output, there isn't anything specified in the output section. In this example we will build the DataWeave code manually, as what we need to do requires more advanced features than what the UI can provide. In the DataWeave code, change the output directive from the default `application/java` to `application/json`.
 . In the transform section, Write the following DataWeave code:
 +
 

--- a/mule-user-guide/v/3.7/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.7/http-listener-connector.adoc
@@ -886,13 +886,13 @@ NOTE: If you wish, you can prevent outbound properties from being passed on as h
 ....
 In the HTTP Listener Connector's properties editor, on the *Response Settings* section, tick the box labeled *Disable Properties* to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response mesages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response messages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
 ....
 [tab,title="XML Editor"]
 ....
 Add a `http:response-builder` as a child element of the `http:listener`, in this child element, set the attribute `disablePropertiesAsHeaders="true"` to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response mesages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response messages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
 
 For example:
 

--- a/mule-user-guide/v/3.8-m1/amazon-sqs-connector.adoc
+++ b/mule-user-guide/v/3.8-m1/amazon-sqs-connector.adoc
@@ -416,7 +416,7 @@ http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee
 			doc:name="Display Message" />
         <logger message="Deleting message with handle : #[header:inbound:sqs.message.receipt.handle]" level="INFO" doc:name="Display Message Handle"/>
         <sqs:delete-message config-ref="Amazon_SQS_Configuration" doc:name="Delete Message"/>
-        <logger message="Message deleted sucessfully from queue." level="INFO" doc:name="Logger"/>
+        <logger message="Message deleted successfully from queue." level="INFO" doc:name="Logger"/>
 	</flow>
 </mule>
 

--- a/mule-user-guide/v/3.8-m1/authentication-in-http-requests.adoc
+++ b/mule-user-guide/v/3.8-m1/authentication-in-http-requests.adoc
@@ -609,7 +609,7 @@ This function provides access to OAuth authorization information from a token ma
 
 ==== Examples
 
-In the table below is a set of examples showing you how to retreive information from a Token Manager. These expressions can be used in any building block in your flow that you place after the HTTP Request Connector that handles your OAuth authentication.
+In the table below is a set of examples showing you how to retrieve information from a Token Manager. These expressions can be used in any building block in your flow that you place after the HTTP Request Connector that handles your OAuth authentication.
 
 [width="99a",cols="50a,50a",options="header"]
 |===
@@ -618,7 +618,7 @@ In the table below is a set of examples showing you how to retreive information 
 | `oauthContext(‘Token_Manager_Config’, ‘Peter’).accessToken` |accessToken value for the RO identified with the id ‘Peter’
 |`oauthContext(‘Token_Manager_Config’).refreshToken` |refreshToken value
 | `oauthContext(‘Token_Manager_Config’).expiresIn` |expires in value
-| `oauthContext(‘Token_Manager_Config’).state` |state used for the authrorization URL
+| `oauthContext(‘Token_Manager_Config’).state` |state used for the authorization URL
 | `oauthContext(‘Token_Manager_Config’).`
 `tokenResponseParameters.‘a_custom_param_name’`
 |custom parameter extracted from the token URL response

--- a/mule-user-guide/v/3.8-m1/authorization-grant-types.adoc
+++ b/mule-user-guide/v/3.8-m1/authorization-grant-types.adoc
@@ -1,5 +1,5 @@
 = Authorization Grant Types
-:keywords: http, authentication, secturity, users, connectors, anypoint, studio, esb, oauth
+:keywords: http, authentication, security, users, connectors, anypoint, studio, esb, oauth
 
 There are four ways that a consumer can obtain authorization to dance with an OAuth service provider.
 

--- a/mule-user-guide/v/3.8-m1/cache-scope.adoc
+++ b/mule-user-guide/v/3.8-m1/cache-scope.adoc
@@ -320,7 +320,7 @@ There are two message processors for invalidating caches:
 
 == Example
 
-The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Finobacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
+The example that follows demonstrates the power of the cache scope with a Fibonacci function. The Fibonacci sequence is a series of numbers in which the next number in the series is always the sum of the two numbers preceding it.
 
 In this example, the Mule flow receives and performs two tasks for each request:
 

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -368,7 +368,7 @@ This sample gives you a clear reference of how the incoming data is structured a
 ]
 ----
 
-. As in the previous case, in the input section you can see a tree that describes the data structure. As there's no metadata about the desired output, there isn't anything specified in the output section. In this example we will build the DataWeave code manually, as waht we need to do requires more advanced features than what the UI can provide. In the DataWeave code, change the output directive from the default `application/java` to `application/json`.
+. As in the previous case, in the input section you can see a tree that describes the data structure. As there's no metadata about the desired output, there isn't anything specified in the output section. In this example we will build the DataWeave code manually, as what we need to do requires more advanced features than what the UI can provide. In the DataWeave code, change the output directive from the default `application/java` to `application/json`.
 . In the transform section, Write the following DataWeave code:
 +
 

--- a/mule-user-guide/v/3.8-m1/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.8-m1/http-listener-connector.adoc
@@ -886,13 +886,13 @@ NOTE: If you wish, you can prevent outbound properties from being passed on as h
 ....
 In the HTTP Listener Connector's properties editor, on the *Response Settings* section, tick the box labeled *Disable Properties* to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response mesages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the fields in the Response Settings section won't be taken into account. Instead, the fields in the *Error Response Settings* are used. If you want to avoid properties from turning into headers in error response messages, tick the box labeled *Disable Properties* in the *Error Response Settings* section.
 ....
 [tab,title="XML Editor"]
 ....
 Add a `http:response-builder` as a child element of the `http:listener`, in this child element, set the attribute `disablePropertiesAsHeaders="true"` to prevent response messages from including outbound properties as headers.
 
-Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response mesages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
+Keep in mind that this only affects responses when the execution of the flow is successful. If an exception is raised, then the `http:response-builder` element won't be taken into account. Instead the `http:error-response-builder` is used. If you want to avoid properties from turning into headers in error response messages, set the attribute `disablePropertiesAsHeaders="true"` in the `http:error-response-builder` child element.
 
 For example:
 


### PR DESCRIPTION
Many typo corrections. Some I didn't change because although they are not proper USA spelling, they are correct British English spelling.

There were also some typo's in the release notes which were commit messages. I left those as is as well.