### PR TITLE
add CI profile to Gradle build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,6 +71,20 @@ When you want to stop the preview server, simply press kbd:[Ctrl+c].
 
 CAUTION: At the moment, not all links will work in the site since the preview server doesn't implement any of the rewrite rules that are used by the production site.
 
+=== Building the Site for Production
+
+The Gradle build script is also capable of building the site for production and publishing it to git.
+The extra tasks and configuration needed for these operations are added when the `profile` property has the value `ci`.
+You can set this property by passing the flag `-Pprofile=ci` to the `gradlew` launch command.
+
+To instruct Gradle to clean, build, and publish the production site, execute the following command:
+
+ $ ./gradlew clean publish -Pprofile=ci
+
+CAUTION: The first time you execute this command, it will run for a very long time (depending on connection speed) since it must clone the publish (aka build output) repository anew.
+
+WARNING: The publish task doesn't yet push the new commit to the remote repository.
+
 == MuleSoft Docs Style Guide
 
 The following sections describe the MuleSoft Docs publishing style.

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 // TODO
-// * add development/production modes and change behavior accordingly
-//   - goal is to make this usable in CI
-// * undo change to _templates/default.template after buildHtml
 // * add mode to run jetty in background
 // * combine css (need to update template as well)
 // * set outputs.dir for custom tasks
