### PR TITLE
migrate build to docs builder 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,17 +18,17 @@ buildscript {
 
   dependencies {
     classpath 'com.eriwen:gradle-css-plugin:2.12.0'
-    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0-M1'
-    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.0-M1'
+    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0'
+    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.0'
   }
 
-  // enable upon upgrading to 1.0.0-RC1 (the non-shaded jar)
-  //configurations.all {
-  //  resolutionStrategy {
-  //    // NOTE override JRuby version pulled in by AsciidoctorJ to work around hang in CodeRay
-  //    force 'org.jruby:jruby:9.0.5.0'
-  //  }
-  //}
+  configurations.all {
+    resolutionStrategy {
+      // NOTE override JRuby version required by AsciidoctorJ to work around hang in CodeRay
+      // TODO can we figure out why the version specified by the docs builder is not honored?
+      force 'org.jruby:jruby:9.0.5.0'
+    }
+  }
 }
 
 defaultTasks 'build'
@@ -100,9 +100,20 @@ task buildHtml(type: JavaExec, group: 'Build', description: 'Builds HTML pages.'
   maxHeapSize = builderMaxHeapSize
   jvmArgs = builderJvmArgs
   //outputs.dir siteDir
+  doFirst {
+    // NOTE revert residual changes to template(s), which may or may not be managed by git
+    if (!file(srcTemplatesDir).directory) {
+      if (git("status --porcelain $templatesDir", '.', true).startsWith('?? ')) {
+        file(templatesDir).deleteDir()
+      }
+      else {
+        git "checkout -- $templatesDir"
+      }
+    }
+  }
   doLast {
     // NOTE revert local changes to template(s), which may or may not be managed by git
-    if (copyTemplates.didWork) {
+    if (file(srcTemplatesDir).directory) {
       if (git("status --porcelain $templatesDir", '.', true).startsWith('?? ')) {
         file(templatesDir).deleteDir()
       }


### PR DESCRIPTION
* migrate build from docs builder 1.0.0-M1 to docs builder 1.0.0 version
* use correct number of columns for scroll-menu div (class="col-md-2" instead of class="col-md-1")
* transitively upgrades from Asciidoctor 1.5.2 to 1.5.4
* pin version of JRuby to 9.0.5.0
* revert residual changes to templates directory at start of buildHtml task
* base decision to revert template changes on whether assets repo has _templates folder

The upgrade to Asciidoctor 1.5.4 introduces the following changes:

* column width percentage values have a precision up to 4 decimal places, always total 100%
* every 10th line number in source listing is no longer enclosed in strong element
  - no visual change since CSS was already being used to suppress this style
* lists that use bullet glyph marker are now interpreted as lists
  - eg. https://docs.mulesoft.com/mule-user-guide/v/3.8/catch-exception-strategy
* videos URIs now include a URI scheme (e.g., https://)
  - eg. https://docs.mulesoft.com/anypoint-connector-devkit/v/3.8/setting-up-your-dev-environment
* hyphens are dropped from auto-generated alt text on images
* footnote numbers are wrapped in a sup element instead of a span element
  - eg. https://docs.mulesoft.com/mule-user-guide/v/3.8/hardware-and-software-requirements