### PR TITLE
how queues and object stores are implemented

### DIFF
--- a/runtime-manager/v/latest/cloudhub-fabric.adoc
+++ b/runtime-manager/v/latest/cloudhub-fabric.adoc
@@ -65,6 +65,25 @@ image:CHWorkers.png[CHWorkers]
 
 If your application is already deployed, you need to redeploy it in order for your new settings to take effect. 
 
+== How CloudHub Fabric is Implemented
+
+Internally, worker scaling and VM queue load balancing is implemented using Amazon SQS. 
+
+[NOTE]
+===
+Object stores in your applications are also always stored persistently using Amazon SQS, even if you did not enable Persistent queues for your application. 
+===
+
+HTTP load balancing is implemented by an internal reverse proxy server. Requests to the application (domain) URL http://appname.cloudhub.io are automatically load balanced between all the application's Worker URLs. 
+
+[NOTE]
+===
+Clients can by-pass the CloudHub Fabric load balancer by using a Worker's direct URL. 
+
+See: link:https://docs.mulesoft.com/runtime-manager/cloudhub-networking-guide[CloudHub Networking Guide] for more information on how to access an application in a specific CloudHub worker. 
+===
+
+
 == Use Cases
 
 Depending on your use case, you may wish to take advantage of both CloudHub Fabric features on the same application, or you may prefer to enable just one of them, or neither.


### PR DESCRIPTION
Added details on how vm persistent queues and object stores are implemented in CloudHub Fabric. 
Also added some details on HTTP load balancing and how to bypass the load balancer.