### PR TITLE
Improved description of the standalone value

### DIFF
--- a/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
+++ b/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
@@ -32,7 +32,7 @@ The policy definition is a YAML file, which assigns values to a set of parameter
 |`description` |string - A description that displays in the policy's details when applying it
 |`category` |string - Category of the policy
 |`type` |string (optional) - Custom policies must always have type set to "custom"
-|`standalone` |boolean - Specifies if the policy can work on its own or if it relies on other policies being active.
+|`standalone` |boolean - true if the policy can be applied directly, or false if the policy can be applied only as part of another policy.
 |`providedCharacteristics` |array - List of characteristics that are fulfilled by applying this policy. Avoid clashes between policies that cannot be applied at the same time. For example, only one "OAuth 2.0" policy can be applied at a time. To ensure this, the `OAuth 2.0 protected` characteristic is used.
 
 The list of existing characteristics is: `Client ID required`, `CORS enabled`, `Baseline Rate Limiting`, `SLA Rate Limiting`, `Requires authentication`, `IP filtered`, `JSON threat protected`, `Security manager`, `OAuth 2.0 protected`, `OAuth 2.0 provider`, `XML threat protected`. This list is not limited: any string input is valid as a characteristic name, and these are case sensitive.


### PR DESCRIPTION
The current description of the standalone parameter makes you think that `standalone: false` means that the policy has dependencies. That is not what happens. Standalone false means that the policy can only be used as part of another policy (similar to "abstract" in a programming language).

I tried to improve the description. Not sure if my use of english was good.