### PR TITLE
add AP dev portal

### DIFF
--- a/api-manager/v/latest/browsing-and-accessing-apis.adoc
+++ b/api-manager/v/latest/browsing-and-accessing-apis.adoc
@@ -13,6 +13,11 @@ You can access your organization's Developer Portal by using the name of your or
 
 API Portals listed on the Developer Portal that are Public or to which you have been granted Portal Viewer access are visible. You can browse the portals alphabetically, or search for APIs according to name, version, or tags. +
 
+Note: You can see an example developer portal at this URL:
+https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals
+
+This is the public developer portal for all Anypoint Platform APIs. You can use these APIs to automate Anypoint Platform activities. 
+
 == Accessing API Portals
 
 To access the portal for an API, click the name or version number of the API.


### PR DESCRIPTION
The anypoint platform developer portal is difficult to find with a simple Google search. We should add this link in other parts of the doc.