### PR TITLE
CORS and mixed content warning issues should be addressed properly.

### DIFF
--- a/api-manager/v/latest/accessing-your-api-behind-a-firewall.adoc
+++ b/api-manager/v/latest/accessing-your-api-behind-a-firewall.adoc
@@ -1,57 +1,75 @@
 = Accessing an API Behind a Firewall
 :keywords: firewall, mixed content, cors, proxy, same-origin, anypoint, api console, api designer, api notebook
 
-Using the following Anypoint Platform browser tools routes calls to your API through a server-side proxy by default:
+The following Anypoint Platform browser tools route calls to your API through a server-side proxy by default:
 
 * API Console
 * API Designer
 * API Notebook
 
-These tools use the proxy to avoid the link:https://en.wikipedia.org/wiki/Same-origin_policy[same-origin] restrictions in browsers. When a browser makes an HTTP request to a domain and that domain returns a page, that page is the _origin domain_. Any scripts running in that page are allowed to make additional requests back to the origin domain only. If a script attempts to make a request to a different domain, the response is normally blocked to prevent the script from gaining access to other sites you visited.
+This _reverse proxy_ allows your browser to get the resources from your API and from the Anypoint Platform browser tools without having to worry about the link:https://en.wikipedia.org/wiki/Same-origin_policy[same-origin restriction policy]. +
+When a browser makes an HTTP request to a domain and that domain returns a page, that page is the _origin domain_. Any scripts running in that page are allowed to make additional requests back to the origin domain only. If a script attempts to make a request to, or load resources from a different domain, the response is normally blocked to prevent the script from gaining access to other sites you visited.
 
-If your API is located behind a firewall that prevents inbound requests, the API is unreachable. You won't be able to use API Console, API Designer, or API Notebook unless you use one of the following ways to avoid same-origin restriction:
+If your API is located behind a firewall that prevents inbound requests, the API is unreachable. You won't be able to use API Console, API Designer, or API Notebook unless you properly <<Use CORS, set up CORS>> (Cross-Origin Resource Sharing) to allow users and/or client requests to access the tools whose resources are located outside your origin domain.
 
-* link:/api-manager/accessing-your-api-behind-a-firewall#disable-same-origin-restrictions-in-your-browser[Disable same-origin restrictions] in your browser.
+Alternatively, for *testing purposes*, you can use one of the following ways to avoid same-origin restriction:
+
 * link:/api-manager/accessing-your-api-behind-a-firewall#bypass-the-proxy[Bypass the proxy].
-* link:/api-manager/accessing-your-api-behind-a-firewall#use-cors[Use CORS].
+* link:/api-manager/accessing-your-api-behind-a-firewall#disable-same-origin-restrictions-in-your-browser[Disable same-origin restrictions] in your browser.
 
 Also, consider link:/api-manager/accessing-your-api-behind-a-firewall#disabling-mixed-content-blocking[disabling mixed content blocking].
 
-== Disable Same-Origin Restrictions in your Browser
+
+[WARNING]
+--
+Releasing an API to production without properly addressing a security model to handle cross-origin resources can potentially enable dangerous Cross-Site Request Forgery (CSRF) attacks, among other threats that can harm clients and users accessing your resources.
+--
+
+== Use CORS
+
+If you link:/api-manager/setting-up-an-api-proxy[Set up an API proxy], you need to link:/api-manager/building-an-external-oauth-2.0-provider-application#implementing-cors[Implement] and link:/api-manager/cors-policy[apply a CORS Policy] for your browser to be able to load the resources in the API behind your firewall and the Anypoint Platform´s browser tools.
+
+== Alternative Methods
+
+If you are testing your implementations in a local, or test environment, you can apply any of the methods described below to be able to access the online browser tools provided by Anypoint Platform.
+
+Keep in mind that you should not release an API using the methods described below.
+
+=== Disable Same-Origin Restrictions in your Browser
 
 If you can't implement CORS for your API, another possible solution to an unreachable API is to disable the same-origin restrictions in your browser. Each browser handles these restrictions in a unique way; for example, after launching Google Chrome from the command line to disable the same-origin restrictions and then closing Chrome, your next Chrome session automatically re-enables the restrictions. Internet Explorer's settings persists across application sessions, so you need to change your Internet Options manually. Mozilla Firefox doesn't currently support a way to disable same-origin restrictions without using a custom build of the browser.
 
 Make sure you understand the potential security implications of changing your browser's security settings. You should only use these options for testing on your own web pages because your browser can become vulnerable to malicious scripts and other potential threats. 
 
-==== Google Chrome for Mac OS X
+===== Google Chrome for Mac OS X
 
 * Open a new Terminal window, paste the following line, and then press *Enter*: `open -a Google\ Chrome --args --disable-web-security`.
 
-==== Google Chrome for Windows
+===== Google Chrome for Windows
 
 * Open a new Command Prompt window, navigate to the location of the Chrome executable (Chrome.exe), paste the following line, and then press *Enter*: `chrome.exe --disable-web-security`.
 
-==== Mozilla Firefox
+===== Mozilla Firefox
 
 You can't disable the same-origin restrictions in Firefox without using a custom build of the browser's source code.
 
