### PR TITLE
Removed tabs from code listing

### DIFF
--- a/mule-user-guide/v/3.7/using-the-mule-client.adoc
+++ b/mule-user-guide/v/3.7/using-the-mule-client.adoc
@@ -176,14 +176,13 @@ import org.mule.api.lifecycle.Callable;
 
 public class MyComponent implements Callable {
 
-	@Override
-	public Object onCall(MuleEventContext eventContext) throws Exception {
+  @Override
+  public Object onCall(MuleEventContext eventContext) throws Exception {
 
     // Instead of using MuleClient, use the MuleEventContext
     // to get the client of 3.7.0 context
     eventContext.getMuleContext().getClient().dispatch("vm://queue1", null);
-
-	}
+  }
 }
 ----
 


### PR DESCRIPTION
This code listing had some tabs intermixed with spaces and when viewed through the browser showed less than ideal.