### PR TITLE
migrate build to docs builder 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
 
   dependencies {
     classpath 'com.eriwen:gradle-css-plugin:2.12.0'
-    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.0'
-    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.0'
+    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.1'
+    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.1'
   }
 
   configurations.all {


### PR DESCRIPTION
- docs builder 1.0.1 uses stable IDs for tabs