### PR TITLE
Change Mule ESB Server to Mule runtime

### DIFF
--- a/mule-management-console/v/3.8/setting-up-mmc-mule-esb-communications.adoc
+++ b/mule-management-console/v/3.8/setting-up-mmc-mule-esb-communications.adoc
@@ -1,9 +1,9 @@
-= Setting Up MMC-Mule ESB Communications
+= Setting Up MMC-Mule Runtime Communications
 
 This page covers:
 
-* How to register or unregister a Mule ESB server in MMC
-* How to configure communication settings between Mule ESB server and MMC
+* How to register or unregister a Mule runtime server in MMC
+* How to configure communication settings between Mule runtime server and MMC
 
 *Contents:*
 
@@ -13,23 +13,23 @@ This document assumes that you are familiar with the basic link:/mule-managemen
 
 == MMC-Server Communications
 
-The Mule Management Console is a Web application that you can use to monitor and manage one or more Mule ESB servers, clusters, and applications. The Management Console communicates with Mule ESB servers via the MMC agent installed in each Mule ESB server. In order for communication between MMC and a Mule ESB server to take place, you need to register the server in the Management Console.
+The Mule Management Console is a Web application that you can use to monitor and manage one or more Mule runtimes (formerly called Mule ESB Servers), clusters, and applications. The Management Console communicates with Mule runtime servers via the MMC agent installed in each Mule runtime server. In order for communication between MMC and a Mule runtime server to take place, you need to register the server in the Management Console.
 
-Communication between MMC and a Mule ESB server begins over HTTP, but after the initial handshake and authentication, the HTTP connection is dropped and a new HTTPS connection is opened.
+Communication between MMC and a Mule runtime server begins over HTTP, but after the initial handshake and authentication, the HTTP connection is dropped and a new HTTPS connection is opened.
 
 The files `tls-default.conf` and `tls-fips140-2.conf` included in the conf folder of the Mule allow you to fine-tune the protocols that can be used to set up the HTTPS connection.
 
-== Registering Mule ESB Servers with MMC
+== Registering Mule Runtimes with MMC
 
-Each Mule ESB server can only be registered with one MMC, but each MMC can manage an unlimited number of Mule ESB servers.
+Each Mule runtime can only be registered with one MMC, but each MMC can manage an unlimited number of Mule runtimes.
 
-The link:/mule-management-console/v/3.8/installing-the-trial-version-of-mmc[trial version] of Mule ESB Enterprise contains a bundled MMC. In the trial version, the Mule ESB server is automatically registered to the bundled MMC. However, if you wish to register more Mule ESB servers to the bundled MMC, you will have to do so manually.
+The link:/mule-management-console/v/3.8/installing-the-trial-version-of-mmc[trial version] of Mule Enterprise Console contains a bundled MMC and a Mule Enterprise Edition runtime. In the trial version, the Mule Enterprise Edition runtime is automatically registered to the bundled MMC. However, if you wish to register more Mule runtimes with the bundled MMC, you will have to do so manually.
 
-When you run the link:/mule-management-console/v/3.8/installing-the-production-version-of-mmc[production version] of MMC for the first time, it will attempt to detect any Mule ESB servers on the network, but will not try to pair with any server it finds. You must manually register your Mule ESB server.
+When you run the link:/mule-management-console/v/3.8/installing-the-production-version-of-mmc[production version] of MMC for the first time, it will attempt to detect any Mule runtimes on the network, but will not try to pair with any server it finds. You must manually register your Mule runtime.
 
-To pair the MMC with a Mule instance, you provide MMC with the URL of the Mule agent listening on the the Mule ESB server. The default port is 7777, and the path is `mmc-support`. So, if you wish to register a Mule ESB server on host 16.172.1.25, the URL would be `http://16.172.1.25:7777/mmc-support`. When you provide this URL to MMC, the Management Console will attempt to pair with the Mule agent in the specified URL, then report success or failure.
+To pair the MMC with a Mule instance, you provide MMC with the URL of the Mule agent listening on the the Mule runtime. The default port is 7777, and the path is `mmc-support`. So, if you wish to register a Mule runtime on host 16.172.1.25, the URL would be `http://16.172.1.25:7777/mmc-support`. When you provide this URL to MMC, the Management Console will attempt to pair with the Mule agent in the specified URL, then report success or failure.
 
-To register a Mule ESB server to MMC, follow these steps:
+To register a Mule runtime with MMC, follow these steps:
 
 . Go to the *Servers* tab.
 . In the left-hand pane is a list of servers divided by groups. If MMC has found any active servers, it will indicate the number of servers found in the *Unregistered* heading, as shown below.
