### PR TITLE
Fixes wrong url for importing a maven project into studio

### DIFF
--- a/anypoint-studio/v/6/using-maven-in-anypoint-studio.adoc
+++ b/anypoint-studio/v/6/using-maven-in-anypoint-studio.adoc
@@ -8,7 +8,7 @@ This section contains the following pages:
 * link:/anypoint-studio/v/6/maven-support-in-anypoint-studio[Maven Support in Anypoint Studio]
 * link:/anypoint-studio/v/6/building-a-mule-application-with-maven-in-studio[Building a Mule Application with Maven in Studio]
 * link:/anypoint-studio/v/6/enabling-maven-support-for-a-studio-project[Enabling Maven Support for a Studio Project]
-* link:/mule-user-guide/v/3.8/importing-a-maven-project-into-studio[Importing a Maven Project into Studio]
+* link:/anypoint-studio/v/6/importing-a-maven-project-into-studio[Importing a Maven Project into Studio]
 
 [NOTE]
 ====


### PR DESCRIPTION
This change fixes a wrong url in the Using Maven in Anypoint Studio page that points to importing a maven project into studio page