### PR TITLE
Fix typo on munit 1.1.1 suite docs

### DIFF
--- a/munit/v/1.1.1/munit-suite.adoc
+++ b/munit/v/1.1.1/munit-suite.adoc
@@ -279,7 +279,7 @@ The attribute `expectException` expects one of the following:
 [source, xml, linenums]
 .MUnit test expected exception _class name_ example
 ----
-<munit:test name="testExceptions" description="Test Exceptions" expectException="java.lang.RuntimException">
+<munit:test name="testExceptions" description="Test Exceptions" expectException="java.lang.RuntimeException">
   <flow-ref name="exceptionFlow"/>
 </munit:test>
 ----


### PR DESCRIPTION
Modifies `munit/v/1.1.1/munit-suite.adoc`