### PR TITLE
Update index.adoc

### DIFF
--- a/release-notes/v/latest/index.adoc
+++ b/release-notes/v/latest/index.adoc
@@ -57,7 +57,7 @@ link:/release-notes/anypoint-connector-devkit-studio-plugin-release-notes[DevKit
 
 *Documentation*: link:/apikit/[APIkit]
 
-|link:/release-notes/cloudhub-release-notes[CloudHub November 2015 R45] |An iPaaS platform that allows quick deployment, management, and scaling of Mule applications in the cloud. Multi-version release notes.
+|link:/release-notes/cloudhub-release-notes[CloudHub] |An iPaaS platform that allows quick deployment, management, and scaling of Mule applications in the cloud. Multi-version release notes.
 
 *Documentation*: link:/runtime-manager/cloudhub[CloudHub]
 


### PR DESCRIPTION
Removed the wording "November 2015 R45" from the CloudHub Release Notes Link