### PR TITLE
migrate build to docs builder 1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
 
   dependencies {
     classpath 'com.eriwen:gradle-css-plugin:2.12.0'
-    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.1'
-    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.1'
+    builder 'com.mulesoft.documentation.builder:mule-docs-builder:1.0.2'
+    singlePageBuilder 'com.mulesoft.documentation.builder:mule-docs-single-page-builder:1.0.2'
   }
 
   configurations.all {
@@ -96,7 +96,7 @@ task buildHtml(type: JavaExec, group: 'Build', description: 'Builds HTML pages.'
   mustRunAfter setup
   classpath = buildscript.configurations.builder
   main = 'com.mulesoft.documentation.builder.Client'
-  args = ['-s', '.', '-d', siteDir, '-ghr', docsRepoUri, '-ghb', docsRepoBranchName, '-url', siteUri]
+  args = ['-s', projectDir.absolutePath, '-d', siteDir, '-ghr', docsRepoUri, '-ghb', docsRepoBranchName, '-url', siteUri]
   maxHeapSize = builderMaxHeapSize
   jvmArgs = builderJvmArgs
   //outputs.dir siteDir


### PR DESCRIPTION
- fix roaming URL(s) in site navigation
- specify source using absolute path