-==== Internet Explorer
+===== Internet Explorer
 
 . Open *Internet Properties*, click the *Security* tab, and then click the *Custom level* button in the *Security level for this zone* section.
 . A *Security Settings* dialog appears. Scroll down the list of security settings and locate the *Miscellaneous* section, and select *Enable* for the *Access data sources across domains* setting.
 . Click *Apply*.
 
-== Bypass the Proxy
+=== Bypass the Proxy
 
 If you use the Anypoint Platform tools in an environment that blocks inbound requests using a firewall, bypass the proxy as described in this section.
 
-=== Bypassing the Proxy for the API Console and API Designer
+==== Bypassing the Proxy for the API Console and API Designer
 
 Go to the API Designer for your API. On the right pane, check that the API is behind a firewall, which bypasses the proxy.
 
 image::accessing-your-api-behind-a-firewall-e7a50.png[accessing-your-api-behind-a-firewall-e7a50]
 
-=== Bypassing the Proxy for the API Notebook
+==== Bypassing the Proxy for the API Notebook
 
 Go to the API Notebook for your API. In the initial code cell that creates a client, create a new code cell with the following code to set a new proxy configuration on the client:
 
@@ -67,14 +85,7 @@ Combining these two lines together, the following example creates a new client a
 
 *`API.set(myClient, 'proxy', false);`*
 
-== Use CORS
-
-After you bypass a proxy, you still might not be able to use API Console, API Designer, or API Notebook because of same-origin browser restrictions.
-
-* link:/api-manager/building-an-external-oauth-2.0-provider-application#implementing-cors[Implement a CORS policy].
-* link:/api-manager/setting-up-an-api-proxy[Set up an API proxy] and link:/api-manager/cors-policy[apply a CORS Policy].
-
-== Disabling Mixed Content Blocking
+=== Disabling Mixed Content Blocking
 
 When an HTTPS web page retrieves resources from an unsecured HTTP endpoint, the resulting blend of secure and unsecure content is called "mixed content." Browsers block such mixed content and display an error because of the security implications. For example, mixed content introduces the possibility that a man-in-the-middle attacker could have injected malicious site resources (such as scripts) during the request and response. You may encounter this issue when using the API Manager, and it's important to understand how you can mitigate it.
 
@@ -82,7 +93,7 @@ The API Manager browser tools (API Console, API Designer, and API Notebook) are 
 
 If you've disabled the platform's server-side proxy, any requests to your API are no longer routed through this proxy and are instead made directly to it. This situation isn't a problem if your API resides at an HTTPS endpoint, because all communication between the browser and the requested resources is encrypted using SSL. However, if your API has an HTTP endpoint, the API Manager browser tools makes requests to the unsecured HTTP endpoint and your browser blocks the resulting "mixed content" -- a mix of the browser tool's HTTPS (secured) content and your API's HTTP (unsecured) content.
 
-==== Disabling Mixed Content Blocking in your Browser
+===== Disabling Mixed Content Blocking in your Browser
 
 Each browser presents mixed content errors in slightly different ways, as described in the following support pages.
 
@@ -91,6 +102,9 @@ Each browser presents mixed content errors in slightly different ways, as descri
 *  link:https://support.mozilla.org/en-US/kb/how-does-content-isnt-secure-affect-my-safety[Mixed content blocking in Firefox]
 
 * Microsoft's link:http://support.microsoft.com/kb/2625928[“Only secure content is displayed” notification in Internet Explorer 9 or later]
+
+
+
 
 
 == See Also

--- a/api-manager/v/latest/accessing-your-api-behind-a-firewall.adoc
+++ b/api-manager/v/latest/accessing-your-api-behind-a-firewall.adoc
@@ -1,13 +1,14 @@
 = Accessing an API Behind a Firewall
 :keywords: firewall, mixed content, cors, proxy, same-origin, anypoint, api console, api designer, api notebook
 
-The following Anypoint Platform browser tools route calls to your API through a server-side proxy by default:
+The following Anypoint Platform browser tools route calls to your API through a _reverse proxy_ by default:
 
 * API Console
 * API Designer
 * API Notebook
 
-This _reverse proxy_ allows your browser to get the resources from your API and from the Anypoint Platform browser tools without having to worry about the link:https://en.wikipedia.org/wiki/Same-origin_policy[same-origin restriction policy]. +
+The browser can then get resources from your API and Anypoint Platform browser tools undeterred by the link:https://en.wikipedia.org/wiki/Same-origin_policy[same-origin restriction policy].
+
 When a browser makes an HTTP request to a domain and that domain returns a page, that page is the _origin domain_. Any scripts running in that page are allowed to make additional requests back to the origin domain only. If a script attempts to make a request to, or load resources from a different domain, the response is normally blocked to prevent the script from gaining access to other sites you visited.
 
 If your API is located behind a firewall that prevents inbound requests, the API is unreachable. You won't be able to use API Console, API Designer, or API Notebook unless you properly <<Use CORS, set up CORS>> (Cross-Origin Resource Sharing) to allow users and/or client requests to access the tools whose resources are located outside your origin domain.


### PR DESCRIPTION
When accessing an API behind a firewall, the CORS settings need to be well configured. 
We should not recommend users to disable their browser´s security settings unless they are using a controlled environment, and such practice should be used only for testing (never for production).