### PR TITLE
The file extension must be in lowercase.

### DIFF
--- a/mule-user-guide/v/3.8/application-format.adoc
+++ b/mule-user-guide/v/3.8/application-format.adoc
@@ -3,7 +3,7 @@
 
 The deployment unit of a Mule application encapsulates everything an application needs to function, such as libraries, custom code, configuration, deployment descriptor and any environment properties accompanying the application. It exists in one of two formats:
 
-* `.zip` file (a regular archive with a 'zip' extension)
+* `.zip` file (a regular archive with a 'zip' extension in lower case)
 * unpacked version of the same `.zip` file (exploded app)
 
 


### PR DESCRIPTION
We had cases where if the application has .ZIP extension (uppercase) isn't  being deployed.