### PR TITLE
Removed spacing which caused exceptions for 3.8.0

### DIFF
--- a/mule-user-guide/v/3.6/http-request-connector.adoc
+++ b/mule-user-guide/v/3.6/http-request-connector.adoc
@@ -656,7 +656,7 @@ To set a list of status codes accepted as success responses, do the following:
 
 . Select the *advanced tab* of the HTTP Request Connector
 . Select the *Success Status Code Validator* radio button
-. Fill in the *Values* field below with `200, 201`
+. Fill in the *Values* field below with `200,201`
 
 ....
 [tab,title="XML Editor"]
@@ -673,7 +673,7 @@ For example:
     ...
 
     <http:request request-config="HTTP_Request_Configuration"  path="/" method="GET">
-         <http:success-status-code-validator values="200, 201"/>
+         <http:success-status-code-validator values="200,201"/>
     </http:request>
 </flow>
 ----
@@ -698,7 +698,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
     <flow name="test_flow">
         <http:listener config-ref="HTTP_Listener_Configuration" path="/" doc:name="HTTP"/>
         <http:request request-config="HTTP_Request_Configuration"  path="/" method="GET">
-            <http:success-status-code-validator values="200, 201"/>
+            <http:success-status-code-validator values="200,201"/>
         </http:request>
 </flow>
 

--- a/mule-user-guide/v/3.7/http-request-connector.adoc
+++ b/mule-user-guide/v/3.7/http-request-connector.adoc
@@ -636,7 +636,7 @@ To set a list of status codes accepted as success responses, do the following:
 ....
 . Select the *advanced tab* of the HTTP Request Connector
 . Select the *Success Status Code Validator* radio button
-. Fill in the *Values* field below with `200, 201`
+. Fill in the *Values* field below with `200,201`
 ....
 [tab,title="XML Editor"]
 ....
@@ -650,7 +650,7 @@ For example:
     ...
  
     <http:request config-ref="HTTP_Request_Configuration"  path="/" method="GET"> 
-         <http:success-status-code-validator values="200, 201"/>
+         <http:success-status-code-validator values="200,201"/>
     </http:request>
 </flow>
 ----
@@ -674,7 +674,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
     <flow name="test_flow">
         <http:listener config-ref="HTTP_Listener_Configuration" path="/" doc:name="HTTP"/>
         <http:request config-ref="HTTP_Request_Configuration"  path="/" method="GET"> 
-            <http:success-status-code-validator values="200, 201"/>
+            <http:success-status-code-validator values="200,201"/>
         </http:request>
 </flow>
  

--- a/mule-user-guide/v/3.8/http-request-connector.adoc
+++ b/mule-user-guide/v/3.8/http-request-connector.adoc
@@ -650,7 +650,7 @@ To set a list of status codes accepted as successful responses, do the following
 
 . Select the *advanced tab* of the HTTP Request Connector
 . Select the *Success Status Code Validator* radio button
-. Fill in the *Values* field below with `200, 201`
+. Fill in the *Values* field below with `200,201`
 ....
 [tab,title="XML Editor"]
 ....
@@ -664,7 +664,7 @@ For example:
     ...
  
     <http:request config-ref="HTTP_Request_Configuration"  path="/" method="GET"> 
-         <http:success-status-code-validator values="200, 201"/>
+         <http:success-status-code-validator values="200,201"/>
     </http:request>
 </flow>
 ----
@@ -688,7 +688,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
     <flow name="test_flow">
         <http:listener config-ref="HTTP_Listener_Configuration" path="/" doc:name="HTTP"/>
         <http:request config-ref="HTTP_Request_Configuration"  path="/" method="GET">
-            <http:success-status-code-validator values="200, 201"/>
+            <http:success-status-code-validator values="200,201"/>
         </http:request>
 </flow>
  


### PR DESCRIPTION
In using http:success-code-validator I used the format as mentioned in the docs: "200, 404" and I received an error of: Caused by: java.lang.NumberFormatException: For input string: " 404"

So this PR changes the docs to use the format: "200,404" (not the space has been removed).

I'm not sure if this is wrong in the docs, or wrong in the code.