### PR TITLE
Correction not carried over to 3.8-m1 side

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then indicate the route to the JSON example you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -171,7 +171,7 @@ image:dw_tut1_fixed_vals.png[fixed vals]
 ---
 {
     ns0#OrderTshirt: {
-        size: "M" unless payload.buyer.state == "TX" otherwise size: "XXL",
+        size: "M" unless payload.buyer.state == "TX" otherwise "XXL",
         email: payload.buyer.email,
         name: payload.buyer.name,
         address1: payload.buyer.address,
@@ -239,7 +239,7 @@ You should get a response with an XML body that has a single value, this is the 
 ---
 {
     ns0#OrderTshirt: {
-        size: "M" unless payload.buyer.state == "TX" otherwise size: "XXL",
+        size: "M" unless payload.buyer.state == "TX" otherwise "XXL",
         email: payload.buyer.email,
         name: payload.buyer.name,
         address1: payload.buyer.address,
@@ -265,7 +265,7 @@ You should get a response with an XML body that has a single value, this is the 
 ---
 {
     ns0#OrderTshirt: {
-        size: "M" unless payload.buyer.state == "TX" otherwise size: "XXL",
+        size: "M" unless payload.buyer.state == "TX" otherwise "XXL",
         email: payload.buyer.email,
         name: payload.buyer.name,
         address1: payload.buyer.address,
@@ -603,7 +603,7 @@ http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee
 ---
 {
     ns0#OrderTshirt: {
-        size: "M" unless payload.buyer.state == "TX" otherwise size: "XXL",
+        size: "M" unless payload.buyer.state == "TX" otherwise "XXL",
         email: payload.buyer.email,
         name: payload.buyer.name,
         address1: payload.buyer.address,

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -62,7 +62,7 @@ You then need to select only a few of these fields, rename some, and assume a va
 +
 image:add_metadatadw.png[image]
 
-. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then indicate the route to the JSON example you just downloaded above.
+. Select the *Create new type* radio button at the top, pick the type *JSON*, assign it any ID you wish, and then browse for the example JSON file you just downloaded above.
 . Note that now when the HTTP Connector is selected in your canvas, the *Output* tab of the metadata explorer should show the fields that will be present in the outgoing payload.
 
 +


### PR DESCRIPTION
There is a correction in the 3.7 docs that changes:

    otherwise size: "XXL"
to

    otherwise "XXL"
But was not carried over to the 3.8-m1 branch.