### PR TITLE
Remove application props/add object store details

### DIFF
--- a/runtime-manager/v/latest/managing-application-data-with-object-stores.adoc
+++ b/runtime-manager/v/latest/managing-application-data-with-object-stores.adoc
@@ -27,12 +27,19 @@ Each connector contains instructions on how to use the Object Store module to st
 
 == Viewing Application Data
 
-To view application data, click the *Properties* tab when viewing your application. This tab contains a list of keys and values. You can view them as plain text, or as a list.
+If the deployed application is using the default user object store, you can view the object store data in Runtime Manager. 
 
-image:applicationdata.png[applicationdata]
+To view a deployed application's object store data, access the link:https://docs.mulesoft.com/runtime-manager/managing-cloudhub-applications[app settings] of your application, then select the *Application Data* link.  
 
-[TIP]
-You can make properties secure so that they're not visible via the Runtime Manager UI or anywhere else, see link:/runtime-manager/secure-application-properties[Secure Application Policies] for more.
+Each object store key will be displayed. If the value for a key is an appropriate type (such as a String or other primitive type), then the value will also be displayed. 
+
+== Persisting Object Store Data in CloudHub
+When you deploy an application which includes object stores, you can elect to persist object store data in CloudHub after the application stops. You can set this option when you first deploy an application, or later when you redeploy the application. 
+
+To persist object store data, access the link:https://docs.mulesoft.com/runtime-manager/managing-cloudhub-applications[app settings] of your application. Then check the *Persistent queues* checkbox. 
+
+[NOTE]
+Unlike on-prem Mule runtimes, in CloudHub object store data is persisted in Amazon database storage. It does not use Hazelcast data-grid technology. 
 
 == Semantics and Storage Limits
 


### PR DESCRIPTION
Application properties are not related to object stores. The link is called "Application Data", but it shows key-value pairs for the default user object store. It does not show Properties. Also added some other details.