### PR TITLE
Update modularizing-your-configuration-files-for-team-development.adoc

### DIFF
--- a/mule-user-guide/v/3.7/modularizing-your-configuration-files-for-team-development.adoc
+++ b/mule-user-guide/v/3.7/modularizing-your-configuration-files-for-team-development.adoc
@@ -44,3 +44,11 @@ Here is the main configuration file illustrated above, which takes care of impor
   </spring:beans>
 </mule>
 ----
+::
+The import mechanism needs the XML files to be in the classpath; typically this is done with a jar-file which contains the XML files - included via Maven-dependency. It is best practice for shared flow-file JARs to be version-controlled, and be the result of proper SDLC controls.
+
+::
+Note that while properly defined flow-imports function at runtime, flow-refs to any imported flows currently show as missing-flows in Studio: 
+
+* canvas: flow-ref icons are marked withthe  small red square with white-X 
+* XML: flow-refs will be marked with a dotted red underline and red error-markers in the right margin


### PR DESCRIPTION
imported flows work, but show as errors in Studio. Users should be warned in the docs
added brief description of the practical include-steps