### PR TITLE
Update until-successful-scope.adoc

### DIFF
--- a/mule-user-guide/v/3.8/until-successful-scope.adoc
+++ b/mule-user-guide/v/3.8/until-successful-scope.adoc
@@ -10,7 +10,7 @@ Until-successful repeatedly retries to process a message that is attempting to c
 * A sub-flow execution, to keep re-executing several actions until they all succeed,
 * Any other message processor execution, to allow more complex scenarios.
 
-NOTE: The until successful component requires a mandatory link:/mule-user-guide/v/3.8/mule-object-stores[object store] to work. However Anypoint Studio doesn't enforce this. If an object store is not declared, Studio throws an InitialisationException. For more information, see <<Until-Successful and Object Store>>.
+NOTE: The until successful component requires a mandatory link:/mule-user-guide/v/3.8/mule-object-stores[object store] to work. However Anypoint Studio doesn't enforce this. If an object store is not declared, Studio throws an InitialisationException. For more information, see <<Until-Successful and Object Store>>. The object store needs to be exclusive for each until successful instance.
 
 *See Also:*
 


### PR DESCRIPTION
We had a case where the customer was using the same object store in cloudhub to store Until Successful data and also to store some key as watermarks. After reviewing the until successful scope, we concluded that if you use the same object store in a until successful scope and in a object store connector, the until successful will delete the entries on application redeploy.