### PR TITLE
Clarification around workday as a dependency

### DIFF
--- a/mule-user-guide/v/3.8/workday-connector.adoc
+++ b/mule-user-guide/v/3.8/workday-connector.adoc
@@ -53,16 +53,14 @@ link:/mule-fundamentals/v/3.8/anypoint-exchange#installing-a-connector-from-anyp
 . Install the Workday connector as described in the previous section.
 . Make sure you have updated the Maven dependencies correctly:
 +
-[width="100a",cols="34a,33a,33a",options="header",]
-|===
-|Connector Version |From |To
-|Version until 4.0.1 |`<groupId>org.mule.modules</groupId>` +
-`<artifactId>mule-module-workday</artifactId>` |`<groupId>org.mule.modules</groupId>` +
-`<artifactId>workday-connector</artifactId>`
-|Versions 4.0.1 to 6.0 or above |`<groupId>org.mule.modules</groupId>` +
-`<artifactId>mule-module-workday-<wd_module_name></artifactId>` |`<groupId>org.mule.modules</groupId>` +
-`<artifactId>workday-connector</artifactId>`
-|===
+[source, xml, linenums]
+----
+<dependency>
+    <groupId>org.mule.modules</groupId>
+    <artifactId>workday-connector</artifactId>
+    <version>8.0.0</version>
+</dependency>
+----
 +
 . It is important to update the flows to: +
 .. Update the existing data mappings


### PR DESCRIPTION
When I was reading https://docs.mulesoft.com/mule-user-guide/v/3.8/workday-connector I was pretty confused on the "Upgrading from an Older Version" table. First I thought there were two different paths to upgrading, depending upon what you are using now. Then the artifact element used angle brackets as well to denote, what I think, a square bracket should be used for.

So I just removed both entries as the outcome is the same, just listed out the current way to denote WD as a dependency.

The only thing I could think of is calling out that there are no longer any WD modules.