### PR TITLE
Update dataweave-operators.adoc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-operators.adoc
+++ b/mule-user-guide/v/3.8/dataweave-operators.adoc
@@ -377,7 +377,7 @@ If these parameters are not named, the index is defined by default as *$$* and t
 .(':object', ':function')  => ':object'
 
 Returns an object with the key:value pairs that pass the acceptance criteria defined in the lambda.
-If these parameters are not named, the key is defined by default as *$$* and the value as *$*.
+If these parameters are not named, the index is defined by default as *$$* and the value as *$*.
 
 .Transform
 [source,DataWeave,linenums]
@@ -400,6 +400,19 @@ filtered: {
 </filtered>
 ----
 
+[TIP]
+====
+If you require to filter by key, you need to use link:/mule-user-guide/v/3.8/dataweave-operators#map-object[mapObject] and *when*. For example, to filter the last example by key:
+[source,xml,linenums]
+----
+%dw 1.0
+%output application/xml
+---
+filtered: {
+  aa: "a", bb: "b", cc: "c", dd: "d"
+} mapObject ({ ($$): $ } when $$ as :string == "dd" otherwise {})
+----
+====
 
 == Remove
 


### PR DESCRIPTION
Correct an error un filter() specs for object. The key is an index and it's documented as key