### PR TITLE
Updating MMC H&S requirements for 3.8

### DIFF
--- a/mule-user-guide/v/3.8/hardware-and-software-requirements.adoc
+++ b/mule-user-guide/v/3.8/hardware-and-software-requirements.adoc
@@ -235,7 +235,7 @@ See link:/release-notes/anypoint-connector-devkit-release-notes[Anypoint Connect
 
 == Mule Management Console (MMC)
 
-See link:/release-notes/mule-management-console-3.7.3[Mule Management Console 3.7.3] release notes for the latest changes to this software.
+See link:/release-notes/mule-management-console-3.8.0[Mule Management Console 3.8.0] release notes for the latest changes to this software.
 
 [cols=",",options="header"]
 |===
@@ -246,9 +246,7 @@ a|* 2GHz CPU
 * 10 GB of storage
 2+|*Software Requirements:*
 |*Java Runtime Environments*
-a|* Mule 3.7: Oracle link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jre-7u80-oth-JPR[Java 1.7] and Oracle link:http://www.oracle.com/technetwork/java/javase/overview/index.html[Java 1.8]
-
-* Mule 3.6: Oracle link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jre-7u80-oth-JPR[Java 1.7]
+a|* Oracle link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jre-7u80-oth-JPR[Java 1.7] and Oracle link:http://www.oracle.com/technetwork/java/javase/overview/index.html[Java 1.8]
 |*Web Application Servers*
 a|* JBoss 6 or 6.1
 * Apache Tomcat 6.x or 7.x


### PR DESCRIPTION
Updating link and JRE. Not sure why it was separated between 'Mule' versions, I suggest checking with the MMC team.