### PR TITLE
Update dataweave-reference-documentation.adoc

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
+++ b/mule-user-guide/v/3.7/dataweave-reference-documentation.adoc
@@ -296,9 +296,6 @@ Valid types are:
 
 ===== CSV Input Parsing
 
-[WARNING]
-When using DataWeave in Anypoint Studio, it's not necessary to declare any input directives for any of the components of the Mule Message that arrive at the DataWeave transformer (Payload, flow variables, and input/outbound properties) nor for any system variables. These are already implicitly recognized as inputs and can be referenced anywhere in the DataWeave body without a need to include them in the header as their type is known from the Mule metadata.
-
 When defining an input of type CSV, there are a few optional parameters you can  add to the input directive to customize how the data is parsed. These are not defined in the DataWeave script but on the Mule XML code, in the Transform Message XML element.
 
 In Anypoint Studio there are two ways to achieve this. You can either manually add the attributes to the project's XML, or do it through the graphical interface, by selecting the element from the tree view in the input section and clicking the gear icon. See link:/anypoint-studio/v/5/using-dataweave-in-studio#parsing-csv-inputs[Using DataWeave in Studio] for more details.


### PR DESCRIPTION
Removed redundant, misplaced "Warning" block.  The same warning some lines up at the beginning of the "Input Directive" section should be enough warning for readers of this page.