### PR TITLE
Fix version of dbserver dependency

### DIFF
--- a/munit/v/1.2.0/munit-database-server.adoc
+++ b/munit/v/1.2.0/munit-database-server.adoc
@@ -86,7 +86,7 @@ You need to add the MUnit DB server artifact to your `pom` file:
 <dependency>
 	<groupId>com.mulesoft.munit.utils</groupId>
 	<artifactId>munit-dbserver-module</artifactId>
-	<version>${munit.version}</version>
+	<version>1.0.0</version>
 </dependency>
 ----
 


### PR DESCRIPTION
The dbserver dependency version is not the same as munit. It has a different release lifecycle.