### PR TITLE
fix invalid AsciiDoc syntax

### DIFF
--- a/anypoint-connector-devkit/v/3.6/oauth-v1.adoc
+++ b/anypoint-connector-devkit/v/3.6/oauth-v1.adoc
@@ -198,7 +198,7 @@ By default, Mule uses a host and port (determined by the `fullDomain` environmen
 <linkedin:config apiKey="${api.key}" apiSecret="${api.secret}">
 <linkedin:oauth-callback-config domain="SOME_DOMAIN" remotePort="SOME_PORT" />
 </linkedin:config>
----- 
+----
 
 For details on how Mule handles callbacks, see HTTP Callbacks.
 

--- a/anypoint-connector-devkit/v/3.6/oauth-v2.adoc
+++ b/anypoint-connector-devkit/v/3.6/oauth-v2.adoc
@@ -79,7 +79,7 @@ public class MyConnector
     * YOUR CODE GOES HERE
     */
 }
----- 
+----
 +
 . Add the OAuth access URL, access token URL, and the OAuth strategy:
 
@@ -207,7 +207,7 @@ By default, Mule uses a host and port (determined by the `fullDomain` environm
 <connector:config-oauth name="oauth2" consumerKey="[ckey]" consumerSecret="[csec]">
   <connector:oauth-callback-config domain="SOME_DOMAIN" localPort="SOME_PORT" path="SOME_PATH"/>
 </connector:config-oauth>
----- 
+----
 
 
 === Adding Secure Socket Layer (SSL)

--- a/anypoint-studio/v/5/datasense-query-editor.adoc
+++ b/anypoint-studio/v/5/datasense-query-editor.adoc
@@ -128,8 +128,8 @@ Click the drop-down menu to select any of the fields available for the selected 
 
 Click to select any of the following operators:
 
-[width="80%",cols=","]
-!========================================
+[%autowidth,width=80%]
+!===
 !< !less than
 !< = !less than or equal to
 != !equal to
@@ -137,7 +137,7 @@ Click to select any of the following operators:
 !> = !greater than or equal to
 !< > !not equal to
 !like !like
-!=======================================
+!===
 
 |*6* |Operator value input box. +
 Enter the value that the filter uses to evaluate the field.

--- a/anypoint-studio/v/6/datasense-query-editor.adoc
+++ b/anypoint-studio/v/6/datasense-query-editor.adoc
@@ -128,8 +128,8 @@ Click the drop-down menu to select any of the fields available for the selected 
 
 Click to select any of the following operators:
 
-[width="80%",cols=","]
-!========================================
+[%autowidth,width=80%]
+!===
 !< !less than
 !< = !less than or equal to
 != !equal to
@@ -137,7 +137,7 @@ Click to select any of the following operators:
 !> = !greater than or equal to
 !< > !not equal to
 !like !like
-!=======================================
+!===
 
 |*6* |Operator value input box. +
 Enter the value that the filter uses to evaluate the field.

--- a/mule-healthcare-toolkit/v/3.3/hl7-endpoint-reference.adoc
+++ b/mule-healthcare-toolkit/v/3.3/hl7-endpoint-reference.adoc
@@ -86,7 +86,7 @@ The complete http://en.wikipedia.org/en/wiki/URI[URI] location of the host to 
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -128,7 +128,7 @@ Allows you to reference an HL7 endpoint configured as a Global Element.
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -162,7 +162,7 @@ The complete http://en.wikipedia.org/en/wiki/URI[URI] location of the host to 
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -194,7 +194,7 @@ Allows you to reference an HL7 endpoint configured as a Global Element.
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`

--- a/mule-healthcare-toolkit/v/3.4/hl7-endpoint-reference.adoc
+++ b/mule-healthcare-toolkit/v/3.4/hl7-endpoint-reference.adoc
@@ -85,7 +85,7 @@ The complete http://en.wikipedia.org/en/wiki/URI[URI] location of the host to 
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options=header]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -126,7 +126,7 @@ Allows you to reference an HL7 endpoint configured as a Global Element.
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -161,7 +161,7 @@ The complete http://en.wikipedia.org/en/wiki/URI[URI] location of the host to 
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`
@@ -193,7 +193,7 @@ Allows you to reference an HL7 endpoint configured as a Global Element.
 
 This parameter is mutually exclusive with the following other parameters:
 
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Studio !XML
 !*Host* (General tab) !`host=""`

--- a/mule-healthcare-toolkit/v/3.5/hl7-global-connector.adoc
+++ b/mule-healthcare-toolkit/v/3.5/hl7-global-connector.adoc
@@ -67,7 +67,7 @@ This tab only contains the *Name* field, where you may optionally type a meaning
 |===
 |Name |Description |XML
 |Name (Studio Only) |Name of the building block as it appears in the flow |`name="connectorName"`
-
+|===
 
 image::hl7_gloabl_advanced.png[hl7_gloabl_advanced]
 

--- a/mule-management-console/v/3.3/repository-of-applications.adoc
+++ b/mule-management-console/v/3.3/repository-of-applications.adoc
@@ -6,33 +6,13 @@ This document, as well as the rest of the documents that make up the link:/mule-
 
  Index of operations
 
-[width="99%",cols="20%,16%,16%,16%,16%,16%",]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* a|
-[width="100%",cols="50%,50%",]
-|===
+2+|Assumptions:
 |Host |localhost
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Port |8080
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Deployed app |mmc.war
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |User/Password |admin/admin
-|===
-
- | 
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.3/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.3/servers.adoc
+++ b/mule-management-console/v/3.3/servers.adoc
@@ -7,28 +7,13 @@ This document, as well as the rest of the documents that make up the link:/mule-
 
  Index of operations
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.3/using-the-management-console-api[Content Organization and Conventions].

--- a/mule-management-console/v/3.4/deployments.adoc
+++ b/mule-management-console/v/3.4/deployments.adoc
@@ -4,32 +4,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.4/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], link:/mule-management-console/v/3.4/deployments[Deployments], and the link:/mule-management-console/v/3.4/using-the-management-console-api[REST API.]
 
-[width="100%",cols="5",]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:*
-a|
-[width=",",cols=",",]
-!===
-!Host !localhost
-!===
-
-a|
-[width=",",cols=",",]
-!===
-!Port !8080
-!===
-
-a|
-[width=",",cols=",",]
-!===
-!Deployed app !mmc.war
-!===
-
-a|
-[width=",",cols=",",]
-!===
-!User/Password !admin/admin
-!===
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.4/rest-api-reference[Content Organization and Conventions].
@@ -77,7 +58,7 @@ Creates a new Deployment.
 |Key |Type |Summary |Child of
 |name |String |Name of the deployment to be created. Must be unique |—
 |servers |Array a|
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !<= 3.4.0 !>= 3.4.1
 !List of server IDs !List of server or group IDs

--- a/mule-management-console/v/3.5/architecture-of-the-mule-management-console.adoc
+++ b/mule-management-console/v/3.5/architecture-of-the-mule-management-console.adoc
@@ -8,7 +8,7 @@ image:MMC-architecture.png[MMC-architecture]
 
 *KEY*
 
-[cols="0,2a"]
+[cols="1,99a"]
 |===
 
 |*1* |The Mule ESB instances monitored by MMC. These can be standalone or embedded instances, or clusters.

--- a/mule-management-console/v/3.5/deployments.adoc
+++ b/mule-management-console/v/3.5/deployments.adoc
@@ -757,7 +757,6 @@ JSON:
 |===
 |From |3.2.2
 |===
-|===
 
 `/api/deployments/{deploymentId}/redeploy`
 

--- a/mule-management-console/v/3.5/repository-of-applications.adoc
+++ b/mule-management-console/v/3.5/repository-of-applications.adoc
@@ -2,29 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], the Application Repository and the link:/mule-management-console/v/3.7/rest-api-reference[REST API]. 
 
