### PR TITLE
Update dataweave-language-introduction.adoc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
+++ b/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
@@ -58,12 +58,6 @@ In order to show the power of DataWeave, here is a minimal example to get starte
 </order>
 ----
 
-[TIP]
-In Anypoint Studio, inputs are implicitly known based on the metadata that runs through the flow components. If using DW outside of Mule, you should declare an input directive '%input payload application/json'
-
-
-
-
 
 == DataWeave File Structure
 
@@ -116,10 +110,11 @@ Upon receiving that as an input, DataWeave produces the XML output shown below:
 
 The DataWeave header contains the *directives*, which define high-level information about your transformation. The structure of the *header* is a sequence of lines, each with its own *directives*. The *header* section ends at `---`.
 
-Through the *directives* you define key aspects of the transformation:
+Through the use of the following *directives*, key aspects of the transformation are defined:
 
 * *DataWeave version*, e.g. `%dw 1.0`
 * *Output type*, e.g. `%output application/xml`
+* *Input type*, e.g. `%input payload application/xml`
 * *Namespaces* to import into your transform, e.g. %namespace ns0 `http://mulesoft.org/tshirt-service/`
 * *Constants* that can be referenced throughout the body, e.g. `%var conversionRate=13.15`
 * *Functions* that can be called throughout the body, e.g. `%var toUser = (user) -> {firstName: user.name, lastName: user.lastName}`
@@ -128,9 +123,9 @@ All directives are declared in the header section of your DataWeave document and
 
 Directives are a mechanism used to declare _variables_, _constants_ and _namespaces_ and their _aliases_, which are referenced in the body.
 
-They are needed to declare the type of the output of your transform.
+Output type directives are needed to declare the type of the output of your transform.
 
-In Anypoint Studio, you may use directives to declare additional input. You likely will not need this feature as any data arriving inside the incoming Mule message is naturally recognized as an input, and can be acted upon easily enough within the DataWeave code body.
+Input directives may optionally be used to declare additional input sources and their input types.
 
 === Version Directive
 
@@ -152,7 +147,7 @@ Use this directive to specify an alias for a URI, which is specified after the a
 
 === Output Directive
 
-Specify the transformation output type in the format: `<content>/<type>`.
+Specify the transformation output type in the following format: `<content>/<type>`.
 
 Only one output type can be specified -- the structure of this output is further specified in the DataWeave body.
 
@@ -174,10 +169,34 @@ Valid types are:
 * `application/dw`
 
 
+=== Input Directive
+
+Optionally specify an input source and its input type in the following format: `<content>/<type>`.
+
+It is not necessary to declare input directives for any of the components of the Mule Message that arrive at the DataWeave transformer (payload, flow variables, and input/outbound properties) nor for any system variables.
+
+You likely will not need this feature as any data arriving inside the incoming Mule message gets implicitly recognized as input based on the accompanying metadata that passes along with it through the flow components.  As a result, the data can be referenced and acted upon easily enough anywhere within the DataWeave body without a need to include them in the header.
+
+[source, dataweave]
+----
+%input payload application/xml
+----
+
+Valid types are:
+
+* link:/mule-user-guide/v/3.8/dataweave-formats#java[`application/java`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#csv[`application/csv`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#csv[`text/csv`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#json[`application/json`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#json[`text/json`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#xml[`application/xml`]
+* link:/mule-user-guide/v/3.8/dataweave-formats#xml[`text/xml`]
+* `application/dw`
+
 
 === Define Constant Directive
 
-You can define a constant in the header, andreference it (or its child elements, if any exist) in the DataWeave body.
+You can define a constant in the header, and reference it (or its child elements, if any exist) in the DataWeave body.
 
 [source, dataweave, linenums]
 ----


### PR DESCRIPTION
A couple of minor punctuation edits.

Removed the "tip" concerning adding an %input directive outside of Studio because it seems to be made moot by other statements.

Re-organized and consolidated information about the %input directive.  Also added some information taken from the 3.7 documentation.

Information about the %input directive should be maintained in the documentation until it is no longer valid.  By the way, if the %input directive is slated for deprecation in a future release, it should also be described in this documentation as such.

Please feel free to amend this proposed documentation change as necessary.