### PR TITLE
Repaired wrong URLs

### DIFF
--- a/tcat-server/v/7.1.0/installing-tcat-server-on-solaris.adoc
+++ b/tcat-server/v/7.1.0/installing-tcat-server-on-solaris.adoc
@@ -4,11 +4,11 @@ This document describes how to install MuleSoft Tcat Server on the Solaris opera
 
 For additional information and to install Tcat Server on other operating systems, see:
 
-* link:tcat-server/v/7.1.0/overview-of-tcat-server[Overview to learn more about the MuleSoft Tcat Server]
-* link:tcat-server/v/7.1.0/release-notes[Release Notes for the latest new features]
+* link:/tcat-server/v/7.1.0/overview-of-tcat-server[Overview to learn more about the MuleSoft Tcat Server]
+* link:/tcat-server/v/7.1.0/release-notes[Release Notes for the latest new features]
 * link:/tcat-server/v/7.1.0/installing-tcat-server-on-linux[Linux]
-* link:/tcat-server/v/7.1.0/installing-tcat-server-on-macosx[Mac OS X]
-* link:/tcat-server/v/7.1.0/installing-tcat-server-on-windows[Microsoft Windows]
+* link:/tcat-server/v/7.1.0/installing-tcat-server-on-mac-osx[Mac OS X]
+* link:/tcat-server/v/7.1.0/installing-tcat-server-on-microsoft-windows[Microsoft Windows]
 
 Send comments or questions to: mailto:tcat-install@mulesoft.com[tcat-install]
 
@@ -17,8 +17,8 @@ Send comments or questions to: mailto:tcat-install@mulesoft.com[tcat-install]
 Tcat Server is supported on all Solaris operating systems that have a supported Java runtime. Server restarts are supported on Solaris 10 and 11.
 
 For additional operating systems supported, see installation documentation on:  link:/tcat-server/v/7.1.0/installing-tcat-server-on-linux[Linux],
-link:/tcat-server/v/7.1.0/installing-tcat-server-on-macosx[Mac OS X], and
-link:/tcat-server/v/7.1.0/installing-tcat-server-on-windows[Microsoft Windows].
+link:/tcat-server/v/7.1.0/installing-tcat-server-on-mac-osx[Mac OS X], and
+link:/tcat-server/v/7.1.0/installing-tcat-server-on-microsoft-windows[Microsoft Windows].
 
 == Required Software
 


### PR DESCRIPTION
Some URLs is wrong in sections _"Installing Tcat Server on Solaris"_ and _"Solaris Operating Systems Supported"_.