### PR TITLE
Repaired URL "Configure Twitter for API Access"

### DIFF
--- a/anypoint-connector-devkit/v/3.8/setting-up-api-access.adoc
+++ b/anypoint-connector-devkit/v/3.8/setting-up-api-access.adoc
@@ -43,7 +43,7 @@ Twitter is a good example of a relatively simple API to access from a connector 
 ** Access secret
 ** Consumer key
 ** Consumer secret
-. For detailed instructions on creating an application on the Twitter platform, see link:/runtime-manager/configure-twitter-for-api-access[Configure Twitter for API Access].
+. For detailed instructions on creating an application on the Twitter platform, see link:/mule-fundamentals/v/3.8/anypoint-connector-tutorial#obtaining-access-to-the-twitter-api[Configure Twitter for API Access].
 
 == SOAP-Based APIs
 


### PR DESCRIPTION
For file "setting-up-api-access.adoc" in the section #twitter-example is wrong ULR "Configure Twitter for API Access" (https://docs.mulesoft.com/runtime-manager/configure-twitter-for-api-access) . When click the link so it return status HTTP 404.
I think that correctly URL can be "https://docs.mulesoft.com/mule-fundamentals/v/3.8/anypoint-connector-tutorial#obtaining-access-to-the-twitter-api".