### PR TITLE
Using "indicate route" for "browse to a file"

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then indicate the route to the JSON example you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +

--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then indicate the route to the JSON example you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +


### PR DESCRIPTION
The wording of "indicate route" tripped me up as my head was deep into thinking about Dataweave and I thought this was some kind of DataWeave nomenclature.

I changed the wording to something I felt was more directed at selecting a file. Hopefully this makes it a bit easier to read and understand.

No worries if you all think otherwise.