### PR TITLE
remove client-side LESS compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
-// TODO
+import com.eriwen.gradle.css.tasks.CombineCssTask
+import com.eriwen.gradle.css.tasks.MinifyCssTask
+import java.nio.file.Files
+import java.nio.file.Paths
+
+// .TODO
 // * add mode to run jetty in background
-// * combine css (need to update template as well)
 // * set outputs.dir for custom tasks
+
 buildscript {
   configurations.create('builder')
   configurations.create('singlePageBuilder')
@@ -34,6 +39,7 @@ buildscript {
 defaultTasks 'build'
 group = 'com.mulesoft.documentation'
 
+apply plugin: 'css'
 apply from: 'gradle/git-helper.gradle'
 
 ext {
@@ -41,7 +47,7 @@ ext {
   assetsDir = '_assets'
   // TIP to test a remote branch, set assetsRepoBranchName = 'name' and assetsRepoCommit = "origin/$assetsRepoBranchName"
   assetsRepoBranchName = 'dev-tag'
-  assetsRepoCommit = '43dc3e19125365df5e100c3833fa5045d7b3e9bc'
+  assetsRepoCommit = 'ec4dc116e4ac4f87e1bb48e2aef2c15ce997b226'
   assetsRepoUri = 'https://github.com/mulesoft/mulesoft-docs-site-assets'
   builderMaxHeapSize = project.hasProperty('maxHeapSize') ? project.property('maxHeapSize') : '2500m'
   builderJvmArgs = ['-Xverify:none', '-XX:+OptimizeStringConcat', '-XX:+UseFastAccessorMethods', '-Djava.net.preferIPv4Stack=true', '-Djava.awt.headless=true']
@@ -60,11 +66,10 @@ ext {
 }
 
 if (file(profileBuildScript).exists()) apply from: profileBuildScript
-apply plugin: 'css'
 
 task cloneAssetsRepo {
   outputs.dir(assetsDir).upToDateWhen { false }
-  onlyIf { !file("$assetsDir/.gitkeep").file }
+  onlyIf { !Files.isSymbolicLink(Paths.get(assetsDir)) && !file("$assetsDir/.gitkeep").file }
   doLast {
     if (file("$assetsDir/.git").directory) {
       git "fetch -q origin", assetsDir
@@ -80,8 +85,14 @@ task setup(group: 'Build', description: 'Prepares the build.') {
   dependsOn cloneAssetsRepo
 }
 
+task cleanAssets(type: Delete) {
+  onlyIf { !Files.isSymbolicLink(Paths.get(assetsDir)) && !file("$assetsDir/.gitkeep").file }
+  delete assetsDir
+}
+
 task clean(type: Delete, group: 'Build', description: 'Deletes assets and site directories.') {
-  delete assetsDir, siteDir, tempDir
+  dependsOn cleanAssets
+  delete buildDir, siteDir, tempDir
 }
 
 // TODO site builder should accept a custom templates directory
@@ -138,7 +149,7 @@ task copyAssets(type: Copy) {
   from(assetsDir) {
     exclude 'README.md'
     exclude '_*/**'
-    //exclude 'css/*.less'
+    exclude 'css'
   }
   into siteDir
   //outputs.dir siteDir
@@ -151,12 +162,19 @@ task copyAssets(type: Copy) {
   //}
 }
 
+[csslint, combineCss, gzipCss, minifyCss].each { tasks.remove(it) }
+
 css {
   source {
-    main {
+    standard {
       css {
         srcDir "$assetsDir/css"
         include '*.css'
+      }
+    }
+    less {
+      css {
+        srcDir "$assetsDir/css"
         include '*.less'
       }
     }
@@ -166,20 +184,51 @@ css {
 lesscss {
   dependsOn setup
   mustRunAfter copyAssets
-  source = css.source.main.css.asFileTree
-  dest = file("$siteDir/css/")
+  source = css.source.less.css.asFileTree
+  dest = "${buildDir}/generated-css/mulesoft"
 }
 
-//def cssDir = "app/styles/"
-//def cssSrc = ["file1.css","file2.css"]
-//
-//combineCss {
-//    source = cssSrc.collect {cssDir+it}
-//    dest = "$buildDir/all.css"
-//}
+task combineMulesoftCss(type: CombineCssTask) {
+  source = lesscss
+  dest = "${buildDir}/css/mulesoft.css"
+  // NOTE the doFirst patch to sort the files can cause false UP-TO-DATE positive
+  outputs.upToDateWhen { false }
+  doFirst {
+    source = files(source.files.sort())
+  }
+}
+
+task combineVendorCss(type: CombineCssTask) {
+  source = files(css.source.standard.css.files.sort())
+  dest = "${buildDir}/css/vendor.css"
+}
+
+task minifyMulesoftCss(type: MinifyCssTask) {
+  source = combineMulesoftCss
+  dest = "${buildDir}/css/mulesoft.min.css"
+  yuicompressor {
+    lineBreakPos = 500
+  }
+}
+
+task minifyVendorCss(type: MinifyCssTask) {
+  source = combineVendorCss
+  dest = "${buildDir}/css/vendor.min.css"
+  yuicompressor {
+    lineBreakPos = 500
+  }
+}
+
+task combineAndMinifyCss(type: Copy, group: 'Build', description: 'Combined and minifies CSS files after compiling LESS files to CSS.') {
+  dependsOn minifyMulesoftCss, minifyVendorCss
+  from("${buildDir}/css") {
+    include '*.min.css'
+  }
+  into "${siteDir}/css"
+}
 
 task build(group: 'Build', description: 'Builds site.') {
-  dependsOn setup, buildHtml, copyAssets //, lesscss
+  dependsOn setup, buildHtml, copyAssets, combineAndMinifyCss
   mustRunAfter clean
 }
 

--- a/gradle/prod-profile.gradle
+++ b/gradle/prod-profile.gradle
@@ -3,7 +3,7 @@
 // ./gradle/consolidate-publish-repo.sh -q
 ext {
   assetsRepoBranchName = 'prod-tag'
-  assetsRepoCommit = '43dc3e19125365df5e100c3833fa5045d7b3e9bc'
+  assetsRepoCommit = 'ec4dc116e4ac4f87e1bb48e2aef2c15ce997b226'
   publishCommitMessage = project.hasProperty('buildTag') ? project.property('buildTag') : 'publish changes'
   publishRepoBranchName = 'master'
   publishRepoUri = 'git@github.com:mulesoft/mulesoft-docs-build-output.git'
@@ -48,7 +48,7 @@ task publishSiteDir {
 task publish(group: 'Build', description: 'Builds site and commits changes to publisher repository.')
 
 afterEvaluate {
-  clean.delete = assetsDir // don't delete _publish directory
+  clean.delete.retainAll(clean.delete - siteDir) // don't delete _publish directory
   //copyAssets.outputs.upToDateWhen { false }
   prepareSiteDir.dependsOn clonePublishRepo
   publish.dependsOn prepareSiteDir, build, publishSiteDir


### PR DESCRIPTION
- combine standard CSS stylesheets and copy to output folder as vendor.min.css
- compile and combine LESS stylesheets and copy to output folder as mulesoft.min.css
- update assets to use template that references combined/minified CSS files
- don't clean assets dir if it's a symlink or contains a .gitkeep file
- remove unused tasks added by the Gradle CSS plugin