### PR TITLE
Bad bookmark anchor for the Precedence Table

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
+++ b/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
@@ -534,7 +534,7 @@ otherwise
 
 
 [TIP]
-Check the <<Operator Precedence Table>> to see what expressions are compiled before or after this one.
+Check the <<Precedence Table>> to see what expressions are compiled before or after this one.
 
 ==== Unless Otherwise
 
@@ -556,7 +556,7 @@ otherwise
 ----
 
 [TIP]
-Check the <<Operator Precedence Table>> to see what expressions are compiled before or after this one.
+Check the <<Precedence Table>> to see what expressions are compiled before or after this one.
 
 ==== Default
 


### PR DESCRIPTION
This just corrects two links in the DW to the Precedence Table. I think "Operator Precedence Table" makes more sense as a link, but these were the only two instances that used that name, so I changed them to use "Precedence Table"