### PR TITLE
Update setting-up-an-api-proxy.adoc

### DIFF
--- a/api-manager/v/latest/setting-up-an-api-proxy.adoc
+++ b/api-manager/v/latest/setting-up-an-api-proxy.adoc
@@ -114,7 +114,12 @@ image::proxying-your-api-b3c5e.png[proxying-your-api-b3c5e]
 === To Pivotal Cloud Foundry
 
 [NOTE]
+====
 This modality is in *Beta* and only available with the link:/anypoint-platform-on-premises[Anypoint Platform On-premises Edition]. For it to be available, you must first install and configure the link:ADD-LINK!!![PCF Tile].
+
+Also, the API's backend application needs to be deployed on the PCF platform before you can run the command that executes this.
+====
+
 
 Currently, this modality is only availale via the command line. To instruct PCF to create and deploy a proxy, you must run the command `cf bind-route-service`. This command must include the following arguments:
 


### PR DESCRIPTION
Added note about how the backend app needs to be on PCF for this to work.

There are several different use cases that can exist, and we need to clarify that we only support this one.