### PR TITLE
Clarify Mule 3.8 runtime steps

### DIFF
--- a/anypoint-platform-for-apis/v/latest/configuring-an-api-gateway.adoc
+++ b/anypoint-platform-for-apis/v/latest/configuring-an-api-gateway.adoc
@@ -1,7 +1,12 @@
 = Configuring an API Gateway
 :keywords: api, cloudhub, gateway, auto-discovery
 
-Mule 3.8.0 runtime unifies the API Gateway runtime with the core Mule runtime, eliminating the need to configure API Gateway. This document pertains to earlier installations.
+Mule 3.8.0 runtime unifies the API Gateway runtime with the core Mule runtime, eliminating the need to configure API Gateway. This document pertains to earlier installations. 
+
+[NOTE]
+====
+You do not need to follow any of these steps if you are deploying API proxy applictions into a Mule 3.8 runtime which is managed by Anypoint Runtime Manager. If your Mule 3.8 runtime is managed with MMC, you only need to follow the steps below to configure your Anypoint Platform client id and client secret in the Mule 3.8 runtime's wrapper.conf file.  
+====
 
 The *API Gateway runtime* points to the backend APIs and services that you define and abstracts them into a layer that the Anypoint Platform for APIs manages. Consumer applications invoke your services. APIs route to the endpoints that the gateway exposes to enforce runtime policies and collect and track analytics data. The API Gateway acts as a dedicated orchestration layer for all your backend APIs to separate orchestration from implementation concerns. The gateway leverages the governance capabilities of the Anypoint Platform for APIs, so that you can apply throttling, security, and other policies to your APIs.
 
@@ -55,6 +60,17 @@ If an API is not registered on Anypoint Platform, auto-discovery triggers that r
 You can  link:/anypoint-platform-for-apis/configuring-an-api-gateway#configuring-organization-credentials[configure Anypoint Studio] to provide organization credentials when you deploy applications to Anypoint Platform from Studio.
 
 If you are not using Anypoint Studio,   link:/anypoint-platform-for-apis/configuring-an-api-gateway#configuring-your-production-api-gateway-for-integration-with-the-anypoint-platform[configure API Gateway] to provide these credentials.
+
+
+[NOTE] 
+====
+If you are planning to deploy an API proxy application into an on-premises Mule 3.8 runtime, these credentials are automatically added to your Mule runtime's wrapper.conf file when you register the Mule runtime with your Anypoint Runtime Manager account. If you are managing your on-premises Mule runtime with MMC, then you will have to follow the above steps to add your Anypoint Platform credentials to this Mule runtime. 
+====
+
+[NOTE]
+====
+It is not supported to manage a Mule runtime with both MMC and the Anypoint Runtime Manager, but you can still enter your Anypoint Platform credentials into the wrapper.conf file for a Mule runtime which is managed by MMC. 
+====
 
 === Deploying a Proxy
 


### PR DESCRIPTION
Added notes clarifying Mule 3.8 runtime configuration steps. Specifically that it may be necessary to configure the client id and client secret in the Mule runtime's wrapper.conf file if the runtime is managed by MMC.