### PR TITLE
Include tip for the FTP configuration

### DIFF
--- a/munit/v/1.2.0/munit-ftp-server.adoc
+++ b/munit/v/1.2.0/munit-ftp-server.adoc
@@ -81,6 +81,7 @@ host=localhost/
 
 --
 
+TIP: You must set an user and a password for the FTP configuration. For this example, any credentials will work.
 
 === Defining the FTP Server
 


### PR DESCRIPTION
The image suggests that no user nor password should be set up. However, it is mandatory to set up the credentials in order use the FTP endpoint connector.