### PR TITLE
Update setting-up-an-api-proxy.adoc

### DIFF
--- a/api-manager/v/latest/setting-up-an-api-proxy.adoc
+++ b/api-manager/v/latest/setting-up-an-api-proxy.adoc
@@ -126,7 +126,30 @@ A new link appears under the API Status labeled *Re-deploy proxy*. If you make c
 +
 image:ReDeployProxy.png[ReDeployProxy]
 
+////
+=== To Pivotal Cloud Foundry
 
+[NOTE]
+This modality is only available with the Anypoint Platform On-premises Edition. For it to be available, you must first install and configure the link:ADD-LINK!!![PCF Tile].
+
+Currently, this modality is only availale via the command line. To instruct PCF to create and deploy a proxy, you must run the following command:
+
+[code]
+----
+$ some command, whatever the syntax is, who knows...
+----
+
+This command can include the following properties:
+
+[table]
+bla 
+bla 
+bla
+
+See link:/runtime-manager/deploying-to-pcf[Deploying to PCF] for more details.
+
+
+////
 
 === Downloading a Proxy
 

--- a/api-manager/v/latest/setting-up-an-api-proxy.adoc
+++ b/api-manager/v/latest/setting-up-an-api-proxy.adoc
@@ -91,13 +91,22 @@ image:api-gw-config-ep-wsdl.png[api-gw-config-ep-wsdl, width="300"]
 
 To deploy a proxy to API Gateway 2.x, follow instructions in the link:/api-manager/deploy-to-api-gateway-runtime[archive documentation].
 
-=== Deploying a Proxy to CloudHub
+== Deploying a Proxy
 
-You need valid permissions for the Runtime Manager and API Manager of your organization to deploy a proxy to CloudHub.
+[NOTE]
+You need valid permissions for the Runtime Manager and API Manager of your organization to deploy a proxy.
+
+=== To CloudHub
 
 . In the API Status section of the API version page, click *Deploy proxy* to deploy the proxy.
 +
-If you configured the proxy for deployment on Cloudhub in the *Configure endpoint* dialog, then the proxy is already deployed in Cloudhub. If you did not configure the proxy for deployment on Cloudhub, the *Deploy proxy* dialog appears.
+If you configured the proxy for deployment on Cloudhub in the *Configure endpoint* dialog, then the proxy is already deployed in Cloudhub.
+
+=== To a Server On-Premises
+
+. In the API Status section of the API version page, click *Deploy proxy* to deploy the proxy.
++
+If you did not configure the proxy for deployment on Cloudhub in the *Configure endpoint* dialog, the *Deploy proxy* dialog appears.
 +
 image::proxying-your-api-65680.png[proxying-your-api-65680]
 +
@@ -116,6 +125,8 @@ image:api-status-new-conf-green.png[api-status-new-conf-green]
 A new link appears under the API Status labeled *Re-deploy proxy*. If you make changes to the configuration, you can click this to re-deploy your proxy application to the same CloudHub application.
 +
 image:ReDeployProxy.png[ReDeployProxy]
+
+
 
 === Downloading a Proxy
 

--- a/api-manager/v/latest/setting-up-an-api-proxy.adoc
+++ b/api-manager/v/latest/setting-up-an-api-proxy.adoc
@@ -151,7 +151,7 @@ See link:/runtime-manager/deploying-to-pcf[Deploying to PCF] for more details.
 
 ////
 
-=== Downloading a Proxy
+== Downloading a Proxy
 
 You can download the latest or a legacy API Gateway Runtime in ZIP file format. The file is a deployable proxy application. 
 


### PR DESCRIPTION
The section was named "deploy a proxy to CloudHub" but it actually covered both the use case of deploying CloudHub and to an on-prem server...  this made it confusing, and is related to what the people in support said about distinguishing Runtime Manager from CloudHub. I hence called it "Deploy a proxy" and added sub-sections for each use case.

I also added a new third sub-section below this for explaining a third proxy deployment modality that will appear with PCF. This section is intentionally commented out, as it's a work in progress and talks about something that will only be available with the PCF release.

I also raised the priority of "Deploying a proxy" and "Downloading a proxy" from level 3 to level 2 so that they have more visibility.