-[width="99a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:*
-|
-[width="99a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-|
-[width="99a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-|
-[width="99a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-|
-[width="99a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!===
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.5/server-groups.adoc
+++ b/mule-management-console/v/3.5/server-groups.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Server Groups and the link:/mule-management-console/v/3.7/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.5/servers.adoc
+++ b/mule-management-console/v/3.5/servers.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Mule Servers and the link:/mule-management-console/v/3.7/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/using-the-management-console-api[Content Organization and Conventions].

--- a/mule-management-console/v/3.6/architecture-of-the-mule-management-console.adoc
+++ b/mule-management-console/v/3.6/architecture-of-the-mule-management-console.adoc
@@ -8,7 +8,7 @@ image:MMC-architecture.png[MMC-architecture]
 
 *KEY*
 
-[cols="0,2a"]
+[cols="1,99a"]
 |===
 
 |*1* |The Mule ESB instances monitored by MMC. These can be standalone or embedded instances, or clusters.

--- a/mule-management-console/v/3.7/architecture-of-the-mule-management-console.adoc
+++ b/mule-management-console/v/3.7/architecture-of-the-mule-management-console.adoc
@@ -8,7 +8,7 @@ image:MMC-architecture.png[MMC-architecture]
 
 *KEY*
 
-[cols="0,2a"]
+[cols="1,99a"]
 |===
 
 |*1* |The Mule ESB instances monitored by MMC. These can be standalone or embedded instances, or clusters.

--- a/mule-management-console/v/3.7/repository-of-applications.adoc
+++ b/mule-management-console/v/3.7/repository-of-applications.adoc
@@ -2,33 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], the Application Repository and the link:/mule-management-console/v/3.7/rest-api-reference[REST API]. 
 
-[width="99%",cols="20%,16%,16%,16%,16%,16%",]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* a|
-[width="100%",cols="50%,50%",]
-|===
+2+|Assumptions:
 |Host |localhost
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Port |8585
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Deployed app |mmc.war
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |User/Password |admin/admin
-|===
-
- | 
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.7/server-groups.adoc
+++ b/mule-management-console/v/3.7/server-groups.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Server Groups and the link:/mule-management-console/v/3.7/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.7/servers.adoc
+++ b/mule-management-console/v/3.7/servers.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.7/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Mule Servers and the link:/mule-management-console/v/3.7/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8585
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8585
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.7/using-the-management-console-api[Content Organization and Conventions].

--- a/mule-management-console/v/3.8/architecture-of-the-mule-management-console.adoc
+++ b/mule-management-console/v/3.8/architecture-of-the-mule-management-console.adoc
@@ -8,7 +8,7 @@ image:MMC-architecture.png[MMC-architecture]
 
 *KEY*
 
-[cols="0,2a"]
+[cols="1,99a"]
 |===
 
 |*1* |The Mule ESB instances monitored by MMC. These can be standalone or embedded instances, or clusters.

--- a/mule-management-console/v/3.8/repository-of-applications.adoc
+++ b/mule-management-console/v/3.8/repository-of-applications.adoc
@@ -2,33 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.8/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], the Application Repository and the link:/mule-management-console/v/3.8/rest-api-reference[REST API]. 
 
-[width="99%",cols="20%,16%,16%,16%,16%,16%",]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* a|
-[width="100%",cols="50%,50%",]
-|===
+2+|Assumptions:
 |Host |localhost
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Port |8585
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |Deployed app |mmc.war
-|===
-
- a|
-[width="100%",cols="50%,50%",]
-|===
 |User/Password |admin/admin
-|===
-
- | 
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.8/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.8/server-groups.adoc
+++ b/mule-management-console/v/3.8/server-groups.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.8/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Server Groups and the link:/mule-management-console/v/3.8/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8080
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8080
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.8/rest-api-reference[Content Organization and Conventions].

--- a/mule-management-console/v/3.8/servers.adoc
+++ b/mule-management-console/v/3.8/servers.adoc
@@ -2,31 +2,13 @@
 
 This document, as well as the rest of the documents that make up the link:/mule-management-console/v/3.8/rest-api-reference[Mule Management Console REST API Reference Guide], are a technical reference only. This document does not provide contextual information such as instructions, use cases or scenarios. To understand this document, you should be familiar with http://www.mulesoft.org/documentation/display/MULE3USER/Home[MULE ESB], Mule Servers and the link:/mule-management-console/v/3.8/using-the-management-console-api[REST API].
 
-[width="100a",cols="20a,20a,20a,20a,20a"]
+[cols="1s,1",options="header"]
 |===
-|*Assumptions:* |
-[width="100a",cols="50a,50a"]
-!===
-!Host !localhost
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Port !8585
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!Deployed app !mmc.war
-!===
-
-|
-[width="100a",cols="50a,50a"]
-!===
-!User/Password !admin/admin
-!=== 
+2+|Assumptions:
+|Host |localhost
+|Port |8585
+|Deployed app |mmc.war
+|User/Password |admin/admin
 |===
 
 For a detailed description of the format used in this document, consult link:/mule-management-console/v/3.8/using-the-management-console-api[Content Organization and Conventions].

--- a/mule-user-guide/v/3.2/choice-flow-control-reference.adoc
+++ b/mule-user-guide/v/3.2/choice-flow-control-reference.adoc
@@ -36,9 +36,9 @@ Complete the following steps to configure Choice Flow Control:
 . Click the down button to the right of the the *Evaluator* field, and select an evaluator from the drop down list (See: **below, lower left**). Consult <<Evaluator Options of the Choice Flow Control>> for the available choices, along with brief descriptions.
 . Enter an expression for evaluating the message. For example, you might enter something like:
 +
-code,code-java----
- code,code-java
- expression="equals('foo') || content.endsWith('bar')" 
+[source,java]
+----
+expression="equals('foo') || content.endsWith('bar')" 
 ----
 
 . If you wish to designate a specific message processor as the route to be used when all other available routes fail to satisfy the expression criteria, click the check box marked *Otherwise* (See: **below, upper right**)

--- a/mule-user-guide/v/3.2/essentials-of-using-mule-esb-3.adoc
+++ b/mule-user-guide/v/3.2/essentials-of-using-mule-esb-3.adoc
@@ -14,11 +14,11 @@ Studio installation is almost instantaneous, and a pair of tutorials can get you
 
 Let’s get Kicking!
 
-[width="99a",cols="40a,60a"]
-|===
-|
+[cols="40,60"]
+!===
+!
 http://www.mulesoft.org/download-mule-esb-community-edition[Download Studio here.] |[Check out our Studio documentation here.]
-|===
+!===
 
 |===
 

--- a/mule-user-guide/v/3.2/notifications-example.adoc
+++ b/mule-user-guide/v/3.2/notifications-example.adoc
@@ -25,8 +25,8 @@ The outbound endpoint the page is listening to will submit three types of events
 |===
 . Type something (e.g.: "Hello Mule!") in the "Secure Echo" text box, leave the drop down box value as "Administrator" and hit the "Send" button. You will see two events associated with the "TestEcho" resource id (one pre-invocation and one post-invocation). You will also see a response that looks a bit like this:
 +
-code,code-java----
- code,code-java
+[source,java]
+----
 Response: {"user":"administrator","phrase":"Hello Mule!"}
 ----
 

--- a/mule-user-guide/v/3.2/studio-components.adoc
+++ b/mule-user-guide/v/3.2/studio-components.adoc
@@ -65,6 +65,7 @@ image:python-component-24x16.png[python-component-24x16] |Python |Allows integra
 
 
 image:Component-24x16.png[Component-24x16] |Script |Makes a script written in Groovy, JavaScript, Python, or Ruby available to the application flow. |link:/mule-user-guide/v/3.2/script-component-reference[Script Component Reference]
+|===
 
 === Web Service Components
 
@@ -78,4 +79,4 @@ Web Service components provide the developer with the framework to reference cla
 
 image:Soap-24x16.png[Soap-24x16] |SOAP |Makes a web service available to the application flow via CXF. |link:/mule-user-guide/v/3.2/soap-component-reference[SOAP Component Reference]
 
-
+|===

--- a/mule-user-guide/v/3.2/studio-endpoints.adoc
+++ b/mule-user-guide/v/3.2/studio-endpoints.adoc
@@ -58,10 +58,10 @@ Endpoint configuration consists of two stages:
 While unique properties exist for various endpoints, most of these building blocks share common properties.
 
 [cols=",",]
-|=========
+|===
 |image:warning.png[warning] |The endpoint Properties panes shown throughout this page are typical, but not definitive for all situations. Keep in mind at all times that specific endpoint property panes and individual property fields vary depending on the type of endpoint _and_ how that endpoint is used within a flow.
 
-|=========
+|===
 
 === The General Tab
 
@@ -70,7 +70,7 @@ image:HTTPEndpointGen-1.png[HTTPEndpointGen-1]
 Typically, the *General* tab provides fields for the following:
 
 [cols=",",options="header",]
-|=====
+|===
 |Property |Description
 |*Display Name* |Defaults to the generic endpoint name. Change the display name, which must be alpha-numeric, to reflect the endpoint's specific role, e.g., `Order Entry Endpoint`
 |*Exchange-Pattern* |Defines the interaction between the client and server. The available patterns are *one-way* and **request-response**. A one-way exchange-pattern assumes that no response from the server is necessary, while a request-response exchange-pattern waits for the server to respond before it allows message processing to continue.
@@ -78,7 +78,7 @@ Typically, the *General* tab provides fields for the following:
 |*Host* |The default name is `localhost`. Enter the Fully Qualified Domain Name (FQDN) or IP address of the server.
 |*Port* |The port number used to connect to the server. (e.g., 80)
 |*Path* |Allows connection to the server using a path instead of a username and password. e.g., /enter/the/path
-|=====
+|===
 
 Depending on the Endpoint type (inbound or outbound); these additional parameters may appear on the General tab:
 
@@ -128,13 +128,13 @@ image:HTTPEndpointRef-1.png[HTTPEndpointRef-1]
 The *References* tab lets you configure an endpoint to use global element settings that you have previously specified. You can set references for the following:
 
 [cols=",",options="header",]
-|======
+|===
 |Property |Description
 |*Connector Reference* |Use the dropdown list to select a previously configured connector for this endpoint. If you have not created a connector for this type of endpoint, you can do so from this window by clicking *Add*. Click *Edit* to modify a previously created global element.
 |*Endpoint Reference* |Use the drop-down list to select a previously configured global endpoint reference. If you have not created a global element for this type of endpoint, you can do so from this window by clicking *Add*. Click *Edit* to modify a previously created global element.
 |*Global Transformers (Request)* |Enter the list of transformers that will be applied to a message before delivery. The transformers will be applied in the order they are listed.
 |*Global Transformers (Response)* |Enter a list of synchronous transformers that will be applied to the response before it is returned from the transport.
-|======
+|===
 
 === The HTTP Settings Tab
 
@@ -168,11 +168,11 @@ image:HTTPEndpointDoc-1.png[HTTPEndpointDoc-1]
 Studio bundles more that two dozen endpoints, and the list continues to grow. Three of these are available only for Mule Enterprise Edition, and therefore, the icons are rendered with light (rather than dark) blue backgrounds, as illustrated in the following table:
 
 [cols=",,",options="header",]
-|======
+|===
 |Database (JDBC) |FTP |WMQ
 |image:JDBC-Endpoint-E-24x16-1.png[JDBC-Endpoint-E-24x16-1] |image:FTP-Endpoint-E-24x16-1.png[FTP-Endpoint-E-24x16-1] |image:JMS-Endpoint-E-24x16-1.png[JMS-Endpoint-E-24x16-1]
 
-|======
+|===
 
 === Inbound and Outbound Endpoints
 
@@ -181,7 +181,7 @@ The endpoints in this list can be added to a flow as either an inbound or outbou
 The following table lists the exchange-pattern(s) supported by each endpoint. When an endpoint supports multiple exchange-patterns, the entry in *bold* represents the default exchange-pattern.
 
 [cols=",,,,",options="header",]
-|====
+|===
 |  |Endpoint |Description |Exchange Pattern(s) |Documentation
 |image:ajax-endpoint.png[ajax-endpoint] |AJAX |Asynchronously exchanges messages between an Ajax server and a browser. |one-way |link:/mule-user-guide/v/3.2/ajax-endpoint-reference[AJAX Reference]
 
@@ -206,7 +206,7 @@ image:Endpoint13.png[Endpoint13] |TCP |Sends or receives messages over a TCP soc
 
 image:vm-endpoint.png[vm-endpoint] |VM |Sends and receives messages via intra-VM component communication. |**one-way**, request-response |Consult the generic <<Configuration>> information given for Endpoints at the top of this page.
 
-|====
+|===
 
 === Inbound Only Endpoints
 
@@ -215,7 +215,7 @@ As their name implies, inbound-only endpoints can only consume messages; they ca
 The following table lists the exchange pattern(s) supported by each endpoint, with the default exchange pattern listed in *bold*.
 
 [cols=",,,,",options="header",]
-|=====
+|===
 |  |Endpoint |Description |Exchange Pattern(s) |Documentation
 |image:Endpoint5.png[Endpoint5] |IMAP |Email transport used to receive a message via IMAP. Turn on security to send IMAP messages via SSL. |one-way |link:/mule-user-guide/v/3.2/imap-endpoint-reference[IMAP Reference]
 
@@ -227,16 +227,17 @@ image:Salesforce-1.png[Salesforce-1] |Salesforce (Streaming) |Provides an easy w
 
 
 image:Twitter-1.png[Twitter-1] |Twitter (Streaming) |Provides an easy way to integrate with the Twitter API using Mule flows. |one-way |[Twitter Cloud Connector Reference]
+|===
 
 === Outbound Only Endpoints
 
 Outbound-only endpoints can send messages to other building blocks or external resources, but they cannot receive messages directly from external sources.
 
 [cols=",,,,",options="header",]
-|========
+|===
 |  |Endpoint |Description |Exchange Pattern(s) |Documentation
 |image:Endpoint9.png[Endpoint9] |SMTP |Sends email via the SMTP protocol. Turn on security to send SMTP messages via SSL. |one-way |Consult the generic <<Configuration>> information given for Endpoints at the top of this page.
 
-|========
+|===
 
 

--- a/mule-user-guide/v/3.2/studio-flow-controls.adoc
+++ b/mule-user-guide/v/3.2/studio-flow-controls.adoc
@@ -46,6 +46,7 @@ image:Choice-24x16.png[Choice-24x16] |Choice |Evaluates a message against specif
 
 
 image:round-robin-24x16.png[round-robin-24x16] |Round Robin |Iterates through a list of two or more message processors, sending successive messages to the next message processor on the list. When it reaches the end of the list, it jumps to the start of the list and resumes the iteration. |Coming Soon!
+|===
 
 === Flow Controls That Modify the Payload
 

--- a/mule-user-guide/v/3.2/studio-transformers.adoc
+++ b/mule-user-guide/v/3.2/studio-transformers.adoc
@@ -62,7 +62,7 @@ image:ruby-transformer-24x16.png[ruby-transformer-24x16] |Ruby |Implements a scr
 Each transformer in this group changes a Java object into another Java object, a Java object into some other data type (such as an HTTP request), or some non-Java data type (such as an HTTP response) into a Java object.
 
 [cols=",,,",options="header",]
-|===================================================
+|===
 |  |Java Object +
  Transformer |Description |Documentation
 |image:Transformer-24x16.png[Transformer-24x16] |Byte-Array-to-Object |Converts a byte array to an object, either by de-serializing the array or converting it to a string). |All of the configuration fields for this transformer are covered in the <<Common Transformer Configuration Fields>> section of this page.
@@ -93,13 +93,14 @@ image:Transformer-24x16.png[Transformer-24x16] |Serializable-to-Byte-Array |Conv
 
 
 image:Transformer-24x16.png[Transformer-24x16] |XML-to-Object |Uses XStream to convert XML into Java Bean graphs. |link:/mule-user-guide/v/3.2/xml-to-object-transformer-reference[XML-to-Object Transformer Reference]
+|===
 
 === Content Transformers
 
 This group of transformers modifies messages by adding to, deleting from, or converting a message payload (or a message header).
 
 [cols=",,,",options="header",]
-|====================================
+|===
 |  |Content +
  Transformer |Description |Documentation
 |image:Transformer-24x16.png[Transformer-24x16] |Append string |Appends a string to a message payload. |link:/mule-user-guide/v/3.2/append-string-transformer-reference[Append String Transformer Reference]
@@ -116,7 +117,7 @@ image:Transformer-24x16.png[Transformer-24x16] |Message-to-HTTP-Response |Create
 
 image:Transformer-24x16.png[Transformer-24x16] |Transformer Ref |References a transformer that is defined as a global element. |link:/mule-user-guide/v/3.2/transformer-reference[Transformer Reference]
 
-|====================================
+|===
 
 For detailed information on configuring standard and custom Transformers with an XML editor, see link:/mule-user-guide/v/3.2/using-transformers[Using Transformers].
 

--- a/mule-user-guide/v/3.3/flight-reservation-example.adoc
+++ b/mule-user-guide/v/3.3/flight-reservation-example.adoc
@@ -348,9 +348,9 @@ Invoked by the Foreach scope in the *ProcessReservation* flow, this flow provide
  +
  image:Acquire+seat+info+flow.png[Acquire+seat+info+flow]
 
- [width="99",cols="99a",options="header"]
- |===
- ^|*View the XML*
+[width="99",cols="99a",options="header"]
+|===
+^|*View the XML*
 |
 [source, xml, linenums]
 ----

--- a/mule-user-guide/v/3.3/session-variable-transformer-reference.adoc
+++ b/mule-user-guide/v/3.3/session-variable-transformer-reference.adoc
@@ -47,7 +47,7 @@ image:Studio_SessionVariablePPP.png[Studio_SessionVariablePPP]
 |`value="MyNewSessionVariableValue"`
 |===
 ....
-[tab,title="STUDIO Visual Editor"]
+[tab,title="XML Editor or Standalone"]
 ....
 [source, code, linenums]
 ----

--- a/mule-user-guide/v/3.4/catch-exception-strategy.adoc
+++ b/mule-user-guide/v/3.4/catch-exception-strategy.adoc
@@ -226,7 +226,7 @@ You can create one or more link:/mule-user-guide/v/3.4/error-handling[global exc
 +
 image:catch_global_both.png[catch_global_both]
 +
-width="100%",cols=",",options="header"]
+[width="100%",cols=",",options="header"]
 |===
 |Attribute |Value
 |*Display Name* |Unique name for the exception strategy, if you wish. (Not required in Standalone)
@@ -344,6 +344,7 @@ image:create_global.png[create_global]
 . To the `exception-strategy` element, add attributes according to the table below. Refer to code below.
 +
 [width="100%",cols=",",options="header"]
+|===
 |Attribute |Value
 |*ref* |Name of the global `catch-exception-strategy` in your project.
 |*doc:name* |Unique name for the exception strategy, if you wish (Not required in Standalone).

--- a/mule-user-guide/v/3.4/concur-connector.adoc
+++ b/mule-user-guide/v/3.4/concur-connector.adoc
@@ -251,8 +251,8 @@ image:5.png[5]
  .. Click *Create/Edit Structure*.
  .. Enter a name for the Map, and under *Type*, select *Element*.
  .. Add fields to the input structure according to the table below.
- +
- [width="100%",cols=",",options="header"]
++
+[width="100%",cols=",",options="header"]
 |===
 |Name |Type
 |comment |String

--- a/mule-user-guide/v/3.4/http-request-response-with-logger-example.adoc
+++ b/mule-user-guide/v/3.4/http-request-response-with-logger-example.adoc
@@ -52,7 +52,7 @@ Next, the flow uses a **link:/mule-user-guide/v/3.4/logger-component-reference[L
 ....
 image:logger.png[logger]
 ....
-[tab,title="Studio XML Editor"]
+[tab,title="XML Editor or Standalone"]
 ....
 [source, xml, linenums]
 ----
@@ -65,11 +65,11 @@ Finally, Mule moves the message to an **link:/mule-user-guide/v/3.4/echo-compone
 
 [tabs]
 ------
-[tab,title="Studio XML Editor"]
+[tab,title="Studio Visual Editor"]
 ....
 image:echo_flow.png[echo_flow]
 ....
-[tab,title="Studio XML Editor"]
+[tab,title="XML Editor or Standalone"]
 ....
 [source, xml, linenums]
 ----

--- a/mule-user-guide/v/3.4/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.4/mule-expression-language-date-and-time-functions.adoc
@@ -144,7 +144,7 @@ Equivalent to http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#g
 |DateTime() |Constructs a dateTime with the current time and the time zone and locale of the server. a|`#[payload = new org.mule.el.datetime.DateTime();]`
 |DateTime(calendar, locale)
 a|Constructs a dateTime with the calendar and locale specified.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !calendar !java.util.Calendar
@@ -155,7 +155,7 @@ locale = org.apache.commons.lang.LocaleUtils.toLocale('en_GB');
 payload = new org.mule.el.datetime.DateTime(calendar, locale);]`
 |DateTime(calendar)
 a|Constructs a dateTime with the calendar specified and the locale of the server.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !calendar !java.util.Calendar
@@ -164,18 +164,18 @@ a|`#[calendar = Calendar.getInstance();
 payload = new org.mule.el.datetime.DateTime(calendar);]`
 |DateTime(calendar)
 a|Constructs a dateTime with the calendar specified and the locale of the server.  
-[cols=",",options="header",]
-!====
+[%header%autowidth.spread]
+!===
 !Argument !Type
 !calendar !javax.xml.datatype.XMLGregorianCalendar
-!====
+!===
 a|`#[calendar = javax.xml.datatype.DatatypeFactory
 .newInstance().newXMLGregorianCalendar();`
  
 `payload = new org.mule.el.datetime.DateTime(calendar);]`
 |DateTime(date)
 a|Constructs a dateTime with the specified date and the locale and time zone of the server.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !date !java.util.Date
@@ -183,7 +183,7 @@ a|Constructs a dateTime with the specified date and the locale and time zone of 
 a|`#[payload = new org.mule.el.datetime.DateTime(new Date());]`
 |DateTIme(iso8601String)
 a|Construct a dateTime using the specified http://en.wikipedia.org/wiki/ISO_8601[iso8601] date.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !iso8601String !java.lang.String
