### PR TITLE
Removing "Alerts" section as it's duplicated from its own page

### DIFF
--- a/runtime-manager/v/latest/managing-servers.adoc
+++ b/runtime-manager/v/latest/managing-servers.adoc
@@ -459,16 +459,6 @@ One advantage of using multicast is that a server does not need to be running to
 [NOTE]
 Check with your network administrator if multicast is allowed within your network, as many networks block multicast functionalities.
 
-== Alerts
-
-You can set up email alerts that are sent whenever certain events occur to your servers, such as a server being disconnected, or a server being removed from a cluster. These alerts may be linked to a specific server or to all of them. See  link:/runtime-manager/alerts-on-runtime-manager[Alerts] for instructions on how to do this.
-
-All users of the Anypoint Platform, even those without permissions to create alerts, can then switch the alerts that are already created into an active or inactive state for their user. This determines what email alerts will reach their inbox.
-
-
-[NOTE]
-Switching an alert off from this view only switches it off for the user that is currently logged in, other users may still have it active.
-
 == See Also
 
 * Learn how to first link:/runtime-manager/deploying-to-your-own-servers[Deploy Applications to your Own Servers]


### PR DESCRIPTION
There is no need for this to be in this particular site.