### PR TITLE
Fixed typo in Mule Domain Support Documentation

### DIFF
--- a/munit/v/1.2.0/munit-domain-support.adoc
+++ b/munit/v/1.2.0/munit-domain-support.adoc
@@ -19,7 +19,7 @@ MUnit support for domain based applications is designed to require the minimum c
 
 [WARNING]
 --
-Rregardless if your application is Maven based or not, when working in Anypoint Studio your Mule Domain must *always* be part of your workspace.
+Regardless if your application is Maven based or not, when working in Anypoint Studio your Mule Domain must *always* be part of your workspace.
 --
 
 === Testing Non Mavenized Domain Based Applications


### PR DESCRIPTION
Rregardless > Regardless