### PR TITLE
removing unsupported Google connectors

### DIFF
--- a/mule-user-guide/v/3.8/batch-processing-reference.adoc
+++ b/mule-user-guide/v/3.8/batch-processing-reference.adoc
@@ -132,8 +132,6 @@ RUN  | |Defines what a batch job should do if all threads are active. +
 Several *Anypoint Connectors* have the ability to handle record-level errors without failing a whole batch commit (i.e. upsert). At runtime, these connectors keep track of which records were successfully accepted by the target resource, and which failed to upsert.  Thus, rather than failing a complete group of records during a commit activity, the connector simply upserts as many records as it can, and tracks any failures for notification. The short – but soon to grow – list of such connectors follows:
 
 * Salesforce
-* Google Contacts
-* Google Calendars
 * NetSuite
 
 == BatchJobResult Processing Statistics


### PR DESCRIPTION
In Anypoint Exchange they are shown to be community supported so we don't guarantee they are maintained nor working with current releases.