@@ -191,7 +191,7 @@ a|Construct a dateTime using the specified http://en.wikipedia.org/wiki/ISO_8601
 a|`#[payload = new org.mule.el.datetime.DateTime('1994-11-05T08:15:30-05:00');]`
 |DateTime(String dateString, String format)
 a|Constructs a dateTime used a string containing a date time in the specified format. The format should be http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !dateString !java.lang.String
@@ -258,7 +258,7 @@ Equivalent to http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#a
 |Function |Description |Return Type |Example
 |withTimeZone(timezone);
 a|Changes the current dateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !timezone !String compatible with  http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -269,7 +269,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|`#[pstTimeZoneI
 ``#[phoenixInstant = server.dateTime.withTimeZone('America/Phoenix');]`
 |changeTimeZone(timezone)
 a|Changes the timezone of the instance. Effectively changing only the timezone of the instance.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !timezone !String compatible with http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -282,7 +282,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|`#[pstTimeZoneI
 A http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone(java.lang.String)[TimeZone.getTimeZone()] compatible string. a|`#[payload = server.dateTime.timeZone]`
 |withLocale(localeAsString);
 a|This method takes the string format of a locale and creates the locale object from it.
-[cols=",",options="header",]
+[%header%autowidth.spread]
 !===
 !Argument !Type
 !localAsString !String. The language code must be lowercase. The country code must be uppercase. The separator must be an underscore. The length must be correct.
