### PR TITLE
Fixed link to installation instructions

### DIFF
--- a/anypoint-platform-on-premises/v/1.5.0/index.adoc
+++ b/anypoint-platform-on-premises/v/1.5.0/index.adoc
@@ -17,7 +17,7 @@ The Anypoint Platform on-Premises Edition 1.5.0 is based on Kubernetes, and prov
 
 
 
-* link:/anypoint-platform-on-premises/v/1.1.0/installing-anypoint-on-premises[Installing Anypoint On-Premises]
+* link:/anypoint-platform-on-premises/v/1.5.0/installing-anypoint-on-premises[Installing Anypoint On-Premises]
 * link:https://docs.mulesoft.com/api-manager/[API Manager]
 * link:https://docs.mulesoft.com/runtime-manager/[Anypoint Runtime Manager]
 * link:https://docs.mulesoft.com/access-management/[Access Management]


### PR DESCRIPTION
The current link was pointing to the 1.1.0 version of the docs. Changed to point to 1.5.0 version