### PR TITLE
Authorization Grant Types update in table

### DIFF
--- a/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
+++ b/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
@@ -70,10 +70,10 @@ The following table shows the mapping of the RAML grant types to the grant type 
 [%header,cols="3*a"]
 |===
 |Authorization Grant Types Defined in RAML Definition |Equivalent Authorization Grant Type to Enable in the OAuth Provider Policy |Supported in embedded APIkit Console?
-|`[token]` |Implicit |Yes
-|`[credentials]` |Client Credentials |No
-|`[owner]` |Resource Owner Password Credentials |No
-|`[code]` |Authorization Code |Yes
+|`[implicit]` |Implicit |Yes
+|`[client_credentials]` |Client Credentials |No
+|`[password]` |Resource Owner Password Credentials |No
+|`[authorization_code]` |Authorization Code |Yes
 |===
 
 == Configuring the OAuth 2.0 Token Validation Policy


### PR DESCRIPTION
the grant types in the table were RAML 0.8, but in de example RAML 1.0 grants were pointed out
maybe change the table and add 0.8 AND 1.0 types as they are so different