@@ -299,11 +299,11 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|`#[payload = se
 |format() |Formats the instance in a string with the http://www.w3.org/TR/xmlschema-2/#isoformats[ISO8601] date time format. |string a|`#[payload = server.dateTime.format()]`
 |format(String pattern)
 a|Formats the instance in a specific format.
-[cols=",",options="header",]
-!====
+[%header%autowidth.spread]
+!===
 !Argument !Type
 !pattern !String. Compatible with http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat]
-!====
+!===
 |string +
 A representation of the instance using the specified format. a|`#[payload = server.dateTime.format(&quot;yyyy.MM.dd G 'at' HH:mm:ss z&quot;)]`
 |===

--- a/mule-user-guide/v/3.4/solace-jms.adoc
+++ b/mule-user-guide/v/3.4/solace-jms.adoc
@@ -27,4 +27,4 @@ The following example demonstrates how to configure Mule to use http://solacesy
     <jms:endpoint queue="queuename" name="JMSQueue" connector-ref="SolaceJMS" doc:name="JMS"/>
 ...
 </flow>
------
+----

--- a/mule-user-guide/v/3.5/datasense-query-editor.adoc
+++ b/mule-user-guide/v/3.5/datasense-query-editor.adoc
@@ -125,8 +125,8 @@ Click the drop-down menu to select any of the fields available for the selected 
 
 Click to select any of the following operators:
 
-[width="80%",cols=","]
-!========================================
+[%autowidth,width=80%]
+!===
 !< !less than
 !< = !less than or equal to
 != !equal to
@@ -134,7 +134,7 @@ Click to select any of the following operators:
 !> = !greater than or equal to
 !< > !not equal to
 !like !like
-!=======================================
+!===
 
 |*6* |Operator value input box. +
 Enter the value that the filter uses to evaluate the field.

