### PR TITLE
XML tag update for the domain example #2

### DIFF
--- a/mule-user-guide/v/3.8/_sources/shared-resources_02.xml
+++ b/mule-user-guide/v/3.8/_sources/shared-resources_02.xml
@@ -10,4 +10,4 @@
 
     <http:listener-config name="HTTP_Listener_Configuration" host="localhost" port="8081"/>
 
-</mule-domain>
+</domain:mule-domain>


### PR DESCRIPTION
The example domain project contains errors in the xml.  The closing xml tag should be `</domain:mule-domain>` instead of `</mule-domain>`.  The file is linked from https://github.com/mulesoft/mulesoft-docs/blob/master/mule-user-guide/v/3.8/shared-resources.adoc.