### PR TITLE
Change `suborg` instances for `business group`

### DIFF
--- a/access-management/v/latest/organization.adoc
+++ b/access-management/v/latest/organization.adoc
@@ -1,5 +1,5 @@
 = Organization
-:keywords: anypoint platform, permissions, configuring, business groups, suborganizations, suborgs
+:keywords: anypoint platform, permissions, configuring, business groups
 
 As an <<The Organization Administrator Role,administrator of an Organization>> in the Anypoint Platform, there are several things you can configure for your entire organization such as:
 

--- a/anypoint-data-gateway/v/latest/managing-gateways.adoc
+++ b/anypoint-data-gateway/v/latest/managing-gateways.adoc
@@ -66,7 +66,7 @@ Left-hand menu pane, which allows you to:
 |5 |Search gateways input box. Type a string to see only gateways whose name contains that string.
 |6 |Support button. Click to contact MuleSoft support (or a contact form if you're on a trial account).
 |7 |Organization configuration button. Click to configure your organization from within Anypoint Platform. You may be required to log in.
-|8 |Organization/suborganization drop-down menu. Click to select between your available organizations and suborganizations. Selecting one allows you to access Gateway Designer specifically for that org or suborg.
+|8 |Organization/Business Group drop-down menu. Click to select between your available organizations and business groups. Selecting one allows you to access Gateway Designer specifically for that organization or business group.
 
 image:suborg_menu-1.2.png[suborg_menu-1.2]
 
@@ -143,7 +143,7 @@ To modify the status of an existing gateway:
 . Go to the gateway list in Gateway designer by clicking *Gateways* in the global left-hand menu (see image  link:#ManagingGateways-image).
 . In the gateway list, locate the gateway you wish to modify, then click the *Edit* menu on the right.
 +
-image:modifying_gw_status-1.2.png[modifying_gw_status-1.2] 
+image:modifying_gw_status-1.2.png[modifying_gw_status-1.2]
 +
 
 . Select from the available options: *Publish*, *Start*, *Delete* or *Settings*. This last option takes you to the Salesforce Settings configuration screen, described below.

--- a/mule-fundamentals/v/3.7/anypoint-exchange.adoc
+++ b/mule-fundamentals/v/3.7/anypoint-exchange.adoc
@@ -317,12 +317,12 @@ In the Business Groups feature in Exchange, published content is shared through 
 The use cases for business groups are:
 
 * Ability of a Central IT organization, such as the root organization to create artifacts and make them available to all Lines of Businesses (LOBs), which are subordinate organizations.
-* Ability of a Central IT organization to locate artifacts published in a sub org and make them available to the rest of the business.
-* Ability of an LOB to publish artifacts for internal to that sub org's consumption.
+* Ability of a Central IT organization to locate artifacts published in a business group and make them available to the rest of the business.
+* Ability of an LOB to publish artifacts for internal to that business group's consumption.
 
 image:exchange-bgroups.png[exchange business groups]
 
-A user only belongs to a sub org because an administrator assigns to a user the sub org. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that sub org.
+A user only belongs to a business group because an administrator assigns to a user the business group. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that business group.
 
 Any user that belongs to an organization to see the artifacts of that org (top level org). So if I’m a member of “org 1” and I don’t have any permissions, I can see published artifacts in org 1.
 

--- a/mule-fundamentals/v/3.7/deploying-mule-applications.adoc
+++ b/mule-fundamentals/v/3.7/deploying-mule-applications.adoc
@@ -128,7 +128,7 @@ See link:/runtime-manager/deployment-strategies[Deployment Strategies] and link:
 See link:/runtime-manager/deploying-to-cloudhub[Deploying to CloudHub] or link:/runtime-manager/deploying-to-your-own-servers[Deploying to Your Own Servers] for instructions on how to deploy through the Anypoint Platform UI. You can also deploy to CloudHub directly from the Studio IDE.
 
 . In Studio, right-click the project name in the *Package Explorer* pane, then select *Deploy to Anypoint Platform*.
-. You are prompted to enter your Anypoint Platform login credentials. Then a menu will open where you must select an Environment and sub organization to deploy to, a domain in which to deploy your application, the runtime to deploy to, etc. If deploying to the cloud, the domain name you enter must be a unique sub-domain which CloudHub creates for your application on the cloudhub.io domain such as, `My-Project-Name`. CloudHub automatically checks the availability of the sub-domain, then displays a checkmark icon to confirm that your entry is unique.
+. You are prompted to enter your Anypoint Platform login credentials. Then a menu will open where you must select an Environment and business group to deploy to, a domain in which to deploy your application, the runtime to deploy to, etc. If deploying to the cloud, the domain name you enter must be a unique sub-domain which CloudHub creates for your application on the cloudhub.io domain such as, `My-Project-Name`. CloudHub automatically checks the availability of the sub-domain, then displays a checkmark icon to confirm that your entry is unique.
 +
 image:deploy-from-studio.jpg[deploy-from-studio]
 +

--- a/mule-fundamentals/v/3.8/anypoint-exchange.adoc
+++ b/mule-fundamentals/v/3.8/anypoint-exchange.adoc
@@ -385,12 +385,12 @@ In the Business Groups feature in Exchange, published content is shared through 
 The use cases for business groups are:
 
 * Ability of a Central IT organization, such as the root organization to create artifacts and make them available to all Lines of Businesses (LOBs), which are subordinate organizations.
-* Ability of a Central IT organization to locate artifacts published in a sub org and make them available to the rest of the business.
-* Ability of an LOB to publish artifacts for internal to that sub org's consumption.
+* Ability of a Central IT organization to locate artifacts published in a business group and make them available to the rest of the business.
+* Ability of an LOB to publish artifacts for internal to that business group's consumption.
 
 image:exchange-bgroups.png[exchange business groups]
 
-A user only belongs to a sub org because an administrator assigns to a user the sub org. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that sub org.
+A user only belongs to a business group because an administrator assigns to a user the business group. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that business group.
 
 Any user that belongs to an organization to see the artifacts of that org (top level org). So if I’m a member of “org 1” and I don’t have any permissions, I can see published artifacts in org 1.
 

--- a/mule-fundamentals/v/3.8/anypoint-exchange2.adoc
+++ b/mule-fundamentals/v/3.8/anypoint-exchange2.adoc
@@ -299,12 +299,12 @@ In the Business Groups feature in Exchange, published content is shared through 
 The use cases for business groups are:
 
 * Ability of a Central IT organization, such as the root organization to create artifacts and make them available to all Lines of Businesses (LOBs), which are subordinate organizations.
-* Ability of a Central IT organization to locate artifacts published in a sub org and make them available to the rest of the business.
-* Ability of an LOB to publish artifacts for internal to that sub org's consumption.
+* Ability of a Central IT organization to locate artifacts published in a business group and make them available to the rest of the business.
+* Ability of an LOB to publish artifacts for internal to that business group's consumption.
 
 image:exchange-bgroups.png[exchange business groups]
 
-A user only belongs to a sub org because an administrator assigns to a user the sub org. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that sub org.
+A user only belongs to a business group because an administrator assigns to a user the business group. If a user is invited to BG1.1 without any permission s/he won’t be able to see any artifacts from that business group.
 
 Any user that belongs to an organization to see the artifacts of that org (top level org). So if I’m a member of “org 1” and I don’t have any permissions, I can see published artifacts in org 1.
 

--- a/mule-fundamentals/v/3.8/deploying-mule-applications.adoc
+++ b/mule-fundamentals/v/3.8/deploying-mule-applications.adoc
@@ -121,7 +121,7 @@ See link:/runtime-manager/deployment-strategies[Deployment Strategies] and link:
 See link:/runtime-manager/deploying-to-cloudhub[Deploying to CloudHub] or link:/runtime-manager/deploying-to-your-own-servers[Deploying to Your Own Servers] for instructions on how to deploy through the Anypoint Platform UI. You can also deploy to CloudHub directly from the Studio IDE.
 
 . In Studio, right-click the project name in the *Package Explorer* pane, then select *Deploy to Anypoint Platform*.
-. You are prompted to enter your Anypoint Platform login credentials. Then a menu opens where you must select an Environment and sub organization to deploy to, a domain in which to deploy your application, the runtime to deploy to, etc. If deploying to the cloud, the domain name you enter must be a unique sub-domain which CloudHub creates for your application on the cloudhub.io domain such as, `My-Project-Name`. CloudHub automatically checks the availability of the sub-domain, then displays a checkmark icon to confirm that your entry is unique.
+. You are prompted to enter your Anypoint Platform login credentials. Then a menu opens where you must select an Environment and business group to deploy to, a domain in which to deploy your application, the runtime to deploy to, etc. If deploying to the cloud, the domain name you enter must be a unique sub-domain which CloudHub creates for your application on the cloudhub.io domain such as, `My-Project-Name`. CloudHub automatically checks the availability of the sub-domain, then displays a checkmark icon to confirm that your entry is unique.
 +
 image:deploy-from-studio.jpg[deploy-from-studio]
 +

--- a/mule-user-guide/v/3.7/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.7/mule-maven-plugin.adoc
@@ -621,7 +621,7 @@ The following tables list all available parameters that you can use. Parameters 
 |Parameter |Description
 |`application` |The application's filepath. If not specified, the result of the Maven build is used as the default.
 |`applicationName` |The application name to use for the deployment. If not specified, the value of `artifactName` is used.
-|`businessGroup` |Specifies the path to the sub organization you want to deploy to, if any. The default is the Master organization.
+|`businessGroup` |Specifies the path to the business group you want to deploy to, if any. The default is the Master organization.
 
 *Example*:
 
@@ -652,7 +652,7 @@ The following tables list all available parameters that you can use. Parameters 
 |Parameter |Description
 |`application` |The application's filepath. If not specified, the result of the Maven build is used as the default.
 |`applicationName` |The application name to use for the deployment. If not specified, the value of `artifactName` is used.
-|`businessGroup` |Specifies the path to the sub organization you want to deploy to, if any. The default is the Master organization.
+|`businessGroup` |Specifies the path to the business group you want to deploy to, if any. The default is the Master organization.
 
 *Example*:
 

--- a/mule-user-guide/v/3.8/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.8/mule-maven-plugin.adoc
@@ -628,7 +628,7 @@ The following tables list all available parameters that you can use. Parameters 
 |Parameter |Description
 |`application` |The application's filepath. If not specified, the result of the Maven build is used as the default.
 |`applicationName` |The application name to use for the deployment. If not specified, uses the value of `artifactName`.
-|`businessGroup` |Specifies the path to the sub organization you want to deploy to, if any. The default is the Master organization.
+|`businessGroup` |Specifies the path to the business group you want to deploy to, if any. The default is the Master organization.
 
 *Example*:
 
@@ -659,7 +659,7 @@ The following tables list all available parameters that you can use. Parameters 
 |Parameter |Description
 |`application`|The application's filepath. If not specified, the result of the Maven build is used as the default.
 |`applicationName` |The application name to use for the deployment. If not specified, the value of `artifactName` is used.
-|`businessGroup` |Specifies the path to the sub organization you deploy to, if any. The default is the Master organization.
+|`businessGroup` |Specifies the path to the business group you deploy to, if any. The default is the Master organization.
 
 *Example*:
 

--- a/release-notes/v/latest/Exchange-May2016-Release-Notes.adoc
+++ b/release-notes/v/latest/Exchange-May2016-Release-Notes.adoc
@@ -24,9 +24,9 @@ To address the movement of an artifact across a hierarchical structure, Exchange
 
 Business Groups are being incorporated in Exchange . This feature across with the Exchange Roles and the new state transition flow of an artifact provides:
 
-* Ability of Central IT (maybe the root organization) to create artifacts and make them available to all Lines of Businesses (sub organizations)
-* Ability of Central IT to locate artifacts published in a sub organization and make it available to the rest of the business
-* Ability of an LOB to publish artifacts for internal (to that sub organization) consumption
+* Ability of Central IT (maybe the root organization) to create artifacts and make them available to all Lines of Businesses (business groups)
+* Ability of Central IT to locate artifacts published in a business group and make it available to the rest of the business
+* Ability of an LOB to publish artifacts for internal (to that business group) consumption
 
 ==== UI and UX Improvements
 

--- a/release-notes/v/latest/anypoint-exchange-release-notes.adoc
+++ b/release-notes/v/latest/anypoint-exchange-release-notes.adoc
@@ -90,9 +90,9 @@ To address the movement of an artifact across a hierarchical structure, Exchange
 
 Business Groups are being incorporated in Exchange . This feature across with the Exchange Roles and the new state transition flow of an artifact provides:
 
-* Ability of Central IT (maybe the root organization) to create artifacts and make them available to all Lines of Businesses (sub organizations)
-* Ability of Central IT to locate artifacts published in a sub organization and make it available to the rest of the business
-* Ability of an LOB to publish artifacts for internal (to that sub organization) consumption
+* Ability of Central IT (maybe the root organization) to create artifacts and make them available to all Lines of Businesses (business groups)
+* Ability of Central IT to locate artifacts published in a business group and make it available to the rest of the business
+* Ability of an LOB to publish artifacts for internal (to that business group) consumption
 
 ==== UI and UX Improvements
 


### PR DESCRIPTION
Based on the University of Austin's feedback, all instances of sub-org was changed for business groups. 


Modified Files:

- access-management/v/latest/organization.adoc
- anypoint-data-gateway/v/latest/managing-gateways.adoc
- mule-fundamentals/v/3.7/anypoint-exchange.adoc
- mule-fundamentals/v/3.7/deploying-mule-applications.adoc
- mule-fundamentals/v/3.8/anypoint-exchange.adoc
- mule-fundamentals/v/3.8/anypoint-exchange2.adoc
- mule-fundamentals/v/3.8/deploying-mule-applications.adoc
- mule-user-guide/v/3.7/mule-maven-plugin.adoc
- mule-user-guide/v/3.8/mule-maven-plugin.adoc
- release-notes/v/latest/Exchange-May2016-Release-Notes.adoc
- release-notes/v/latest/anypoint-exchange-release-notes.adoc