### PR TITLE
XML tag update for the domain example #7

### DIFF
--- a/mule-user-guide/v/3.8/_sources/shared-resources_07.xml
+++ b/mule-user-guide/v/3.8/_sources/shared-resources_07.xml
@@ -19,4 +19,4 @@
 
     <db:generic-config name="dbConfig" dataSource-ref="jdbcDataSource"/>
 
-</mule-domain>
+</domain:mule-domain>


### PR DESCRIPTION
The example domain project contains errors in the xml.  The closing xml tag should be `</domain:mule-domain>` instead of `</mule-domain>`.  The file is linked from https://github.com/mulesoft/mulesoft-docs/blob/master/mule-user-guide/v/3.8/shared-resources.adoc.