--- a/mule-user-guide/v/3.5/dotnet-connector.adoc
+++ b/mule-user-guide/v/3.5/dotnet-connector.adoc
@@ -171,7 +171,7 @@ The first element in the flow is an HTTP connector. This connector accepts inbou
 
 [tabs]
 ------
-[tab,title=",",options="header"]
+[tab,title="Studio Visual Editor"]
 ....
 . Drag an HTTP endpoint into the canvas, then select it to open the properties editor console.
 . Configure the following HTTP parameters as follows: +

--- a/mule-user-guide/v/3.5/endpoint-configuration-reference.adoc
+++ b/mule-user-guide/v/3.5/endpoint-configuration-reference.adoc
@@ -64,14 +64,16 @@ comparator="org.mule.transport.file.comparator.OlderFirstComparator" reverseOrde
 An outbound endpoint can also be dynamic. This means that the endpoint's URI is the value of an link:/mule-user-guide/v/3.7/mule-expression-language-mel[expression], which is evaluated just before a message is sent to it. This allows the target of a message to be determined by its contents or the value of any message property. Dynamic endpoints can use either of the endpoint formats shown above.
 
 [width="100%",cols=","]
-*Dynamic Endpoints*
+|===
+^|*Dynamic Endpoints*
 
-[source,xml, linenums]
+a|[source,xml, linenums]
 ----
 <outbound-endpoint address="smtp://user:secret@#[message.outboundProperties['host']]"/>
  
 <jms:outbound-endpoint host="localhost" queue="#[app.registry['defaultJmsQueue']]"/>
 ----
+|===
 
  The only part of an endpoint URI that cannot be dynamic is the scheme. Don't do this:
 

--- a/mule-user-guide/v/3.5/mule-digital-signature-processor.adoc
+++ b/mule-user-guide/v/3.5/mule-digital-signature-processor.adoc
@@ -197,6 +197,11 @@ You can define the required configurations in either the Global Signature elemen
 
 The following procedure describes how to apply XML digital signatures to messages processed in a Mule flow.
 
+[tabs]
+------
+[tab,title="STUDIO Visual Editor"]
+....
+
 . Add a global *Signature* message processor to your application, applying a unique *Name* for the element and change the default value, `JCE_SIGNER`, in the *Default Signer* field  to XML_SIGNER (see image below, left).
 . Click the **XML Signer** tab (see image below, right), then configure the message processor's attributes according to the table below. Note that while the *Keystore Path* and *Keystore Password* are optional, this global element is the only place you can define a them for your Signature element.
 +

--- a/mule-user-guide/v/3.5/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.5/mule-expression-language-date-and-time-functions.adoc
@@ -214,7 +214,7 @@ a|
 
 |DateTime(calendar, locale) a|
 Constructs a DateTime with the calendar and locale specified.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -230,7 +230,7 @@ payload = new org.mule.el.datetime.DateTime(calendar, locale);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -244,7 +244,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.  
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !javax.xml.datatype.XMLGregorianCalendar
@@ -260,7 +260,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(date) a|
 Constructs a DateTime with the specified date and the locale and time zone of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !date !java.util.Date
@@ -273,7 +273,7 @@ a|
 
 |DateTIme(iso8601String) a|
 Construct a DateTime using the specified http://en.wikipedia.org/wiki/ISO_8601[iso8601] date.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !iso8601String !java.lang.String
@@ -286,7 +286,7 @@ a|
 
 |DateTime(String dateString, String format) a|
 Constructs a DateTime used a string containing a date time in the specified format. The format should be http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !dateString !java.lang.String
@@ -372,7 +372,7 @@ Equivalent to http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#a
 |Function |Description |Return Type |Example
 |withTimeZone(timezone); a|
 Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -389,7 +389,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |changeTimeZone(timezone) a|
 Changes the timezone of the instance. Effectively changing only the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -414,7 +414,7 @@ A http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone(j
 
 |withLocale(localeAsString); a|
 This method takes the string format of a locale and creates the locale object from it.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !localAsString !String. The language code must be lowercase. The country code must be uppercase. The separator must be an underscore. The length must be correct.
@@ -443,7 +443,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |format(String pattern) a|
 Formats the instance in a specific format.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !pattern !String compatible with http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat]

--- a/mule-user-guide/v/3.5/poll-reference.adoc
+++ b/mule-user-guide/v/3.5/poll-reference.adoc
@@ -284,6 +284,7 @@ All flows use an asynchronous processing strategy by default. If you do not set 
 . Configure the *Since Id* attribute of the Twitter connector according to the table below:
 +
 [width="100%",cols=",",options="header"]
+|===
 |Attribute |Value |Description |Sample XML
 |*sinceId* |string or Mule expression |Instructs the connector to return only those tweets with an ID greater than the value of the `lastID` variable. `lastID` is a flow variable that Mule creates, then updates every time the poll runs. |`sinceId="#[flowVars['lastID']]"`
 |===

--- a/mule-user-guide/v/3.5/solace-jms.adoc
+++ b/mule-user-guide/v/3.5/solace-jms.adoc
@@ -27,4 +27,4 @@ The following example demonstrates how to configure Mule to use http://solacesy
     <jms:endpoint queue="queuename" name="JMSQueue" connector-ref="SolaceJMS" doc:name="JMS"/>
 ...
 </flow>
------
+----

--- a/mule-user-guide/v/3.5/starting-and-stopping-mule-esb.adoc
+++ b/mule-user-guide/v/3.5/starting-and-stopping-mule-esb.adoc
@@ -173,7 +173,7 @@ To install Mule as a Windows service, go to the `$MULE_HOME/bin/` directory, th
 [source, code, linenums]
 ----
 mule install
-----  
+----
 
 To remove Mule from your Windows services, go to the `$MULE_HOME/bin/` directory, then run:
 
@@ -187,14 +187,14 @@ Once Mule is installed as a service, you can control it with the following comma
 [source, code, linenums]
 ----
 mule start|restart|stop
-----  
+----
 
 To start Mule with additional configuration, issue:
 
 [source, code, linenums]
 ----
 mule start -config <your-config-file.xml>
----- 
+----
 
 Once Mule is installed as a service, you can also use the Windows `net` utility to start or stop it:
 

--- a/mule-user-guide/v/3.5/wsdl-connectors.adoc
+++ b/mule-user-guide/v/3.5/wsdl-connectors.adoc
@@ -19,25 +19,20 @@ A WSDL endpoint enables you to easily invoke web services without link:/mule-use
 You must provide the full URL to the WSDL of the service to invoke, and you must supply a `method` parameter that tells Mule which operation to invoke on the service:
 
 ----
-
 wsdl:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
 ----
 
 The WSDL URL is prepended with the `wsdl:` prefix. Mule checks your class path to see if there is a WSDL provider that it can use to create a client proxy from the WSDL. Mule supports both Axis and CXF as WSDL providers. If you want to use a specific one, you can specify it on the URL as follows:
 
 ----
-----
 wsdl-cxf:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
-----
 ----
 
 or
 
 ----
------
 wsdl-axis:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
 ----
------
 
 In general, you should use the CXF WSDL endpoint. The one limitation of the CXF WSDL provider is that it does not allow you to use non-Java primitives (objects that are not a String, int, double, and so on). Sometimes the Axis WSDL generation will not work (incorrect namespaces are used), so you can experiment with each one to see which works best.
 

--- a/mule-user-guide/v/3.6/datasense-query-editor.adoc
+++ b/mule-user-guide/v/3.6/datasense-query-editor.adoc
@@ -128,8 +128,8 @@ Click the drop-down menu to select any of the fields available for the selected 
 
 Click to select any of the following operators:
 
-[width="80%",cols=","]
-!========================================
+[%autowidth,width=80%]
+!===
 !< !less than
 !< = !less than or equal to
 != !equal to
@@ -137,7 +137,7 @@ Click to select any of the following operators:
 !> = !greater than or equal to
 !< > !not equal to
 !like !like
-!=======================================
+!===
 
 |*6* |Operator value input box. +
 Enter the value that the filter uses to evaluate the field.

--- a/mule-user-guide/v/3.6/endpoint-configuration-reference.adoc
+++ b/mule-user-guide/v/3.6/endpoint-configuration-reference.adoc
@@ -64,14 +64,16 @@ comparator="org.mule.transport.file.comparator.OlderFirstComparator" reverseOrde
 An outbound endpoint can also be dynamic. This means that the endpoint's URI is the value of an link:/mule-user-guide/v/3.6/mule-expression-language-mel[expression], which is evaluated just before a message is sent to it. This allows the target of a message to be determined by its contents or the value of any message property. Dynamic endpoints can use either of the endpoint formats shown above.
 
 [width="100%",cols=","]
