### PR TITLE
config GW obsolete for some use cases, more reasons for credentials

### DIFF
--- a/access-management/v/latest/organization.adoc
+++ b/access-management/v/latest/organization.adoc
@@ -7,7 +7,7 @@ As an <<The Organization Administrator Role,administrator of an Organization>> i
 * Assign users to roles to define their permissions in the platform
 * Edit and remove users from your organization
 * Configure organization settings
-* Access your organization's client ID and client secret, needed for configuring your API Gateway instances
+* Access your organization's link:/access-management/organization#client-id-and-client-secret[client ID and client secret]
 * Access analytics for the APIs in your organization
 * Create Business Groups to delegate the management of the resources within each of these and to easily delimit the scopes of roles and permissions. As a Business Group owner, there are also several things to configure at Business Group level.
 
@@ -24,7 +24,7 @@ The *Organization* tab displays your organization name, which was created when y
 
 === Client ID and Client Secret
 
-Each organization has a *client ID* and a *client secret* that authenticate it. These values are required for configuring an on-premises API Gateway or for deploying proxies or APIs to an API Gateway hosted on CloudHub.
+Each organization has a *client ID* and a *client secret* that authenticate it. These values are required for configuring an on-premises Mule Runtime or link:/api-manager/api-gateway-runtime-archive[legacy API Gateway Runtime], deploying proxies or APIs to CloudHub, and for other purposes.
 
 To obtain the values of these credentials for your organization, log in to the Anypoint Platform as an administrator, click the gear icon at the top-right and then select the *Organization* tab.
 
@@ -43,7 +43,7 @@ image::organization-11dbd.png[organization-11dbd]
 
 Even though multiple organizations can be created by different users using the same company name, each organization has a unique domain.
 
-Here you can also consult your organization's Client Id and Client Secret. These are useful if you want to use an API Gateway, as you must register it with a specific organization. The Client Id and Client Secret that belong to the Master Organization provide all of the permissions from the Business Groups within it.
+Here you can also consult your organization's Client Id and Client Secret. These are useful if you want to use an API Manager, as you must register it with a specific organization. The Client Id and Client Secret that belong to the Master Organization provide all of the permissions from the Business Groups within it.
 
 [TIP]
 Business Groups also have their own Client Id and Client Secret. You can use these if you're not an Organization Admin.

--- a/access-management/v/latest/troubleshooting-anypoint-platform-access.adoc
+++ b/access-management/v/latest/troubleshooting-anypoint-platform-access.adoc
@@ -46,7 +46,7 @@ Please contact us directly for billing information.
 
 === I received a notice that my trial is expiring. Help!
 
-Please talk to your account representative or mailto:info@mulesoft.com[contact us] to request an Enterprise license for your on-premises API Gateway instances or to create a subscription account on CloudHub if you are using cloud API Gateways.
+Please talk to your account representative or mailto:info@mulesoft.com[contact us] to request an Enterprise license for your on-premises Mule Runtime instances or to create a subscription account on CloudHub.
 
 === My organization uses external identity management. How do I log in?
 


### PR DESCRIPTION
Configuring GW no longer required for all use cases and is not the only reason for credentials. Added pointer to Client ID and Client Secret section and included a few of the many reasons you need credentials.