### PR TITLE
Update mule-expression-language-date-and-time-functions.adoc

### DIFF
--- a/mule-user-guide/v/3.8/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.8/mule-expression-language-date-and-time-functions.adoc
@@ -270,7 +270,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]`
 ==========================
 
 |`DateTime(calendar)` a|
-Constructs a DateTime with the calendar specified and the locale of the server.  
+Constructs a DateTime with the calendar specified and the locale of the server.
 [cols="20%,80%",options="header"]
 !===
 !Argument !Type
@@ -312,12 +312,12 @@ Construct a DateTime using the specified link:http://en.wikipedia.org/wiki/ISO_8
 ==========================
 
 |`DateTime(String dateString, String format)` a|
-Constructs a DateTime used a string containing a date time in the specified format. The format should be link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
+Constructs a DateTime using a string containing a date time in the specified format. The format should be link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
 [cols="20%,80%",options="header"]
 !===
 !Argument !Type
 !dateString !java.lang.String
-!string !java.lang.String
+!format !java.lang.String
 !===
 
 [CAUTION]
@@ -329,7 +329,7 @@ Throws exception: [red]#ParseException#
 *Example*: +
 ==========================
 `#[dateString = new Date().toString();
- 
+
 payload = new org.mule.el.datetime.DateTime(dateString, 'EEE MMM dd HH:mm:ss zzz yyyy');]`
 ==========================
 


### PR DESCRIPTION
Corrected the name given in the documentation to match the name given for an argument to the DateTime contructor.
Fixed a grammatical typo.
Removed some extraneous whitespace.