-*Dynamic Endpoints*
+|===
+^|*Dynamic Endpoints*
 
-[source,xml, linenums]
+a|[source,xml, linenums]
 ----
 <outbound-endpoint address="smtp://user:secret@#[message.outboundProperties['host']]"/>
  
 <jms:outbound-endpoint host="localhost" queue="#[app.registry['defaultJmsQueue']]"/>
 ----
+|===
 
  The only part of an endpoint URI that cannot be dynamic is the scheme. Don't do this:
 

--- a/mule-user-guide/v/3.6/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.6/http-listener-connector.adoc
@@ -1334,7 +1334,7 @@ See link:/mule-user-guide/v/3.6/tls-configuration[TLS Configuration] for more de
 . Complete the flow by adding any other building block after the HTTP Connector, such as a *Logger* component.
 
 ....
-[tab,title="Studio Visual Editor"]
+[tab,title="XML Editor"]
 ....
 
 For example:

--- a/mule-user-guide/v/3.6/http-request-connector.adoc
+++ b/mule-user-guide/v/3.6/http-request-connector.adoc
@@ -266,7 +266,7 @@ Additionally, you can also send form parameters with your request, included in t
 
 [tabs]
 ------
-[tab,title="XML Editor"]
+[tab,title="Studio Visual Editor"]
 ....
 
 [TIP]

--- a/mule-user-guide/v/3.6/mule-digital-signature-processor.adoc
+++ b/mule-user-guide/v/3.6/mule-digital-signature-processor.adoc
@@ -200,6 +200,11 @@ You can define the required configurations in either the Global Signature elemen
 
 The following procedure describes how to apply XML digital signatures to messages processed in a Mule flow.
 
+[tabs]
+------
+[tab,title="STUDIO Visual Editor"]
+....
+
 . Add a global *Signature* message processor to your application, applying a unique *Name* for the element and change the default value, `JCE_SIGNER`, in the *Default Signer* field  to XML_SIGNER (see image below, left).
 . Click the **XML Signer** tab (see image below, right), then configure the message processor's attributes according to the table below. Note that while the *Keystore Path* and *Keystore Password* are optional, this global element is the only place you can define a them for your Signature element.
 +

--- a/mule-user-guide/v/3.6/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.6/mule-expression-language-date-and-time-functions.adoc
@@ -214,7 +214,7 @@ a|
 
 |DateTime(calendar, locale) a|
 Constructs a DateTime with the calendar and locale specified.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -230,7 +230,7 @@ payload = new org.mule.el.datetime.DateTime(calendar, locale);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -244,7 +244,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.  
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !javax.xml.datatype.XMLGregorianCalendar
@@ -260,7 +260,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(date) a|
 Constructs a DateTime with the specified date and the locale and time zone of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !date !java.util.Date
@@ -273,7 +273,7 @@ a|
 
 |DateTIme(iso8601String) a|
 Construct a DateTime using the specified http://en.wikipedia.org/wiki/ISO_8601[iso8601] date.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !iso8601String !java.lang.String
@@ -286,7 +286,7 @@ a|
 
 |DateTime(String dateString, String format) a|
 Constructs a DateTime used a string containing a date time in the specified format. The format should be http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !dateString !java.lang.String
@@ -372,7 +372,7 @@ Equivalent to http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#a
 |Function |Description |Return Type |Example
 |withTimeZone(timezone); a|
 Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -389,7 +389,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |changeTimeZone(timezone) a|
 Changes the timezone of the instance. Effectively changing only the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone%28java.lang.String%29[TimeZone.getTimeZone()]
@@ -414,7 +414,7 @@ A http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getTimeZone(j
 
 |withLocale(localeAsString); a|
 This method takes the string format of a locale and creates the locale object from it.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !localAsString !String. The language code must be lowercase. The country code must be uppercase. The separator must be an underscore. The length must be correct.
@@ -443,7 +443,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |format(String pattern) a|
 Formats the instance in a specific format.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !pattern !String compatible with http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat]

--- a/mule-user-guide/v/3.6/siebel-connector.adoc
+++ b/mule-user-guide/v/3.6/siebel-connector.adoc
@@ -186,8 +186,8 @@ image:depedencies+error.png[depedencies+error]
 .. For the Siebel Business Services connector:
 +
 image:businessservicesconfig.png[businessservicesconfig]
-[width="100%",cols="50%,50%",options="header",]
 +
+[width="100%",cols="50%,50%",options="header",]
 |===
 |Field |Description
 |*Name* |Enter a name to this connector to reference it later.

--- a/mule-user-guide/v/3.6/solace-jms.adoc
+++ b/mule-user-guide/v/3.6/solace-jms.adoc
@@ -27,4 +27,4 @@ The following example demonstrates how to configure Mule to use http://solacesy
     <jms:endpoint queue="queuename" name="JMSQueue" connector-ref="SolaceJMS" doc:name="JMS"/>
 ...
 </flow>
------
+----

--- a/mule-user-guide/v/3.6/starting-and-stopping-mule-esb.adoc
+++ b/mule-user-guide/v/3.6/starting-and-stopping-mule-esb.adoc
@@ -198,7 +198,7 @@ Once Mule is installed as a service, you can also use the Windows `net` utility
 [source, code, linenums]
 ----
 net start|stop mule
----- 
+----
 
 == Common Parameters
 

--- a/mule-user-guide/v/3.6/using-bitronix-to-manage-transactions.adoc
+++ b/mule-user-guide/v/3.6/using-bitronix-to-manage-transactions.adoc
@@ -105,7 +105,7 @@ Bitronix integration provides a JMS caching connection factory, which you must u
     <bti:transaction-manager/>
  
 </mule-domain>
----- 
+----
 
 [cols=",",options="header",]
 |===

--- a/mule-user-guide/v/3.6/wsdl-connectors.adoc
+++ b/mule-user-guide/v/3.6/wsdl-connectors.adoc
@@ -19,25 +19,20 @@ A WSDL endpoint enables you to easily invoke web services without link:/mule-use
 You must provide the full URL to the WSDL of the service to invoke, and you must supply a `method` parameter that tells Mule which operation to invoke on the service:
 
 ----
-
 wsdl:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
 ----
 
 The WSDL URL is prepended with the `wsdl:` prefix. Mule checks your class path to see if there is a WSDL provider that it can use to create a client proxy from the WSDL. Mule supports both Axis and CXF as WSDL providers. If you want to use a specific one, you can specify it on the URL as follows:
 
 ----
-----
 wsdl-cxf:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
-----
 ----
 
 or
 
 ----
------
 wsdl-axis:http://www.webservicex.net/stockquote.asmx?WSDL&method=GetQuote
 ----
------
 
 In general, you should use the CXF WSDL endpoint. The one limitation of the CXF WSDL provider is that it does not allow you to use non-Java primitives (objects that are not a String, int, double, and so on). Sometimes the Axis WSDL generation will not work (incorrect namespaces are used), so you can experiment with each one to see which works best.
 

--- a/mule-user-guide/v/3.7/amazon-sns-connector.adoc
+++ b/mule-user-guide/v/3.7/amazon-sns-connector.adoc
@@ -278,11 +278,11 @@ amazon.sqs.queue.region=<SQS Queue Region>
 amazon.sqs.queue.url=<SQS Queue URL>
 ----
 +
-. Drag a **HTTP endpoint** onto the canvas and configure the following parameters: +
+. Drag a **HTTP endpoint** onto the canvas and configure the following parameters:
++
 image:sns-http-props.png[sns http config props]
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.7/anypoint-filter-processor.adoc
+++ b/mule-user-guide/v/3.7/anypoint-filter-processor.adoc
@@ -60,7 +60,7 @@ image:filters.png[filters]
 
 The Anypoint Filter processor allows you to filter messages according to the following four filter strategies:
 
-[cols="20a,40a,540a",options="header"]
+[cols="20a,40a,40a",options="header"]
 |===
 |Operation |Description |Example
 |*Filter by ip* |Type an IP address or regular expression to define the address or range from which the Filter can accept connections. |*Regex:* `192.168.1.10`, `192.168.1.*` (to allow the range from 1.0 to 1.254)

