### PR TITLE
Removal of timeunit property type

### DIFF
--- a/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
+++ b/anypoint-platform-for-apis/v/latest/applying-custom-policies.adoc
@@ -77,7 +77,7 @@ The `configuration` parameter lists a set of properties. Each can contain the fo
 |`propertyName` |string - Property name for internal reference
 |`name` |string - Property name to display in configuration window
 |`description` |string - Property description to display in configuration window
-|`type` |string - Data type: `string`, `boolean`, `int`, `timeunit`, `ipaddress`, `expression` (in MEL)
+|`type` |string - Data type: `string`, `boolean`, `int`, `ipaddress`, `expression` (in MEL)
 |`optional` |boolean - True if assigning a value for it is optional.
 |`sensitive` |boolean - True if the information contained by this field is sensitive (typically used for passwords and tokens). When policy information is requested from the server, these sensitive fields are filtered out.
 |`allowMultiple` |boolean - True if multiple values can be assigned. Only valid if `type` is `ipaddress`.
@@ -100,20 +100,6 @@ configuration:
    type: int
    minimumValue: 5
    maximumValue: 10
-   optional: true
-   sensitive: false
-   allowMultiple: false
-----
-
-==== Timeunit
-
-[source,yaml,linenums]
-----
-configuration:
- - propertyName: atimeunit
-   name: Test Timeunit single
-   description: Some Description
-   type: timeunit
    optional: true
    sensitive: false
    allowMultiple: false


### PR DESCRIPTION
Currently timeunit is not totally supported. If you put a timeunit, API Platform doesn't render the right UI component, and you cannot fill the property value. I asked to the Custom Policies team, and they confirmed that. We should remove it from the docs.