### PR TITLE
Attachment link correction

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -304,7 +304,7 @@ image:ex3_metadatadw.png[image]
 ====
 If you don't have a Salesforce account and don't want to go through the trouble of creating one, you can assign the data structure directly to the Transform Message component:
 
-.. Download this sample JSON file link:_attachments:dw_example2.json[sample JSON]
+.. Download this sample JSON file link:_attachments/dw_example2.json[sample JSON]
 .. Open the Transform message properties editor, note that the input section will have a warning about there being no metadata. Click on the `Define metadata` link.
 .. Select `Create new Type`, pick `JSON`
 .. Name your Type Id `Contacts`, select `Example` in the dropdown menu and then find the file that you just downloaded from your local drive

--- a/mule-user-guide/v/3.7/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.7/dataweave-tutorial.adoc
@@ -304,7 +304,7 @@ image:ex3_metadatadw.png[image]
 ====
 If you don't have a Salesforce account and don't want to go through the trouble of creating one, you can assign the data structure directly to the Transform Message component:
 
-.. Download this sample JSON file _attachments:dw_example2.json[sample JSON]
+.. Download this sample JSON file link:_attachments:dw_example2.json[sample JSON]
 .. Open the Transform message properties editor, note that the input section will have a warning about there being no metadata. Click on the `Define metadata` link.
 .. Select `Create new Type`, pick `JSON`
 .. Name your Type Id `Contacts`, select `Example` in the dropdown menu and then find the file that you just downloaded from your local drive

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -304,7 +304,7 @@ image:ex3_metadatadw.png[image]
 ====
 If you don't have a Salesforce account and don't want to go through the trouble of creating one, you can assign the data structure directly to the Transform Message component:
 
-.. Download this sample JSON file link:_attachments:dw_example2.json[sample JSON]
+.. Download this sample JSON file link:_attachments/dw_example2.json[sample JSON]
 .. Open the Transform message properties editor, note that the input section will have a warning about there being no metadata. Click on the `Define metadata` link.
 .. Select `Create new Type`, pick `JSON`
 .. Name your Type Id `Contacts`, select `Example` in the dropdown menu and then find the file that you just downloaded from your local drive

--- a/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
+++ b/mule-user-guide/v/3.8-m1/dataweave-tutorial.adoc
@@ -304,7 +304,7 @@ image:ex3_metadatadw.png[image]
 ====
 If you don't have a Salesforce account and don't want to go through the trouble of creating one, you can assign the data structure directly to the Transform Message component:
 
-.. Download this sample JSON file _attachments:dw_example2.json[sample JSON]
+.. Download this sample JSON file link:_attachments:dw_example2.json[sample JSON]
 .. Open the Transform message properties editor, note that the input section will have a warning about there being no metadata. Click on the `Define metadata` link.
 .. Select `Create new Type`, pick `JSON`
 .. Name your Type Id `Contacts`, select `Example` in the dropdown menu and then find the file that you just downloaded from your local drive


### PR DESCRIPTION
On https://docs.mulesoft.com/mule-user-guide/v/3.7/dataweave-tutorial this link does not render, I'm not an asciidoc user, so I don't know the formatting. I just followed suite that I found other references using.

Note: I've looked for information on how to build on my local machine the mulesoft-docs site so I can double check the formatting, is this possible? Is everything in the repo in order for me to do this? (assuming I put the generated content under a web server like nginx to serve it up). If so, are there any instructions?