--- a/mule-user-guide/v/3.7/endpoint-configuration-reference.adoc
+++ b/mule-user-guide/v/3.7/endpoint-configuration-reference.adoc
@@ -64,14 +64,16 @@ comparator="org.mule.transport.file.comparator.OlderFirstComparator" reverseOrde
 An outbound endpoint can also be dynamic. This means that the endpoint's URI is the value of an link:/mule-user-guide/v/3.7/mule-expression-language-mel[expression], which is evaluated just before a message is sent to it. This allows the target of a message to be determined by its contents or the value of any message property. Dynamic endpoints can use either of the endpoint formats shown above.
 
 [cols=","]
-*Dynamic Endpoints*
+|===
+|*Dynamic Endpoints*
 
-[source,xml, linenums]
+a|[source,xml, linenums]
 ----
 <outbound-endpoint address="smtp://user:secret@#[message.outboundProperties['host']]"/>
  
 <jms:outbound-endpoint host="localhost" queue="#[app.registry['defaultJmsQueue']]"/>
 ----
+|===
 
 The only part of an endpoint URI that cannot be dynamic is the scheme. Don't do this:
 

--- a/mule-user-guide/v/3.7/ldap-connector.adoc
+++ b/mule-user-guide/v/3.7/ldap-connector.adoc
@@ -85,8 +85,8 @@ To install LDAP connector in Anypoint Studio, follow the steps below:
 image:ldap_install_updatesite.png["Anypoint Studio Install Window"]
 * Click *Next* and accept the License Agreement.
 * Restart Studio when prompted.
-* Now, the LDAP connector should appear in your Studio Palette: +
-
+* Now, the LDAP connector should appear in your Studio Palette:
++
 [.center.text-center]
 image:ldap_install_palette.png["Anypoint Studio palette - LDAP connector"]
 
@@ -261,7 +261,6 @@ config.url=<URL>
 . Drag an **HTTP endpoint** onto the canvas and configure the following parameters:
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.7/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.7/mule-expression-language-date-and-time-functions.adoc
@@ -220,7 +220,7 @@ a|
 
 |DateTime(calendar, locale) a|
 Constructs a DateTime with the calendar and locale specified.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -236,7 +236,7 @@ payload = new org.mule.el.datetime.DateTime(calendar, locale);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -250,7 +250,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(calendar) a|
 Constructs a DateTime with the calendar specified and the locale of the server.  
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !calender !javax.xml.datatype.XMLGregorianCalendar
@@ -266,7 +266,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]
 
 |DateTime(date) a|
 Constructs a DateTime with the specified date and the locale and time zone of the server.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !date !java.util.Date
@@ -279,7 +279,7 @@ a|
 
 |DateTIme(iso8601String) a|
 Construct a DateTime using the specified link:http://en.wikipedia.org/wiki/ISO_8601[iso8601] date.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !iso8601String !java.lang.String
@@ -292,7 +292,7 @@ a|
 
 |DateTime(String dateString, String format) a|
 Constructs a DateTime used a string containing a date time in the specified format. The format should be link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !dateString !java.lang.String
@@ -378,7 +378,7 @@ Equivalent to link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.h
 |Function |Description |Return Type |Example
 |withTimeZone(timezone); a|
 Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone()]
@@ -395,7 +395,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |changeTimeZone(timezone) a|
 Changes the timezone of the instance. Effectively changing only the timezone of the instance.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !timezone !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone()]
@@ -420,7 +420,7 @@ A link:http://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZ
 
 |withLocale(localeAsString); a|
 This method takes the string format of a locale and creates the locale object from it.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !localAsString !String. The language code must be lowercase. The country code must be uppercase. The separator must be an underscore. The length must be correct.
@@ -449,7 +449,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1) a|
 
 |format(String pattern) a|
 Formats the instance in a specific format.
-[cols="50%,50%",options="header"]
+[%header,cols="2*"]
 !===
 !Argument !Type
 !pattern !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat]

--- a/mule-user-guide/v/3.7/peoplesoft-connector.adoc
+++ b/mule-user-guide/v/3.7/peoplesoft-connector.adoc
@@ -152,8 +152,8 @@ image:ps_install_updatesite.png["Anypoint Studio Install Window"]
 
 * Click *Next* and accept the License Agreement.
 * Restart Studio when prompted.
-* Now, the PeopleSoft connector should appear in your Studio Palette: +
-
+* Now, the PeopleSoft connector should appear in your Studio Palette:
++
 [.center.text-center]
 image:ps_install_palette.png["Anypoint Studio palette - PeopleSoft Connector"]
 
@@ -470,8 +470,8 @@ config.componentInterfaceGetHistoryItems=<TRUE_OR_FALSE>
 ----
 +
 . Drag a **HTTP endpoint** onto the canvas and configure the following parameters:
-[options="header,autowidth"]
 +
+[options="header,autowidth"]
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.7/solace-jms.adoc
+++ b/mule-user-guide/v/3.7/solace-jms.adoc
@@ -27,4 +27,4 @@ The following example demonstrates how to configure Mule to use link:http://sol
     <jms:endpoint queue="queuename" name="JMSQueue" connector-ref="SolaceJMS" doc:name="JMS"/>
 ...
 </flow>
------
+----

--- a/mule-user-guide/v/3.8/amazon-sns-connector.adoc
+++ b/mule-user-guide/v/3.8/amazon-sns-connector.adoc
@@ -269,11 +269,11 @@ amazon.sqs.queue.region=<SQS Queue Region>
 amazon.sqs.queue.url=<SQS Queue URL>
 ----
 +
-. Drag a **HTTP connector** onto the canvas and configure the following parameters: +
+. Drag a **HTTP connector** onto the canvas and configure the following parameters:
++
 image:sns-http-props.png[sns http config props]
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.8/database-connector-examples.adoc
+++ b/mule-user-guide/v/3.8/database-connector-examples.adoc
@@ -40,7 +40,8 @@ The table below lists the parameters for the database used by these examples. If
 |===
 
 * Table `roles`. Primary key: `id` (role ID).
-[width="100%"cols=",",options="header",]
+
+[width="100%",cols=",",options="header",]
 |===
 |Column |Type
 |id |Integer
@@ -441,7 +442,7 @@ generatedata
 ////
 image:global_db_conn_Advanced.png[global_db_conn_Advanced]
 
-[width="100%",cols=",",options="header"]
+[%header%autowidth.spread]
 |===
 |Parameter |Value
 |*Use XA Transactions* | 
@@ -589,7 +590,7 @@ jdbc:mysql://xubuntu:3306/company?user=generatedata&password=generatedata&genera
 ////
 image:global_db_conn_Advanced.png[global_db_conn_Advanced]
 
-[width="100%",cols=",",options="header",]
+[%header%autowidth.spread]
 |===
 |Parameter |Value
 |*Use XA Transactions* | 

--- a/mule-user-guide/v/3.8/endpoint-configuration-reference.adoc
+++ b/mule-user-guide/v/3.8/endpoint-configuration-reference.adoc
@@ -64,14 +64,16 @@ comparator="org.mule.transport.file.comparator.OlderFirstComparator" reverseOrde
 An outbound endpoint can also be dynamic. This means that the endpoint's URI is the value of an link:/mule-user-guide/v/3.8/mule-expression-language-mel[expression], which is evaluated just before a message is sent to it. This allows the target of a message to be determined by its contents or the value of any message property. Dynamic endpoints can use either of the endpoint formats shown above.
 
 [cols=","]
-*Dynamic Endpoints*
+|===
+|*Dynamic Endpoints*
 
-[source,xml, linenums]
+a|[source,xml, linenums]
 ----
 <outbound-endpoint address="smtp://user:secret@#[message.outboundProperties['host']]"/>
  
 <jms:outbound-endpoint host="localhost" queue="#[app.registry['defaultJmsQueue']]"/>
 ----
+|===
 
 The only part of an endpoint URI that cannot be dynamic is the scheme. Don't do this:
 

--- a/mule-user-guide/v/3.8/ldap-connector.adoc
+++ b/mule-user-guide/v/3.8/ldap-connector.adoc
@@ -66,8 +66,8 @@ To install LDAP connector in Anypoint Studio, follow the steps below:
 image:ldap_install_updatesite.png["Anypoint Studio Install Window"]
 * Click *Next* and accept the License Agreement.
 * Restart Studio when prompted.
-* Now, the LDAP connector should appear in your Studio Palette: +
-
+* Now, the LDAP connector should appear in your Studio Palette:
++
 [.center.text-center]
 image:ldap_install_palette.png["Anypoint Studio palette - LDAP connector"]
 
