### PR TITLE
Update dataweave-language-introduction.adoc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
+++ b/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
@@ -33,7 +33,7 @@ In order to show the power of DataWeave, here is a minimal example to get starte
 ----
 
 .Transform
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -76,7 +76,7 @@ The two sections are delimited by a three-dash *separator*: "---"
 
 This is basically what a `.dwl` file looks like. This code describes a transformation from a JSON input to an XML output:
 
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -136,7 +136,7 @@ In Anypoint Studio, you may use directives to declare additional input. You like
 
 Specify the version of the DataWeave syntax that is used to interpret the transformation using the version directive.
 
-[source,DataWeave]
+[source, dataweave]
 ---------------------------------------------------------------------
 %dw 1.0
 ---------------------------------------------------------------------
@@ -144,7 +144,7 @@ Specify the version of the DataWeave syntax that is used to interpret the transf
 === Namespace Directive
 
 Use this directive to specify an alias for a URI, which is specified after the alias. The directive is relevant only when either the input or the output is of type XML.
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ---------------------------------------------------------------------
 %namespace mes http://www.mulesoft.com/anypoint/SOA/message/v1.0
 ---------------------------------------------------------------------
@@ -156,7 +156,7 @@ Specify the transformation output type in the format: `<content>/<type>`.
 
 Only one output type can be specified -- the structure of this output is further specified in the DataWeave body.
 
-[source,DataWeave]
+[source, dataweave]
 ----
 %output application/xml
 ----
@@ -179,7 +179,7 @@ Valid types are:
 
 You can define a constant in the header, andreference it (or its child elements, if any exist) in the DataWeave body.
 
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %var conversionRate=13.15
@@ -195,7 +195,7 @@ You can define a constant in the header, andreference it (or its child elements,
 
 You can define a link:/mule-user-guide/v/3.8/dataweave-types#functions-and-lambdas[function] in the header, you can then call it in any part of the DataWeave body, including arguments.
 
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -209,7 +209,7 @@ You can define a link:/mule-user-guide/v/3.8/dataweave-types#functions-and-lambd
 A function directive can be defined via `%var` as in the example above, or via `%function`
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -262,13 +262,13 @@ Simple values can be of the following types:
 Arrays are represented as a sequence of value expressions.
 
 .Input
-[source,DataWeave]
+[source, dataweave]
 --------------------------------------------------------------------
 [ 1, 2 + 2, 3 * 3, $x ]
 --------------------------------------------------------------------
 
 .Transform
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -283,7 +283,7 @@ See link:/mule-user-guide/v/3.8/dataweave-types#array[DataWeave types] for more 
 These are represented as a comma separated sequence of key: value pairs surrounded by curly brackets { }.
 
 .Transform
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ---------------------------------------------------------------------
 %dw 1.0
 %output application/xml
@@ -317,7 +317,7 @@ In the DataWeave header, you define constants as directives, these can then be r
 The following creates an XML document and inserts the constant value for Language "Español" in the output language element.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -354,7 +354,7 @@ Consider the following examples:
 
 *Scoped to Simple Value*
 
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -365,7 +365,7 @@ using (x = 2) 3 + x # <1>
 
 *Scoped to Array literal*
 
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -375,7 +375,7 @@ using (x = 2) [1, x, 3]
 
 *Scoped to Object literal*
 
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -393,7 +393,7 @@ using (x = 2) [1, x, 3]
 
 *Invalid Reference outside of Scope*
 
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -426,7 +426,7 @@ An operator applies a specific logic/transformation over a data-structure.
 Operators can be classified based on their link:https://en.wikipedia.org/wiki/Arity[arity] as Unary, Binary or Ternary. See link:/mule-user-guide/v/3.8/dataweave-operators[DataWeave Operators] for a full reference.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -449,7 +449,7 @@ Operators can be classified based on their link:https://en.wikipedia.org/wiki/Ar
 A selector allows for the navigation and querying the multiple levels of a data-structure to reference a certain value or set of values. See link:/mule-user-guide/v/3.8/dataweave-selectors[DataWeave Selectors] for a full reference.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -497,7 +497,7 @@ A selector allows for the navigation and querying the multiple levels of a data-
 The keyword *when* conditionally evaluates a part of your DataWeave code, depending on if an expression evaluates to true or to false. You can make a single line conditional, or enclose a whole section in curly brackets. In case the *when* expression evaluates to *false*, its corresponding part of the code is ignored, and the code that corresponds to the *otherwise* expression is executed.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -519,7 +519,7 @@ Check the <<Operator Precedence Table>> to see what expressions are compiled bef
 The keyword *unless* conditionally evaluates a part of your DataWeave code, depending on if an expression evaluates to true or to false. You can make a single line conditional, or enclose a whole section in curly brackets. In case the *unless* expression evaluates to *true*, its corresponding part of the code is ignored, and the code that corresponds to the *otherwise* expression is executed.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -541,7 +541,7 @@ Check the <<Operator Precedence Table>> to see what expressions are compiled bef
 Assigns a default value in case no value is found in the input field.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -567,7 +567,7 @@ DataWeave supports four different types of patterns:
 
 Each pattern type can be either named or unnamed. The example below is not actual DataWeave code, but rather a model for how matching works, you can see more concrete examples on each of the sections that follow:
 
-[source,dataweave, linenums]
+[source, dataweave, linenums]
 ---
 value match {
   (<name>:)?<pattern> -> <when matched>,
@@ -588,7 +588,7 @@ Matches when the evaluated value equals a simple literal value.
 
 
 .Transform
-[source,dataweave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -642,7 +642,7 @@ Matches when running a certain expression over the evaluated value returns true.
 
 
 .Transform
-[source,dataweave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -695,7 +695,7 @@ Matches when the evaluated value is of the specified type
 
 
 .Transform
-[source,dataweave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -761,7 +761,7 @@ Matches when the evaluated value fits a given regular expression
 
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -843,7 +843,7 @@ DataWeave provides a set of values that are automatically assigned by the system
 Returns the present moment in link:/mule-user-guide/v/3.8/dataweave-types#dates[(:datetime)] type.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -875,7 +875,7 @@ Returns a random number of type link:/mule-user-guide/v/3.8/dataweave-types#numb
 
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -901,7 +901,7 @@ Which takes two parameters:
 * The payload to send to this flow, as a map
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -968,7 +968,7 @@ In this space you can use any MEL expression to define custom functions, for exa
 
 With that in place, in the DataWeave code of your Transform Message element you can just refer to these functions. Note that the inputs and outputs of these functions can even be objects and arrays.
 
-[source, ruby, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -993,7 +993,7 @@ The first argument points the content that must be read, the second is the forma
 
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -1042,7 +1042,7 @@ The first argument points to the element that must be written, the second is the
 
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/xml
@@ -1097,7 +1097,7 @@ Mr Orange|orange@mulesoft.com|4567|Integration Ninja
 Returns the specified value and also logs the value in the DataWeave representation with the specified prefix.
 
 .Transform
-[source,DataWeave, linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json
@@ -1150,7 +1150,7 @@ This table lists the order in which different DataWeave expressions are compiled
 == Closer Look at an Example Transformation
 
 .Transform
-[source,DataWeave,linenums]
+[source, dataweave, linenums]
 ----
 %dw 1.0
 %output application/json


### PR DESCRIPTION
Corrected a source type to be "DATAWEAVE" instead of "RUBY".  Also, lots of (unnecessary) updates to make DataWeave source declarations look more consistent (I can be anal-retentive sometimes).