### PR TITLE
Added a TIP to server tasks

### DIFF
--- a/cloudhub/v/latest/managing-applications-and-servers-in-the-cloud-and-on-premises.adoc
+++ b/cloudhub/v/latest/managing-applications-and-servers-in-the-cloud-and-on-premises.adoc
@@ -161,6 +161,10 @@ If running Windows, substitute `amc_setup.bat` for `./amc_setup` (without `./`)
 . In the *Servers* screen of Anypoint Runtime Manager, you should see that your server (named `srv1` in this example) is listed as *Created*:
 +
 image:srv1_created.png[srv1_created]
++
+[TIP]
+If your server was already running you will still see it as created. You would have to restart it in order to have it communicate with the runtime manager.
++
 
 === Start Mule or API Gateway
 


### PR DESCRIPTION
Adding a small tip box highlighting that if a server is running when registered it needs to be restarted for it to communicate with the runtime manager. It's not explicitly documented and a customer recently got stuck on this step because of this.