### PR TITLE
Update apikit-beyond-the-basics.adoc

### DIFF
--- a/anypoint-platform-for-apis/v/latest/apikit-beyond-the-basics.adoc
+++ b/anypoint-platform-for-apis/v/latest/apikit-beyond-the-basics.adoc
@@ -176,7 +176,18 @@ Every time a message throws an exception, Studio checks to see if the exception 
 * If it *finds a match*, Studio returns an HTTP-status-code-friendly response using the property and payload defined in the exception mapping. For example, if an exception matches `org.mule.module.apikit.exception.BadRequestException`, Studio returns a `400` error which indicates that the content of the request was bad. 
 * If it **does _not_ find a match**, Studio returns a `500 Internal Server Error` response.
 
-You can adjust or add to the five default exception strategy mappings as needed. Note that if you remove _all_ exception mappings, all errors thrown in the project will elicit a `500 Internal Server Error` response.
+You can adjust or add to the five default exception strategy mappings as needed. What follows is an example of manually adding an exception strategy mapping to custom handle a "500 Internal Server Error" response:
+
+[source,xml,linenums]
+----
+        <apikit:mapping statusCode="500"> 
+            <apikit:exception value="java.lang.Exception" /> 
+            <set-property propertyName="Content-Type" value="application/json"/> 
+            <set-payload value="#['{ &quot;message&quot;: &quot;Internal Server Error: ' + exception.message + '&quot; }']"/> 
+        </apikit:mapping>
+----
+
+Note that if you remove _all_ exception mappings, all errors thrown in the project will elicit a `500 Internal Server Error` response.
 
 You have no need to manually adjust the auto-generated exception strategies or manually reference them within the flows. However, if you have manually created your main flow (refer to <<Backend-First Design>>), you must also manually create, then reference the exception strategy mappings. To reference the `apikit:mapping-exception-strategy`, including all the exception mappings you created, add a *Reference Exception Strategy* to your main flow (see below).
 


### PR DESCRIPTION
Added an example to show how one would handle create a mapping to manually handle the 500 Internal Server Error response in a custom way.  Such an example is relevant for generic handling of certain runtime exceptions that arise in DataWeave script that would proceed unreported otherwise.