### PR TITLE
Update dataweave-reference-documentation.adoc

### DIFF
--- a/mule-user-guide/v/3.8-m1/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-reference-documentation.adoc
@@ -1420,11 +1420,11 @@ The first method only works if the variable name doesn't include any periods or 
 [TIP]
 If the metadata about these inbound properties is known to Studio, an autocomplete function  helps you out.
 
-You can optionally also define the inbound property as a variable input directive in the header, although this isn't required.
+You can optionally also define the inbound property as a constant directive in the header, although this isn't required.
 
 [source,DataWeave]
 ---------------------------------------------------------------------
-%var inboundProperties[’userName’]
+%var inUname = inboundProperties['userName']
 ---------------------------------------------------------------------
 
 ==== Outbound Properties from a Mule Message
@@ -1452,11 +1452,11 @@ The first method only works if the variable name doesn't include any periods or 
 [TIP]
 If the metadata about these outbound properties is known to Studio, an autocomplete function  helps you out.
 
-You can optionally also define the outbound property as a variable input directive in the header, although this isn't required.
+You can optionally also define the outbound property as a constant directive in the header, although this isn't required.
 
 [source,DataWeave]
 ---------------------------------------------------------------------
-%var outboundProperties[’userName’]
+%var outUname = outboundProperties['userName']
 ---------------------------------------------------------------------
 
 
@@ -1486,11 +1486,11 @@ The first method only works if the variable name doesn't include any periods or 
 [TIP]
 If the metadata about these flow variables is known to Studio, an autocomplete function helps you out.
 
-You can optionally also define the flow variable as a variable input directive in the header, although this isn't required.
+You can optionally also define the flow variable as a constant directive in the header, although this isn't required.
 
 [source,DataWeave]
 ---------------------------------------------------------------------
-%var flowVars[’userName’]
+%var uname = flowVars['userName']
 ---------------------------------------------------------------------
 
 == Operators


### PR DESCRIPTION
Corrections to descriptions and examples of DataWeave **_var_** declarations for message properties and flow variables.