### PR TITLE
Update release notes typo

### DIFF
--- a/release-notes/v/latest/anypoint-studio-6.1-with-3.8.2-runtime-update-site-2-release-notes.adoc
+++ b/release-notes/v/latest/anypoint-studio-6.1-with-3.8.2-runtime-update-site-2-release-notes.adoc
@@ -76,7 +76,7 @@ Then specify the location of your old version of Anypoint Studio in your local d
 
 === New Features
 
-* STUDIO-8358 - Excell DW support for studio
+* STUDIO-8358 - Excel DW support for studio
 
 
 == Support


### PR DESCRIPTION
Update the word "Excell" for "Excel" it takes only one L at the end.