### PR TITLE
Update in HTTP paths with wildcards

### DIFF
--- a/mule-user-guide/v/3.8/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.8/http-listener-connector.adoc
@@ -214,6 +214,15 @@ image:http-listener-connector-9f800.png[wildcard path in basic settings for conn
 . Create a Global Element for the Connector, set the *Host* to `localhost` and leave the *Port* as the default `8081`
 . Complete the flow by adding any other building block after the HTTP Connector, such as a *Logger* component.
 
+[IMPORTANT]
+====
+When a request comes in, available listeners based on path are selected by pattern matching on a _folder by folder_ basis and going from left to right. This means that if you specify the following two listeners:
+
+* `/regions/*/customers`
+* `/regions/us/prospects`
+
+A request to `/region/us/customers` *will fail*, because request is mapped to the more specific listener which does not support the _customers_ path. Because of this it is a good practice to leave the wildcards for the rightmost part of paths and try to avoid having them overlap with more specific listeners.
+====
 
 === Using Wildcard in Path - Full XML Code
 


### PR DESCRIPTION
I have added a note on paths with wildcards after handling a couple cases where overlapping paths lead to an error. The already present note on the most exact path being used does not explain this situation where a request goes unfulfilled.
Available if you have any questions.
Best.