### PR TITLE
Fixed a typo in Dataweave examples

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-examples.adoc
+++ b/mule-user-guide/v/3.7/dataweave-examples.adoc
@@ -1681,5 +1681,5 @@ payload map {
 
 == See Also
 
-* Read about DataWeave in the link:http://blogs.mulesoft.com/dev/anypoint-studio-dev/getting-started-with-dataweave-part-1/[Mulesfot Blog]
+* Read about DataWeave in the link:http://blogs.mulesoft.com/dev/anypoint-studio-dev/getting-started-with-dataweave-part-1/[Mulesoft Blog]
 * See how to use DataWeave to reference an external flow that encrypts your message link:http://blogs.mulesoft.com/dev/training-dev/encrypt-specific-xml-tags-with-the-power-of-dataweave/[MuleSoft Blog]


### PR DESCRIPTION
"Mulesfot" is a somewhat less dignified name. 