### PR TITLE
Update information about using MUnit on Studio

### DIFF
--- a/munit/v/1.2.0/using-munit-in-anypoint-studio.adoc
+++ b/munit/v/1.2.0/using-munit-in-anypoint-studio.adoc
@@ -8,28 +8,6 @@ MUnit is fully integrated with Anypoint Studio. You can use Studio's graphical i
 * <<Viewing Test Results,View>> test results and coverage
 * <<Debugging Tests,Debug>> your tests
 
-== Installing MUnit in Studio
-
-To use MUnit in Studio, you have to install it from the update site.
-
-To install MUnit, follow these steps:
-
-. Verify that your version of Studio is 5.2.0 (July 2015 release) or newer.
-. Add the MUnit update site:
-.. Go to *Help* > *Install New Software*.
-.. Studio displays the *Available Software* window. In the *Work with:* field, paste the MUnit update site:
-+
-[source, code]
-----
-http://studio.mulesoft.org/r4/munit
-----
-+
-.. Check *Munit* and *Munit Tools for Mule*, as shown below.
-+
-image:install-site.png[install-site]
-+
-.. Click *Next*, then complete the installation wizard.
-
 == The MUnit Folder
 
 Using MUnit automatically adds a new folder, `src/test/munit`, to your project.
@@ -239,6 +217,30 @@ TIP: In the event you have failed test you can select the button re-debug failed
 * Or right-click the desired test, then select *Debug*:
 
 image:debug3.png[debug3]
+
+TIP: Since Studio 5.4.0, MUnit comes installed by default. If you are using a previous version, you will need to install it.
+
+== Installing MUnit in Studio
+
+To use MUnit in Studio, you have to install it from the update site.
+
+To install MUnit, follow these steps:
+
+. Verify that your version of Studio is 5.2.0 (July 2015 release) or newer.
+. Add the MUnit update site:
+.. Go to *Help* > *Install New Software*.
+.. Studio displays the *Available Software* window. In the *Work with:* field, paste the MUnit update site:
++
+[source, code]
+----
+http://studio.mulesoft.org/r4/munit
+----
++
+.. Check *Munit* and *Munit Tools for Mule*, as shown below.
++
+image:install-site.png[install-site]
++
+.. Click *Next*, then complete the installation wizard.
 
 == See Also
 


### PR DESCRIPTION
Due that MUnit comes by default with Studio since 5.4.0, there is no need to explain how to install it at first. Just in case that they are using a previous version of Studio, we are leaving it at the bottom of the page just to inform them how to do it. This will need to be replicated on version 1.1.1 and 1.0.0