+import com.palominolabs.gradle.task.git.clone.GitCloneTask
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.RepositoryBuilder
+
 buildscript {
   configurations.create('builder')
   configurations.create('singlePageBuilder')
@@ -21,35 +22,58 @@ buildscript {
   dependencies {
     classpath 'com.eriwen:gradle-css-plugin:2.12.0'
     classpath 'com.palominolabs.gradle.task:gradle-git-clone-task:0.0.2'
+    classpath 'org.ajoberstar:gradle-git:1.5.1-rc.3'
+
     builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-SNAPSHOT'
+    //builder('com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-SNAPSHOT') {
+    //  exclude group: 'org.asciidoctor', module: 'asciidoctorj-pdf'
+    //  exclude group: 'com.beust', module: 'jcommander'
+    //  exclude group: 'org.jruby', module: 'jruby'
+    //}
+    //builder 'org.jruby:jruby:9.0.5.0'
+
     // NOTE jar for single-page builder is not available on s3, so much be built and installed locally
     singlePageBuilder 'com.mulesoft.documentation.builder.previewer:mule-docs-single-page-builder:1.0.0-SNAPSHOT'
+    //singlePageBuilder('com.mulesoft.documentation.builder.previewer:mule-docs-single-page-builder:1.0.0-SNAPSHOT') {
+    //  exclude group: 'org.asciidoctor', module: 'asciidoctorj-pdf'
+    //  exclude group: 'com.beust', module: 'jcommander'
+    //  exclude group: 'org.jruby', module: 'jruby'
+    //}
+    //singlePageBuilder 'org.jruby:jruby:9.0.5.0'
   }
 }
 
-import com.palominolabs.gradle.task.git.clone.GitCloneTask
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.lib.RepositoryBuilder
-
-apply plugin: 'css'
-
 group = 'com.mulesoft.documentation'
+
 ext {
+  assetsDir = '_assets'
+  assetsRepoBranchName = 'staging'
+  assetsRepoUri = 'https://github.com/mulesoft/mulesoft-docs-site-assets'
+  builderMaxHeapSize = '2g'
+  docsRepoBranchName = 'master'
+  docsRepoUri = 'https://github.com/mulesoft/mulesoft-docs'
+  profile = project.hasProperty('profile') ? project.property('profile') : 'dev'
+  profileBuildScript = "gradle/$profile-profile.gradle"
   siteDir = '_site'
+  siteUri = 'http://localhost:8000'
+  templatesDir = '_templates'
 }
 
+if (file(profileBuildScript).exists()) apply from: profileBuildScript
+apply plugin: 'css'
+
 task cloneAssetsRepo(type: GitCloneTask) {
-  dir = file('_assets')
-  enabled = !dir.exists()
-  uri = 'https://github.com/mulesoft/mulesoft-docs-site-assets'
-  def branchName = 'staging'
-  treeish = 'origin/' + branchName
+  dir = file(assetsDir)
+  onlyIf { !dir.exists() }
+  uri = assetsRepoUri
+  treeish = 'origin/' + assetsRepoBranchName
   trySshAgent = false
   doLast {
-    // checkout staging branch properly; should be fixed upstream (https://github.com/palominolabs/gradle-git-clone-task)
+    // checkout staging branch properly
+    // TODO should be fixed upstream (https://github.com/palominolabs/gradle-git-clone-task)
     def git = new Git(new RepositoryBuilder().readEnvironment().findGitDir(dir).build())
-    def create = !git.branchList().call().find { it.name.equals('refs/heads/' + branchName) }
-    git.checkout().setCreateBranch(create).setName(branchName).setStartPoint(treeish).call()
+    def create = !git.branchList().call().find { it.name == "refs/heads/$assetsRepoBranchName" }
+    git.checkout().setCreateBranch(create).setName(assetsRepoBranchName).setStartPoint(treeish).call()
   }
 }
 
@@ -57,42 +81,50 @@ task setup(group: 'Build', description: 'Prepares the build.') {
   dependsOn cloneAssetsRepo
 }
 
-task clean(type: Delete, group: 'Build', description: 'Deletes the site output directory.') {
-  delete siteDir
+task clean(type: Delete, group: 'Build', description: 'Deletes assets and site directories.') {
+  delete assetsDir, siteDir
 }
 
-// FIXME site builder should accept a custom templates directory
+// TODO site builder should accept a custom templates directory
 task copyTemplates(type: Copy) {
-  dependsOn setup
-  from '_assets/_templates'
-  into '_templates'
+  if (profile == 'dev') {
+    dependsOn setup
+  }
+  else {
+    enabled = false
+  }
+  from "$assetsDir/$templatesDir"
+  into templatesDir
 }
 
-task buildHtml(type: JavaExec, group: 'Build', description: 'Builds the HTML pages.') {
+task buildHtml(type: JavaExec, group: 'Build', description: 'Builds HTML pages.') {
   dependsOn copyTemplates
-  //mustRunAfter copyTemplates
+  mustRunAfter setup
   classpath = buildscript.configurations.builder
   main = 'com.mulesoft.documentation.builder.Client'
-  args = ['-s', '.', '-d', siteDir, '-ghr', 'https://github.com/mulesoft/mulesoft-docs', '-ghb', 'master', '-url', 'http://localhost:8000']
-  maxHeapSize = '2g'
+  args = ['-s', '.', '-d', siteDir, '-ghr', docsRepoUri, '-ghb', docsRepoBranchName, '-url', siteUri]
+  maxHeapSize = builderMaxHeapSize
   //outputs.dir siteDir
   doLast {
-    new Git(new RepositoryBuilder().readEnvironment().findGitDir(file('.')).build())
-      .checkout().addPath('_templates').call()
+    if (profile == 'dev') {
+      // NOTE undo changes to templates
+      new Git(new RepositoryBuilder().readEnvironment().findGitDir(file('.')).build())
+        .checkout().addPath(templatesDir).call()
+    }
   }
 }
 
-// pass file to build using -Dfile=path/to/file.adoc
-task buildSingleHtml(type: JavaExec, group: 'Build', description: 'Builds a single HTML page.') {
+// pass file to build using -Pfile=path/to/file.adoc
+task buildHtmlSingle(type: JavaExec, group: 'Build', description: 'Builds a single HTML page.') {
   classpath = buildscript.configurations.singlePageBuilder
   main = 'com.mulesoft.documentation.builder.previewer.Client'
-  args = ['-s', System.getProperty('file') || '', '-d', '_tmp']
+  args = ['-s', file(project.hasProperty('file') ? project.property('file') : 'index.adoc').absolutePath, '-d', '_tmp']
 }
 
 task copyAssets(type: Copy) {
   dependsOn setup
   mustRunAfter buildHtml
-  from('_assets') {
+  from(assetsDir) {
     exclude 'README.md'
     exclude '_*/**'
     //exclude 'css/*.less'
@@ -105,7 +137,7 @@ css {
   source {
     main {
       css {
-        srcDir '_assets/css'
+        srcDir "$assetsDir/css"
         include '*.css'
         include '*.less'
       }
@@ -125,16 +157,15 @@ lesscss {
 //
 //combineCss {
 //    source = cssSrc.collect {cssDir+it}
-//    dest = "${buildDir}/all.css"
+//    dest = "$buildDir/all.css"
 //}
 
-task build(group: 'Build', description: 'Builds the site.') {
-  //dependsOn setup, buildHtml, copyAssets, lesscss
-  dependsOn setup, buildHtml, copyAssets
+task build(group: 'Build', description: 'Builds site.') {
+  dependsOn setup, buildHtml, copyAssets //, lesscss
   mustRunAfter clean
 }
 
-task serve(type: JettyRun, group: 'Tools', description: 'Runs the site using a local preview server.') {
+task serve(type: JettyRun, group: 'Tools', description: 'Runs site in a local preview server.') {
   mustRunAfter build
   classpath = files()
   contextPath ''

--- a/gradle/ci-profile.gradle
+++ b/gradle/ci-profile.gradle
@@ -1,0 +1,51 @@
+apply plugin: 'org.ajoberstar.github-pages'
+
+ext {
+  assetsRepoBranchName = 'master'
+  builderMaxHeapSize = '6g'
+  publishMessage = project.hasProperty('buildTag') ? project.property('buildTag') : 'publish changes'
+  publishRepoBranchName = 'master'
+  publishRepoMirror = file('.gradle/build-output')
+  publishRepoUri = 'https://github.com/mulesoft/mulesoft-docs-build-output'
+  //publishRepoUri = 'git@github.com:mulesoft/mulesoft-docs-build-output.git'
+  publishWorkingDir = '.gradle/build-output-work'
+  siteUri = 'https://docs.mulesoft.com'
+}
+
+githubPages {
+  repoUri = publishRepoMirror.path
+  targetBranch = publishRepoBranchName
+  commitMessage = publishMessage
+  workingPath = publishWorkingDir
+  pages { from siteDir }
+}
+
+prepareGhPages {
+  mustRunAfter 'build'
+  doFirst {
+    // TODO verify this is a valid clone
+    if (publishRepoMirror.directory) {
+      exec {
+        workingDir publishRepoMirror
+        executable 'git'
+        args 'fetch', '-q', 'origin'
+      }
+      exec {
+        workingDir publishRepoMirror
+        executable 'git'
+        args 'reset', '-q', '--soft', 'FETCH_HEAD'
+      }
+    }
+    else {
+      exec {
+        workingDir publishRepoMirror.parentFile
+        executable 'git'
+        args 'clone', '-q', '--bare', '--single-branch', publishRepoUri, publishRepoMirror.name
+      }
+    }
+  }
+}
+
+task publish(group: 'Build', description: 'Builds site and commits changes to publish repository.') {
+  dependsOn 'build', publishGhPages
+}


### PR DESCRIPTION
- add profile for using Gradle build in CI (-Pprofile=ci)
- load build script per profile
- configure GitHub Pages plugin keep clone between runs
- move all settings into extended project properties
- check for existing assets clone dynamically using an onlyIf block
- don't copy template except when dev profile is active
- revert template after running docs builder when dev profile is active
- fix file property lookup when using single page builder
- update task descriptions