### PR TITLE
Reworded Dynamic Keys explanation

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-types.adoc
+++ b/mule-user-guide/v/3.8/dataweave-types.adoc
@@ -144,7 +144,7 @@ Dynamic elements allow you to add the result of an expression as key:value pairs
 --------------------------------------------------------
 === Dynamic keys
 
-In order to set an a key via an expression, the expression should be wrapped in parenthesis.
+In order to specify a key via an expression, the expression should be wrapped in parenthesis.
 
 .Transform
 [source,DataWeave,linenums]


### PR DESCRIPTION
The docs had:

> In order to set an a key via an expression

And I didn't feel like that made much sense, so I changed it to:
> In order to specify a key via an expression