### PR TITLE
Removing Java 6 warning

### DIFF
--- a/mule-management-console/v/3.8/persisting-mmc-data-to-ms-sql-server.adoc
+++ b/mule-management-console/v/3.8/persisting-mmc-data-to-ms-sql-server.adoc
@@ -16,12 +16,6 @@ This document assumes that you have installed:
 
 For practical purposes, this document mentions Tomcat as the servlet container; however, the instructions contained here apply also to Tcat or JBoss. If using Tcat or JBoss, make sure to unpack the Management Console .war file in the appropriate directory. For additional information, see link:/mule-management-console/v/3.8/installing-the-production-version-of-mmc[Installing the Production Version of MMC].
 
-[WARNING]
-====
-*Known Issue with MS SQL and Java 6, Update 29*
-
-There is a http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7105007[known issue] with Java 6, Update 29, regarding an SSL configuration which causes connection attempts to the database to hang indefinetely, with no timeout, thus preventing MMC startup. MS SQL cannot be used with this Java version. Please upgrade to a later JVM.
-====
 
 == Prerequisites
 


### PR DESCRIPTION
Not needed, only Java 7&8 is supported.