### PR TITLE
Clarified minThreads, maxThreads

### DIFF
--- a/mule-user-guide/v/3.8/tuning-performance.adoc
+++ b/mule-user-guide/v/3.8/tuning-performance.adoc
@@ -74,7 +74,7 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 Where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
-*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. At first, a new thread is created to handle each new inbound request until reaching `minThreads`. After that, subsequent requests are buffered until `maxBufferSize` requests are queued. Then new threads are created to handle the buffered requests until `maxThreads` is reached.
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
 


### PR DESCRIPTION
Clarified how these parameters work together. 

Should add a note on what happens when maxThreads is reached and maxBufferSize is reached. Does the connector deny subsequent requests?