### PR TITLE
Update applying-custom-policies.adoc

### DIFF
--- a/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
+++ b/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
@@ -31,7 +31,6 @@ The policy definition is a YAML file, which assigns values to a set of parameter
 |`name` |string - Policy name
 |`description` |string - A description that displays in the policy's details when applying it
 |`category` |string - Category of the policy
-|`type` |string (optional) - Custom policies must always have type set to "custom"
 |`standalone` |boolean - Specifies if the policy can work on its own or if it relies on other policies being active.
 |`providedCharacteristics` |array - List of characteristics that are fulfilled by applying this policy. Avoid clashes between policies that cannot be applied at the same time. For example, only one "OAuth 2.0" policy can be applied at a time. To ensure this, the `OAuth 2.0 protected` characteristic is used.
 
@@ -127,7 +126,6 @@ id: ip-whitelist
 name: IP whitelist
 description: Limits all service calls to a defined set of IP addresses.
 category: Security
-type: system
 standalone: true
 requiresConnectivity: false
 providedCharacteristics:


### PR DESCRIPTION
Removed the description of type in the policy YAML. Reason: type is optional, and supported options are system or custom. However system is used internally; and users are not able to upload custom policies with type: system. This document describes the creation of custom policies, so it will confusing for users.
I also removed the type: system from the example... doing a copy & paste of that example will not work.