### PR TITLE
pin production assets to specific commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ task cloneAssetsRepo {
       git "fetch -q origin", assetsDir
     }
     else {
-      git "clone -q $assetsRepoUri $assetsDir", file(assetsDir).parent
+      git "clone -q -n $assetsRepoUri $assetsDir", file(assetsDir).parent
     }
     git "checkout -q -B $assetsRepoBranchName $assetsRepoCommit", assetsDir
   }

--- a/gradle/prod-profile.gradle
+++ b/gradle/prod-profile.gradle
@@ -1,8 +1,8 @@
 // Command to execute in CI:
 // ./gradlew -g .gradle --no-search-upward -Pprofile=prod -PbuildTag=$BUILD_TAG -PmaxHeapSize=4g clean publish
 ext {
-  assetsRepoBranchName = 'master'
-  assetsRepoCommit = "origin/$assetsRepoBranchName"
+  assetsRepoBranchName = 'prod'
+  assetsRepoCommit = '36f0a3126b07ed5b37a00f83aa8e4d726c9dfbef'
   publishCommitMessage = project.hasProperty('buildTag') ? project.property('buildTag') : 'publish changes'
   publishRepoBranchName = 'master'
   publishRepoUri = 'git@github.com:mulesoft/mulesoft-docs-build-output.git'


### PR DESCRIPTION
- pin production assets to specific commit in master branch
- don't checkout HEAD after cloning assets repository (handled by checkout command)