### PR TITLE
Update in DataWeave for Studio input typre

### DIFF
--- a/mule-user-guide/v/3.7/using-dataweave-in-studio.adoc
+++ b/mule-user-guide/v/3.7/using-dataweave-in-studio.adoc
@@ -51,6 +51,25 @@ If your transform outputs XML data, a namespace directive will be automatically 
 %namespace ns0 http://mulesoft.org/tshirt-service
 ----
 
+Also, to define an input payload type you don't do it using and input directive but through an attribute in the XML instead.
+If you do not provide this attribute DataWeave will try to read the payload MIME type, if it is specified.
+If it is undeclared or not understood it will default to 'application/java', a warning will be logged.
+See for example the following snippet declaring an input of JSON type.
+[source,xml]
+----
+<dw:transform-message doc:name="Transform Message">
+	<dw:input-payload mimeType="text/json" />
+	<dw:set-payload>
+	<![CDATA[%dw 1.0
+	%output application/java
+	---
+	{
+		// YOUR DW SCRIPT
+	}
+	]]>
+	</dw:set-payload>
+</dw:transform-message>
+----
 For further reference about writing DataWeave code, see link:/mule-user-guide/v/3.7/dataweave-reference-documentation[DataWeave Language Reference]
 
 


### PR DESCRIPTION
On Studio, actually on Mule, the input directive does not work to define the input type.
Neither for payload nor for any kind of input.
In order to define the input type the mimeType attribute should be used on the appropriate input- elements.

See DOCS-1476