@@ -294,7 +294,6 @@ config.url=<URL>
 . Drag an **HTTP endpoint** onto the canvas and configure the following parameters:
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.8/mule-expression-language-date-and-time-functions.adoc
+++ b/mule-user-guide/v/3.8/mule-expression-language-date-and-time-functions.adoc
@@ -241,7 +241,7 @@ Equivalent to link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.h
 ==========================
 |`DateTime(calendar, locale)` a|
 Constructs a DateTime with the calendar and locale specified.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -257,7 +257,7 @@ payload = new org.mule.el.datetime.DateTime(calendar, locale);]`
 
 |`DateTime(calendar)` a|
 Constructs a DateTime with the calendar specified and the locale of the server.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !calender !java.util.Calendar
@@ -271,7 +271,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]`
 
 |`DateTime(calendar)` a|
 Constructs a DateTime with the calendar specified and the locale of the server.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !calender !javax.xml.datatype.XMLGregorianCalendar
@@ -287,7 +287,7 @@ payload = new org.mule.el.datetime.DateTime(calendar);]`
 
 |`DateTime(date)` a|
 Constructs a DateTime with the specified date and the locale and time zone of the server.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !date !java.util.Date
@@ -300,7 +300,7 @@ Constructs a DateTime with the specified date and the locale and time zone of th
 
 |`DateTime(iso8601String)` a|
 Construct a DateTime using the specified link:http://en.wikipedia.org/wiki/ISO_8601[iso8601] date.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !iso8601String !java.lang.String
@@ -313,7 +313,7 @@ Construct a DateTime using the specified link:http://en.wikipedia.org/wiki/ISO_8
 
 |`DateTime(String dateString, String format)` a|
 Constructs a DateTime using a string containing a date time in the specified format. The format should be link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat] compatible.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !dateString !java.lang.String
@@ -400,7 +400,7 @@ Equivalent to link:http://docs.oracle.com/javase/8/docs/api/java/util/Calendar.h
 |Function |Description |Return Type
 |`withTimeZone(timezone);` a|
 Changes the current DateTime to match a defined timezone. Effectively changing the dateTime and the timezone of the instance.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !timezone !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone()]
@@ -419,7 +419,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1)
 
 |`changeTimeZone(timezone)` a|
 Changes the timezone of the instance. Effectively changing only the timezone of the instance.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !timezone !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone()]
@@ -445,7 +445,7 @@ String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/util/T
 
 |`withLocale(localeAsString);` a|
 This method takes the string format of a locale and creates the locale object from it.
-[cols="30%,70%",options="header"]
+[%header,cols="30,70"]
 !===
 !Argument !Type
 !localAsString !+String+. The language code must be lowercase. The country code must be uppercase. The separator must be an underscore. The length must be correct.
@@ -476,7 +476,7 @@ This allows chaining: server.dateTime.plusWeeks(1).plusDays(1)
 
 |`format(String pattern)` a|
 Formats the instance in a specific format.
-[cols="20%,80%",options="header"]
+[%header,cols="20,80"]
 !===
 !Argument !Type
 !pattern !String compatible with link:http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat]

--- a/mule-user-guide/v/3.8/netsuite-connector.adoc
+++ b/mule-user-guide/v/3.8/netsuite-connector.adoc
@@ -37,7 +37,7 @@ For compatibility details for your version see the link:link:/release-notes/nets
 ////
 The NetSuite connector is compatible with:
 
-[width="100%",cols="50%,50%",options="header"]
+[%header,cols="2*"]
 |===
 |Application/Service |Version
 |Anypoint Studio | 5.4.x and later

--- a/mule-user-guide/v/3.8/object-store-connector.adoc
+++ b/mule-user-guide/v/3.8/object-store-connector.adoc
@@ -307,7 +307,6 @@ Lets start with the flow to store employee data.
 image:objectstore-http-props-store.png[objectstore http config props for store endpoint]
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP
@@ -396,11 +395,11 @@ image:objectstore-http-props-store.png[objectstore http config props for store e
 Now lets add another flow to retrieve employee data stored previously.
 
 . Drag a *Flow Component* below the above flow.
-. Drag a *HTTP connector* onto the canvas and configure the following parameters: +
+. Drag a *HTTP connector* onto the canvas and configure the following parameters:
++
 image:objectstore-http-props-retrieve.png[objectstore http config props for retrieve endpoint]
 +
 [options="header,autowidth"]
-+
 |===
 |Parameter|Value
 |*Display Name*|HTTP
@@ -500,7 +499,8 @@ http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/m
 
 . Save and run the project as a Mule Application.
 . Open a web browser and enter the below to check the response.
-.. To store a employee record enter the URL: + `http://localhost:8081/store?id=1&name=David&lname=Malhar&age=10`.
+.. To store a employee record enter the URL: +
+`http://localhost:8081/store?id=1&name=David&lname=Malhar&age=10`.
 .. To retrieve a employee record enter the URL: +
 `http://localhost:8081/retrieve?id=1`
 +

--- a/mule-user-guide/v/3.8/peoplesoft-connector.adoc
+++ b/mule-user-guide/v/3.8/peoplesoft-connector.adoc
@@ -153,8 +153,8 @@ image:ps_install_updatesite.png["Anypoint Studio Install Window"]
 
 * Click *Next* and accept the License Agreement.
 * Restart Studio when prompted.
-* Now, the PeopleSoft connector should appear in your Studio Palette: +
-
+* Now, the PeopleSoft connector should appear in your Studio Palette:
++
 [.center.text-center]
 image:ps_install_palette.png["Anypoint Studio palette - PeopleSoft Connector"]
 
@@ -471,8 +471,8 @@ config.componentInterfaceGetHistoryItems=<TRUE_OR_FALSE>
 ----
 +
 . Drag a **HTTP endpoint** onto the canvas and configure the following parameters:
-[options="header,autowidth"]
 +
+[options="header,autowidth"]
 |===
 |Parameter|Value
 |*Display Name*|HTTP

--- a/mule-user-guide/v/3.8/solace-jms.adoc
+++ b/mule-user-guide/v/3.8/solace-jms.adoc
@@ -27,4 +27,4 @@ The following example demonstrates how to configure Mule to use link:http://sol
     <jms:endpoint queue="queuename" name="JMSQueue" connector-ref="SolaceJMS" doc:name="JMS"/>
 ...
 </flow>
------
+----

--- a/release-notes/v/latest/servicenow-connector-release-notes.adoc
+++ b/release-notes/v/latest/servicenow-connector-release-notes.adoc
@@ -183,13 +183,13 @@ There are no bug fixes in this release.
 |Issue|Description
 |Functional test cases  returning an error for three tables a|
 For the following tables:
-[cols="2,1",options="header"]
-!============================================
+[%header,cols="2,1"]
+!===
 !Display Table Name !Database Table Name
 !Asset Entitlement !ALM_ENTITLEMENT_ASSET
 !License Entitlement !ALM_ENTITLEMENT
 !User Entitlement !ALM_ENTITLEMENT_USER
-!============================================
+!===
 Functional test cases return the following error:
 ----
 "Operation against file 'alm_entitlement' was aborted by Business Rule 'Ensure Entitlements do not exceed rights^dab4b33b2bb92900c173448405da153e'. Business Rule Stack:Ensure Entitlements do not exceed rights"
@@ -370,13 +370,13 @@ There are no bug fixes in this release.
 |Issue|Description
 |CLDCONNECT-1935 a|
 For the following tables:
-[cols="2,1",options="header"]
-!============================================
+[%header,cols="2,1"]
+!===
 !Display Table Name !Database Table Name
 !Asset Entitlement !ALM_ENTITLEMENT_ASSET
 !License Entitlement !ALM_ENTITLEMENT
 !User Entitlement !ALM_ENTITLEMENT_USER
-!============================================
+!===
 Functional test cases return the following error:
 `Operation against file 'alm_entitlement' was aborted by Business Rule 'Ensure Entitlements do not exceed rights^dab4b33b2bb92900c173448405da153e'. Business Rule Stack:Ensure Entitlements do not exceed rights`
 


### PR DESCRIPTION
- fix unbalanced delimited blocks
- fix incorrect/duplicate tab titles
- fix broken block attribute lines
- shorten table delimiters to 4 characters
- use shorthand attributes for nested tables
- use consistent layout for assumptions table