### PR TITLE
Update runtime-manager-1.5.1-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/runtime-manager-1.5.1-release-notes.adoc
+++ b/release-notes/v/latest/runtime-manager-1.5.1-release-notes.adoc
@@ -27,9 +27,6 @@ Agent plugins integrations is compatible with the following runtime versions:
 |===
 
 
-[TIP]
-The Runtime Manager version that is bundled as part of the Anypoint Platform On-Premise edition is link:/release-notes/runtime-manager-1.2.0-release-notes[Version 1.2].
-
 
 == Deprecated Features or Functionality
 


### PR DESCRIPTION
I would remove the on-prem version tip, at least from the release notes. It's confusing because it makes it seem like they are the same versions and they are not.

Thanks,
Suchi