### PR TITLE
fix broken formatting that was hiding text

### DIFF
--- a/mule-user-guide/v/3.8/http-request-connector.adoc
+++ b/mule-user-guide/v/3.8/http-request-connector.adoc
@@ -785,7 +785,7 @@ This sends a GET request to link:http://www.example.com/test[www.example.com/tes
 
 == Configuring Source and Target
 
-By default, the body of your request is taken from the`#[payload]` of the incoming Mule message and the response is sent onwards as the `\#[payload]` of the output Mule message, you can change this default behavior through the `source` and `target` attributes.
+By default, the body of your request is taken from the `\#[payload]` of the incoming Mule message and the response is sent onwards as the `#[payload]` of the output Mule message, you can change this default behavior through the `source` and `target` attributes.
 
 [tabs]
 ------


### PR DESCRIPTION
Something crazy happening with the formatting/wiki markup, but this displays the currently hidden info at least.