### PR TITLE
XML header and tag update for the domain example #9

### DIFF
--- a/mule-user-guide/v/3.8/_sources/shared-resources_09.xml
+++ b/mule-user-guide/v/3.8/_sources/shared-resources_09.xml
@@ -8,14 +8,6 @@
               http://www.mulesoft.org/schema/mule/ee/domain http://www.mulesoft.org/schema/mule/ee/domain/current/mule-domain-ee.xsd
               http://www.mulesoft.org/schema/mule/jbossts http://www.mulesoft.org/schema/mule/jbossts/current/mule-jbossts.xsd">
 
-
-<mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xmlns:jbossts="http://www.mulesoft.org/schema/mule/jbossts"
-             xsi:schemaLocation="
-                http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd
-                http://www.mulesoft.org/schema/mule/jbossts http://www.mulesoft.org/schema/mule/jbossts/current/mule-jbossts.xsd">
-
     <jbossts:transaction-manager/>
 
-</mule-domain>
+</domain:mule-domain>


### PR DESCRIPTION
Removing the outdated `<mule-domain>` tags and adding `<\domain:mule-domain> tag.  The file is linked from https://github.com/mulesoft/mulesoft-docs/blob/master/mule-user-guide/v/3.8/shared-resources.adoc.