### PR TITLE
The jsonplaceholder link had 2 "http://" prefixes

### DIFF
--- a/api-manager/v/latest/tutorial-create-an-api-portal.adoc
+++ b/api-manager/v/latest/tutorial-create-an-api-portal.adoc
@@ -14,7 +14,7 @@ The Home page appears in editing mode. You can edit the text using markdown.
 . Click one of the greyed-out icons in the body area to enter text, upload a graphic, or upload a file. For example, click the text icon.
 . Enter a t-shirt graphic and information about the API that you want to communicate to portal visitors.
 . Use the Add drop-down to add widgets and pages to the site:
-* Add an external link to the `Free JSON REST Service` at `http://http://jsonplaceholder.typicode.com/`.
+* Add an external link to the `Free JSON REST Service` at `http://jsonplaceholder.typicode.com/`.
 * Add a nav bar heading, `API Tools`.
 * Add an API reference (API Console) and retitle the nav bar item to `T-Shirt Ordering API Simulation`.
 +


### PR DESCRIPTION
Fixed the 2 http:// prefixes for the link to jsonplaceholder