### PR TITLE
Update using-policies.adoc

### DIFF
--- a/api-manager/v/latest/using-policies.adoc
+++ b/api-manager/v/latest/using-policies.adoc
@@ -97,6 +97,39 @@ INFO  2015-09-28 15:37:54,214 [[leagues-rest].httpListenerConfig.worker.01] org.
 INFO  2015-09-28 15:37:54,214 [[leagues-rest].httpListenerConfig.worker.01] org.mule.api.processor.LoggerMessageProcessor: POLICY B
 ----
 
+== Applying and Removing Policies
+
+After declaring an endpoint for your API version, the following tabs on the link:/api-manager/tutorial-set-up-and-deploy-an-api-proxy#navigate-to-the-api-version-details-page[API version details page] become active: Applications, Policies, and SLA Tiers.
+
+To apply a policy to your endpoint:
+
+. Click *Policies* to view the list of available policies for your organization. 
+. Select individual policies to read their descriptions. When you find the one you want to apply, click *Apply*.
+. Depending on the policy, you may need to provide further configuration. See detailed instructions for configuring one of the available policies:
+
+** link:/api-manager/ldap-security-manager[LDAP policy]
+** link:/api-manager/oauth-2.0-provider-and-oauth-2.0-token-enforcement-policies[AES-based OAuth policy set]
+** link:/api-manager/pingfederate-oauth-token-enforcement-policy[PingFederate Policy]
+** link:/api-manager/openam-oauth-token-enforcement-policy[OpenAM Policy]
+** External Authorization
+
+A disabled *Apply* indicates one of the following conditions:
+
+* Another applied policy fulfills the requirement (see the Fulfills column)
+* Another policy must be applied first (see the Requires column)
+
+To remove policies, click *Remove*. To reapply the policy, reconfigure the policy. Your previous configuration is not saved.
+
+== Order of Policies
+
+The order of execution of policies is deterministic and can be configured if you are using one of the following releases:
+
+* Studio 6.0 for creation, deployed to Anypoint Platform with auto-discovery
+* Mule 3.8 unified runtime
+* API Gateway Runtime 2.2.0
+
+For previous versions, the order of execution is undetermined. 
+
 === Default Enforcement Order of Policies
 
 [%header,cols="5a,95a"]
@@ -129,36 +162,9 @@ OAuth 2.0 Provider
 Simple Security Manager
 |===
 
-== Applying and Removing Policies
+Custom policies that don't have an order configured will be executed after the Out of the Box policies listed above.
 
-After declaring an endpoint for your API version, the following tabs on the link:/api-manager/tutorial-set-up-and-deploy-an-api-proxy#navigate-to-the-api-version-details-page[API version details page] become active: Applications, Policies, and SLA Tiers.
-
-To apply a policy to your endpoint:
-
-. Click *Policies* to view the list of available policies for your organization. 
-. Select individual policies to read their descriptions. When you find the one you want to apply, click *Apply*.
-. Depending on the policy, you may need to provide further configuration. See detailed instructions for configuring one of the available policies:
-
-** link:/api-manager/ldap-security-manager[LDAP policy]
-** link:/api-manager/oauth-2.0-provider-and-oauth-2.0-token-enforcement-policies[AES-based OAuth policy set]
-** link:/api-manager/pingfederate-oauth-token-enforcement-policy[PingFederate Policy]
-** link:/api-manager/openam-oauth-token-enforcement-policy[OpenAM Policy]
-** External Authorization
-
-A disabled *Apply* indicates one of the following conditions:
-
-* Another applied policy fulfills the requirement (see the Fulfills column)
-* Another policy must be applied first (see the Requires column)
-
-To remove policies, click *Remove*. To reapply the policy, reconfigure the policy. Your previous configuration is not saved.
-
-== Setting the Order of Execution of Policies
-
-You can set the order of execution of applied policies on an application in Anypoint Platform if you are using one of the following releases:
-
-* Studio 6.0 for creation, deployed to Anypoint Platform with auto-discovery
-* Mule 3.8 unified runtime
-* API Gateway Runtime 2.2.0
+=== Setting the Order of Execution of Policies
 
 *To set the order of execution of applied policies:*
 


### PR DESCRIPTION
The default order of policies only applies to Gateways with version 2.2.0 and above so I moved the default order section to be part of the section that describes how to set the order. I don't know if the wording is the most accurate, please feel free to adjust it.