### PR TITLE
Remove contraint not valid anymore

### DIFF
--- a/anypoint-platform-for-apis/v/latest/images-and-attachments-in-api-portal.adoc
+++ b/anypoint-platform-for-apis/v/latest/images-and-attachments-in-api-portal.adoc
@@ -98,5 +98,3 @@ Click the Trash icon, then click *Delete* to confirm the operation.
 *Max. size:* 5 MB. Images and attachments that you upload to API Portal cannot exceed this size. If your image exceeds this size, you can host it on an external site and link to it from within API Portal.
 
 *Linking:* You can link to images hosted on external sites, but not to other file types. The link function is not available for attachments.
-
-*Exporting:* Currently, exporting your API does not include images or attachments. If you attempt to export an API that contains images or attachments, you will get a reminder message during the export.


### PR DESCRIPTION
When the feature was firstly released it went out without images and attachment being included as part of export feature. On a next release this was added, so this is not a valid constraint anymore