### PR TITLE
Update using-dataweave-in-studio.adoc

### DIFF
--- a/mule-user-guide/v/3.8/using-dataweave-in-studio.adoc
+++ b/mule-user-guide/v/3.8/using-dataweave-in-studio.adoc
@@ -177,8 +177,7 @@ You can also set this via the XML editor. To define an input payload type, use t
 [source,xml, linenums]
 ----
 <dw:transform-message doc:name="Transform Message">
-	<dw:input-payload mimeType="application/xml" />
-  <dw:input-payload doc:sample="sample_data/content.xml"/>
+	<dw:input-payload mimeType="application/xml" doc:sample="sample_data/content.xml"/>
 	<dw:set-payload>
 	<![CDATA[%dw 1.0
 	%output application/java
@@ -473,19 +472,18 @@ Below is a full Transform Message component described via XML
 [source,xml,linenums]
 ----
 <dw:transform-message doc:name="Transform Message" mode="immediate">
-        <dw:input-payload mimeType="text/csv">
-					<dw:reader-property name="separator" value="|"/>
-					<dw:reader-property name="header" value="false"/>
-				</dw:input-payload>
-  <dw:input-payload doc:sample="sample_data/content.csv"/>
+        <dw:input-payload mimeType="text/csv" doc:sample="sample_data/content.csv">
+		<dw:reader-property name="separator" value="|"/>
+		<dw:reader-property name="header" value="false"/>
+	</dw:input-payload>
         <dw:set-variable variableName="myVariable">
         	<![CDATA[
-							%dw 1.0
-        			%output application/json
-        			---
-        			payload
+			%dw 1.0
+        		%output application/json
+        		---
+        		payload
         	]]>
-			</dw:set-variable >
+	</dw:set-variable >
 </dw:transform-message>
 ----
 


### PR DESCRIPTION
The <dw:input-payload> element may only appear once within an enclosing <dw:transform-message> element; it may not be repeated.

Cleaned up some whitespace indents.