### PR TITLE
Update Persisting MMC Data to MS SQL Server

### DIFF
--- a/mule-management-console/v/3.8/persisting-mmc-data-to-ms-sql-server.adoc
+++ b/mule-management-console/v/3.8/persisting-mmc-data-to-ms-sql-server.adoc
@@ -76,6 +76,8 @@ If connection using a standard client fails due to a connectivity issue (not an 
 
 From the Management Console host, run:
 
+telnet ip.of.sql.server 1433
+
 If the connection succeeds, you should output similar to the following:
 
 The above output indicates that the connection was successful. A "connection refused" error usually indicates that nothing is listening on the specified host and port. Any other output, or lack of output, indicates a connectivity problem, such as a routing issue or firewall blocking requests between the Management Console host and the database host.
@@ -138,6 +140,8 @@ Copy the file `sqljdbc4.jar` to the following directory:` <MMC_HOME>/WEB-INF/lib
   Unpacking gzipped tar files
 
 To uncompress and unpack the .tar.gz file, open a terminal and use the `cd` command to navigate to the directory containing the file. Then, run the following commands:
+
+tar -xvf yourfile.tar
 
 This will uncompress the file, whose filename extension will change from `.tar.gz` to `.tar`. Unpack the file with the `tar` command, as shown below.
 
@@ -209,7 +213,7 @@ The `spring.profiles.active` section in the `web.xml` configuration file allows
 |`env.host` |Hostname or IP address where the database server is listening |`localhost`
 |`env.port` |Port where the database server is listening |`1433`
 |`env.url` |URL for connecting to the database |`jdbc\:sqlserver\://${env.host}\:${env.port};databaseName=${env.dbschema}`
-|`env.dbschema` |Database to connect to |`mmc_persistency_status`
+|`env.dbschema` |Database to connect to |`MMC_STATUS`
 |===
 . Save the file with your modifications, if any.
 
@@ -275,7 +279,7 @@ The `spring.profiles.active` section in the `web.xml` configuration file allows
 |`mmc.tracking.db.url` |URL for connecting to the database |`jdbc:sqlserver://${mmc.tracking.db.host}:${mmc.tracking.db.port};databaseName=${mmc.tracking.db.dbname}`
 |`mmc.tracking.db.username` |Database user |`mmc_tracking`
 |`mmc.tracking.db.password` |Password for the database user |`mmc123`
-|`mmc.tracking.db.dbname` |Database to connect to |`persistency`
+|`mmc.tracking.db.dbname` |Database to connect to |`MMC_PERSISTENCY`
 |`mmc.max.events.exception.details.length` |Number of characters from a Business Events exception that will be stored in the tracking database. The maximum allowed is 261120. |`8000`
 |===
 . Save the file with your modifications, if any.


### PR DESCRIPTION
- Line 79 The example for the telnet action was empty (added that)
- Line 123 The download link for the sqljdbc4.jar at Microsoft is correct but the actual download gives a Page not found.
- Line 144 At topic 'Unpacking gzipped tar files' misses the actual example for the command (added that)
- Line 216 'env.dbschema' should be MMC_STATUS (changed that)
- Line 282 'mmc.tracking.db.dbname' should be MMC_PERSISTENCY (changed that)