### PR TITLE
Update Tomcat deployment instructions

### DIFF
--- a/mule-user-guide/v/3.7/deploying-mule-as-a-service-to-tomcat.adoc
+++ b/mule-user-guide/v/3.7/deploying-mule-as-a-service-to-tomcat.adoc
@@ -9,6 +9,8 @@ This page describes two activities that will enable you to deploy your Mule appl
 
 For more information on hot deploying Mule applications, see link:/mule-user-guide/v/3.7/application-server-based-hot-deployment[Application Server Based Hot Deployment].
 
+These instructions have been verified in Mule 3.7.3
+
 == Installing Mule on Tomcat
 
 . link:http://tomcat.apache.org[Download] and install Apache Tomcat, following Apache's installation instructions.
@@ -17,12 +19,12 @@ For more information on hot deploying Mule applications, see link:/mule-user-gui
 +
 [source, xml, linenums]
 ----
-<Listener className="org.mule.config.builders. MuleXmlBuilderContextListener" />
+<Listener className="org.mule.module.tomcat.MuleTomcatListener" />
 ----
 
-. If you have not already done so, create a Tomcat home directory on your local system.
+. Create a mule-libs subdirectory under the Tomcat home directory
 
-. Copy the contents of the Mule `lib` folder with all its subdirectories – *except* `/boot` to the `mule-libs/` – to your Tomcat home directory. You do not need to flatten the directories.
+. Copy the contents of the Mule `lib` folder with all its subdirectories – *except* `/boot` to the `mule-libs/` subdirectory of your Tomcat home directory. Do not flatten the directory structure.
 
 . Copy the `mule-module-tomcat-<version>.jar` file to the `mule-libs/mule/` directory in your Tomcat home directory.
 
@@ -38,7 +40,13 @@ For more information on hot deploying Mule applications, see link:/mule-user-gui
 
 * `disruptor-3.3.0.jar`
 
-* `wrapper-3.5.19.jar`
+* `wrapper-3.5.26.jar`
+
+* `log4j-slf4j-impl-2.1.jar`
+
+* `log4j-api-2.1.jar`
+
+* `log4j-core-2.1.jar`
 
 . In the Tomcat `conf/catalina.properties` file, add the following to `common.loader` (preceded by a comma to separate it from existing values):
 +
@@ -50,6 +58,8 @@ ${catalina.home}/mule-libs/user/*.jar,${catalina.home}/mule-libs/mule/*.jar,${ca
 == Deploying Mule Applications in Tomcat
 
 . Package your Mule application's configuration files and custom Java classes in a `.war` file (see link:/mule-user-guide/v/3.7/application-server-based-hot-deployment[Application Server Based Hot Deployment]).
+
+. In the Maven project all Mule provided dependencies -ie any library provided in the mule-libs directory- must have a <scope>provided</scope> definition to prevent classloading conflicts between duplicated libraries.
 
 . Copy your application's `.war` file, then paste it in the Tomcat `/webapps` directory.
 


### PR DESCRIPTION
Current instructions are out of date for Mule 3.7.x and don't work. Probably don't work with 3.6.x either but I didn't try that. I tested this deploying a Mule web app in Tomcat 7 and Mule 3.7.3.