### PR TITLE
Add the Web Service Consumer configuration

### DIFF
--- a/mule-user-guide/v/3.8/using-mtom.adoc
+++ b/mule-user-guide/v/3.8/using-mtom.adoc
@@ -71,3 +71,7 @@ The configuration of an MTOM client is exactly like the configuration of a norma
     wsdlLocation="classpath:employeeDirectory.wsdl"
     mtomEnabled="true"/>
 ----
+
+== Configuring the Web Service Consumer
+
+To configure an MTOM client with the Web Service Consumer, you must specify the `mtomEnabled` attribute.  The message payload should include a sub-section that holds attachments (such as text, images, or applications) that travel with the message.  For more information on attachments, see https://docs.mulesoft.com/mule-user-guide/v/3.8/attachment-transformer-reference[Attachment Transformer].


### PR DESCRIPTION
Customers have struggled using the Web Service Consumer connector to send MTOM messages due to lack of documentation.  See the support cases #123204 and #123133.  I'm not sure how to include a screenshot otherwise I would.  Also, see the MTOM test case https://github.com/mulesoft/mule/blob/mule-3.8.x/modules/ws/src/test/java/org/mule/module/ws/functional/MtomFunctionalTestCase.java