### PR TITLE
XML tag update for the domain example #11

### DIFF
--- a/mule-user-guide/v/3.8/_sources/shared-resources_11.xml
+++ b/mule-user-guide/v/3.8/_sources/shared-resources_11.xml
@@ -25,4 +25,4 @@
 
     <bti:transaction-manager/>
 
-</mule-domain>
+</domain:mule-domain>


### PR DESCRIPTION
The example domain project contains errors in the xml.  The closing xml tag should be `</domain:mule-domain>` instead of `</mule-domain>`.  The file is linked from https://github.com/mulesoft/mulesoft-docs/blob/master/mule-user-guide/v/3.8/shared-resources.adoc.