### PR TITLE
Fixed causeMatches() error

### DIFF
--- a/mule-user-guide/v/3.6/catch-exception-strategy.adoc
+++ b/mule-user-guide/v/3.6/catch-exception-strategy.adoc
@@ -102,9 +102,9 @@ What follows are some examples of expressions that you can enter in the *Execute
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 
 . Click anywhere on the canvas to save your configurations.
@@ -148,9 +148,9 @@ What follows are some examples of expressions that you can use as values of the 
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 +
 [source, xml, linenums]

--- a/mule-user-guide/v/3.7/catch-exception-strategy.adoc
+++ b/mule-user-guide/v/3.7/catch-exception-strategy.adoc
@@ -103,9 +103,9 @@ What follows are some examples of expressions that you can enter in the *Execute
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 
 . Click anywhere on the canvas to save your configurations.
@@ -149,9 +149,9 @@ What follows are some examples of expressions that you can use as values of the 
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 +
 [source, xml, linenums]

--- a/mule-user-guide/v/3.8/catch-exception-strategy.adoc
+++ b/mule-user-guide/v/3.8/catch-exception-strategy.adoc
@@ -103,9 +103,9 @@ What follows are some examples of expressions that you can enter in the *Execute
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 
 . Click anywhere on the canvas to save your configurations.
@@ -149,9 +149,9 @@ What follows are some examples of expressions that you can use as values of the 
 
 * `exception.causedExactlyBy(org.mule.example.ExceptionType)`
 
-* `exception.causeMatches(org.mule.example.*)`
+* `exception.causeMatches('org.mule.example.*')`
 
-* `exception.causeMatches(*) && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
+* `exception.causeMatches('*') && !exception.causedBy(java.lang.ArithmeticException) && !exception.causedBy(org.mule.api.registry.ResolverException)`
 ====
 +
 [source, xml, linenums]


### PR DESCRIPTION
argument must be a String.