### PR TITLE
Fixed broken using-munit-in-anypoint-studio link

### DIFF
--- a/munit/v/1.2.0/index.adoc
+++ b/munit/v/1.2.0/index.adoc
@@ -74,7 +74,7 @@ For an overview of MUnit in Anypoint Studio, see link:/munit/v/1.2.0/using-munit
 
 The pages listed below provide an overview of MUnit features including simple examples. Topics include the MUnit message processors, the DB and FTP servers provided by MUnit, Maven support and more. For a short step-by-step guide to creating a test, see the link:/munit/v/1.2.0/munit-short-tutorial[MUnit Tutorial].
 
-TIP: The examples in these pages are XML-only; however, as stated <<studio,above>>, you can also use MUnit via Anypoint Studio's graphical interface. See link:/munit/v/1.1.0/using-munit-in-anypoint-studio[Using MUnit in Anypoint Studio] for details.
+TIP: The examples in these pages are XML-only; however, as stated <<studio,above>>, you can also use MUnit via Anypoint Studio's graphical interface. See link:/munit/v/1.2.0/using-munit-in-anypoint-studio[Using MUnit in Anypoint Studio] for details.
 
 * link:/munit/v/1.2.0/using-munit-in-anypoint-studio[Using MUnit in Anypoint Studio]
 * link:/munit/v/1.2.0/munit-suite[MUnit Suite]


### PR DESCRIPTION
It was pointing to 1.1.0 resulting in 404 error.