### PR TITLE
Add latest MUnit release notes links to navigation panel

### DIFF
--- a/release-notes/v/latest/_toc.adoc
+++ b/release-notes/v/latest/_toc.adoc
@@ -259,6 +259,8 @@
 *** link:/release-notes/arm-on-prem-sep2015-release-notes[Anypoint Runtime Manager On-Premise Edition September 2015]
 ** link:/release-notes/anypoint-platform-on-prem-1.1.0-release-notes[Anypoint Platform On Premises Edition 1.1.0 Release Notes]
 ** link:/release-notes/munit-release-notes[MUnit Release Notes]
+*** link:/release-notes/munit-1.2.0-m1-release-notes[MUnit 1.2.0-M1 Release Notes]
+*** link:/release-notes/munit-1.1.1-release-notes[MUnit 1.1.1 Release Notes]
 *** link:/release-notes/munit-1.1.0-release-notes[MUnit 1.1.0 Release Notes]
 *** link:/release-notes/munit-1.0.0-release-notes[MUnit 1.0.0 Release Notes]
 *** link:/release-notes/munit-1.0-rc-release-notes[MUnit 1.0-RC Release Notes]


### PR DESCRIPTION
The links for MUnit 1.2.0-M1 and 1.1.1 release notes were missing from the index tree. 