### PR TITLE
Added missing connector with auto-paging

### DIFF
--- a/mule-user-guide/v/3.8-m1/auto-paging-in-anypoint-connectors.adoc
+++ b/mule-user-guide/v/3.8-m1/auto-paging-in-anypoint-connectors.adoc
@@ -21,6 +21,7 @@ The table below lists the link:/mule-user-guide/v/3.8-m1/anypoint-connectors[An
 |Google Prediction | 
 |Google Spreadsheets | 
 |Google Tasks | 
+|Marketo |
 |Microsoft Dynamics CRM (on Demand) | 
 |Microsoft Dynamics CRM (on Premise) | 
 |NetSuite | 


### PR DESCRIPTION
Marketo v2.0.0 supports auto-paging.
Connector was released last week.