### PR TITLE
parameterize staging profile of build

### DIFF
--- a/gradle/staging-profile.gradle
+++ b/gradle/staging-profile.gradle
@@ -1,28 +1,34 @@
 // Command to execute in CI:
 // ./gradlew -g .gradle --no-search-upward -Pprofile=staging -PstagingIdentity=$CREDS -PmaxHeapSize=4g clean publish
 ext {
-  siteUri = 'http://docs-stg.mulesoft.com'
-  stagingUser = 'ec2-user'
-  stagingIdentity = project.hasProperty('stagingIdentity') ? project.property('stagingIdentity') : new File(System.getProperty('user.home'), '.ssh/id_rsa').toString()
-  stagingHost = 'docs-stg.mulesoft.com'
-  stagingDestinationDir = '/usr/share/nginx/html'
-  //stagingUser = System.getProperty('user.name')
-  //stagingHost = 'localhost'
-  //stagingDestinationDir = '/tmp/html'
+  if (project.hasProperty('stagingDocsRepoUri')) docsRepoUri = project.property('stagingDocsRepoUri')
+  siteUri = project.hasProperty('stagingSiteUri') ? project.property('stagingSiteUri') : 'http://docs-stg.mulesoft.com'
+  stagingHost = project.hasProperty('stagingHost') ? project.property('stagingHost') : 'docs-stg.mulesoft.com'
+  if (!stagingHost.empty && stagingHost != 'local') {
+    stagingUser = project.hasProperty('stagingUser') ? project.property('stagingUser') : 'ec2-user'
+    stagingIdentity = project.hasProperty('stagingIdentity') ? project.property('stagingIdentity') : new File(System.getProperty('user.home'), '.ssh/id_rsa').toString()
+  }
+  stagingDir = project.hasProperty('stagingDir') ? project.property('stagingDir') : '/usr/share/nginx/html'
 }
 
-task disallowRobots(group: 'Build', description: 'Disallows robots from crawling the site.') {
+task disallowRobots(group: 'Build', description: 'Disallows robots from crawling the site') {
   doLast {
     File robotsConfig = file("$siteDir/robots.txt")
     if (robotsConfig.file) robotsConfig.text = "User-agent: *\nDisallow: /"
   }
 }
 
-task publishToStaging(type: Exec, group: 'Publishing', description: 'Synchronizes site output to remote staging server') {
+// transfer status legend: http://stackoverflow.com/questions/4493525/rsync-what-means-the-f-on-rsync-logs/12037164#12037164
+task publishToStaging(type: Exec, group: 'Publishing', description: 'Synchronizes site output to staging server using rsync') {
   executable 'rsync'
-  // transfer status legend: http://stackoverflow.com/questions/4493525/rsync-what-means-the-f-on-rsync-logs/12037164#12037164
-  // QUESTION should we use --size-only to ignore timestamp changes?
-  args '-rtOzi', "-e ssh -i $stagingIdentity", '--delete-delay', "$siteDir/", "$stagingUser@$stagingHost:$stagingDestinationDir/"
+  if (stagingHost.empty || stagingHost == 'local') {
+    args '-rtOi', '--delete-delay', "$siteDir/", "$stagingDir/"
+  }
+  else {
+    // QUESTION is the link fast enough to disable compression?
+    // QUESTION should we use --size-only to ignore timestamp changes?
+    args '-rtOzi', "-e ssh -i $stagingIdentity", '--delete-delay', "$siteDir/", "$stagingUser@$stagingHost:$stagingDir/"
+  }
   if (dryRun) args = ['-n'] + args
 }
 


### PR DESCRIPTION
These changes allow the staging profile of the build to be reused for other environments (e.g., modusbox).