@@ -51,11 +51,11 @@ After you have registered your servers, click *All* in the left servers group p
 
 image:reg_servers_list.png[reg_servers_list]
 
-== Registering a Mule ESB Server to a New MMC
+== Registering a Mule runtime Server to a New MMC
 
-Each Mule ESB server can only be registered to one MMC at a time. If you want to register a Mule ESB server to a new MMC, you must first unregister it in the MMC that the server is currently registered with. You can do this either in the MMC itself or on the server's configuration files. Both methods are explained below.
+Each Mule runtime server can only be registered to one MMC at a time. If you want to register a Mule runtime server to a new MMC, you must first unregister it in the MMC that the server is currently registered with. You can do this either in the MMC itself or on the server's configuration files. Both methods are explained below.
 
-=== Unregistering a Mule ESB Server
+=== Unregistering a Mule Runtime
 
 [NOTE]
 ====
@@ -74,19 +74,19 @@ The server has been unregistered; you can now register it in another Management 
 
 It is possible that you are not able to unregister a Mule server via the MMC, for example if the MMC has been undeployed and is no longer available. In this case, follow the steps below.
 
-. Ensure that the ESB server is not running.
-. Go to the directory `$MULE_HOME/.mule/.agent`. This directory contains Mule ESB server-MMC pairing information.
+. Ensure that the runtime is not running.
+. Go to the directory `$MULE_HOME/.mule/.agent`. This directory contains Mule runtime-MMC pairing information.
 . Find and delete the file `truststore.jks`.
 
-After you delete the file, you can register the Mule ESB server to any instance of MMC, following the steps outlined <<Registering Mule ESB Servers with MMC>>. When you register the server, a new `truststore.jks` will be created.
+After you delete the file, you can register the Mule runtime server to any instance of MMC, following the steps outlined <<Registering Mule runtime with MMC>>. When you register the server, a new `truststore.jks` will be created.
 
-== Changing the Default ESB Agent Port
+== Changing the Default runtime Agent Port
 
-A Mule ESB server communicates with MMC using its embedded agent. By default, the agent is enabled and listening on port 7777. You can change the port with the `-Dmule.mmc.bind.port` parameter for the Java Virtual Machine (JVM). You can do this in two ways, which are listed below.
+A Mule runtime communicates with MMC using its embedded agent. By default, the agent is enabled and listening on port 7777. You can change the port with the `-Dmule.mmc.bind.port` parameter for the Java Virtual Machine (JVM). You can do this in two ways, which are listed below.
 
 === On the Command Line on Mule Startup
 
-If starting the Mule ESB server from the provided startup script, you can include the port number parameter as a parameter to the startup command as shown below. If running in background, include the parameter after `start`.
+If starting the Mule runtime from the provided startup script, you can include the port number parameter as a parameter to the startup command as shown below. If running in background, include the parameter after `start`.
 
 [source, code, linenums]
 ----
@@ -112,7 +112,8 @@ wrapper.java.additional.4=-Dmule.mmc.bind.port=<number>
 
 [TIP]
 ====
-If you wish to include a port range, letting Mule ESB bind to the first available port, use `<low port>-<high port>`, e.g. `7780-7785`.
+If you wish to include a port range, letting the Mule runtime bind to the first available port, use `<low port>-<high port>`, e.g. `7780-7785`. 
+Note: MMC registers the Mule runtime on a particular port number. If the Mule runtime restarts and binds to a different port number in the available range, the Mule runtime will no longer be able to connect to MMC.  You will have to unregister then register the Mule runtime using the new port number. 
 ====
 
 [TIP]
@@ -129,9 +130,9 @@ For more information about the `wrapper.conf` file, consult the Java Service Wr
 
 Like all Web apps, the Mule Management Console listens for incoming HTTP connections. If you deployed the MMC in a Web application server, you will access MMC via the Web app server's listening port, for example 8080 by default in Tomcat. In that case, the only way to change MMC's listening port is to change your Web app server's listening port.
 
-If you run the trial version of MMC, MMC is running as an app deployed by the Mule ESB server it is bundled with. By default it listens on port 8585. To modify MMC's listening port, follow the steps below.
+If you run the trial version of MMC, MMC is running as an app deployed by the Mule runtime it is bundled with. By default it listens on port 8585. To modify MMC's listening port, follow the steps below.
 
-. Ensure that the Mule ESB server is not running.
+. Ensure that the Mule runtime is not running.
 . Open the file `$MULE_HOME/apps/mmc/mule-config.xml` for editing.
 . Find the line that reads:
 +


### PR DESCRIPTION
The product was re-branded as Mule runtime