### PR TITLE
migrate to 1.0.0-M1 version of docs builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,13 @@ buildscript {
   configurations.create('singlePageBuilder')
 
   repositories {
-    mavenLocal()
-    ivy {
-      url 'https://s3-us-west-2.amazonaws.com/docs-site-builder'
-      layout 'pattern', { artifact '[artifact]-[revision].[ext]' }
+    if (project.hasProperty('useMavenLocal')) {
+      mavenLocal()
     }
     jcenter()
+    maven {
+      url 'https://repository-master.mulesoft.org/nexus/content/repositories/public'
+    }
   }
 
   dependencies {
@@ -24,7 +25,7 @@ buildscript {
     classpath 'com.palominolabs.gradle.task:gradle-git-clone-task:0.0.2'
     classpath 'org.ajoberstar:gradle-git:1.5.1-rc.3'
 
-    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-SNAPSHOT'
+    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-M1'
     //builder('com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-SNAPSHOT') {
     //  exclude group: 'org.asciidoctor', module: 'asciidoctorj-pdf'
     //  exclude group: 'com.beust', module: 'jcommander'
@@ -33,7 +34,7 @@ buildscript {
     //builder 'org.jruby:jruby:9.0.5.0'
 
     // NOTE jar for single-page builder is not available on s3, so much be built and installed locally
-    singlePageBuilder 'com.mulesoft.documentation.builder.previewer:mule-docs-single-page-builder:1.0.0-SNAPSHOT'
+    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.0-M1'
     //singlePageBuilder('com.mulesoft.documentation.builder.previewer:mule-docs-single-page-builder:1.0.0-SNAPSHOT') {
     //  exclude group: 'org.asciidoctor', module: 'asciidoctorj-pdf'
     //  exclude group: 'com.beust', module: 'jcommander'


### PR DESCRIPTION
- migrate to 1.0.0-M1 version of docs builder hosted in Nexus
- only enable local Maven repository if -PuseMavenLocal property is set