### PR TITLE
Update Mule 101 link

### DIFF
--- a/mule-user-guide/v/3.2/index.adoc
+++ b/mule-user-guide/v/3.2/index.adoc
@@ -10,4 +10,4 @@ link:/mule-management-console/v/3.4/mmc-walkthrough[Set up the *Mule Management 
 
 link:/anypoint-connector-devkit/v/3.4[Extend the Mule ESB with the *DevKit*]
 
-http://www.mulesoft.com/webinars/esb/mule-101-intro-to-mule[Watch the **Mule 101 Webinar** to learn the basic Mule concepts]
+https://www.mulesoft.com/webinars/api/mule-101-anypoint-platform-overview[Watch the **Mule 101 Webinar** to learn the basic Mule concepts]


### PR DESCRIPTION
Updated link to Mule 101 webinar produced in July 2016.  Previous asset created in early 2015.