### PR TITLE
Updating customize build pack documentation

### DIFF
--- a/anypoint-platform-on-premises/v/1.5.0/customize-mule-runtime-buildpack.adoc
+++ b/anypoint-platform-on-premises/v/1.5.0/customize-mule-runtime-buildpack.adoc
@@ -5,61 +5,31 @@
 ====
 Customizing a BuildPack is an optional step when link:/anypoint-platform-on-premises/configuring-anypoint-platform-for-pcf[configuring Anypoint Platform for PCF]. You can instead use the default Mule Runtime BuildPack, which includes Mule runtime 3.8.1.
 
-Each buildpack in named following a specific format: `mule-runtime-buildpack-<runtime_version_number>`
-For example: `mule-runtime-buildpack-3-8-1`
+Each buildpack in named following a specific format: `mule_runtime_buildpack_<runtime_version_number>`
+For example: `mule_runtime_buildpack_3_8_1`
 ====
 
 == Overview
 
-This extension of the link:https://github.com/cloudfoundry/java-buildpack[`java-buildpack`] is a Cloud Foundry buildpack for running link:/mule-fundamentals/v/3.8/anypoint-platform-primer[Mule applications].  It is designed to run both traditional Mule Integration applications and APIs (gateways and implementations) on both a Mule runtime (formerly known as Mule ESB) or an API Gateway runtime.
+This extension of the link:https://github.com/cloudfoundry/java-buildpack[`java-buildpack`] is a Cloud Foundry buildpack for running link:/mule-fundamentals/v/3.8/anypoint-platform-primer[Mule applications].  It is designed to run both traditional Mule Integration applications and APIs (gateways and implementations) on a Mule runtime (formerly known as Mule ESB).
 
 
 == Installation
 
-. Download the package form [????]
+. Download the Mule Runtime Buildpack (zip file).
 
-. Select the appropriate Mulesoft artifacts repository
-
-
-. Open the `config/mule.yml` from within the downloaded package. Point it to file to the repository where the BuildPack will find Mulesoft artifacts:
-
-* If using link:https://anypoint.mulesoft.com/apiplatform/jesusdeoliveira/#/portals/organizations/aa30fc71-3aa1-491f-b81a-464dd9e41f2e/apis/73317/versions/76323[Mulesoft's Nexus-2-buildpack repository proxy facility]: The Nexus-2-buildpack repository proxy is a cloud API that translates Nexus release catalogs into JavaBuilpack versioned component dependency repositories. You'll need an API key and secret and appropriate Nexus credentials in order to use this component:
-** Uncomment the appropriate section to use *API Gateway runtimes* or *Mule runtimes*.
-** Update the `version` variable according to the version of the runtime you want to make available through the buildpack. For example:
-*** if you want to enable all versions on the 3.x family, use `3.+`
-*** if you want to enable all minor versions of 3.7 family, use `3.7.+`
-*** If you want to enable only version 3.8.0, use `3.8.0`
-*** *more information about how the JavaBuildpack versioned dependency component resolves versions and syntax of version specifications, see link:https://github.com/cloudfoundry/java-buildpack/blob/master/docs/extending-repositories.md#version-syntax-and-ordering[here].*
-** Replace credentials appropriately:
-*** `<client_id>`: API key for your Mulesoft Nexus-2-buildpack repository proxy facility
-*** `<client_secret>`: API secret for your Mulesoft Nexus-2-buildpack repository proxy facility
-*** `<nexusUsername>`: Username for your Mulesoft EE Nexus repository
-*** `<nexusPassword>`: Password for your Mulesoft EE Nexus repository
-
-* Otherwise, if using a custom JavaBuildpack repository, update the `config/mule.yml` file accordingly (more information on how to set-up a custom JavaBuildpack repository can be found link:https://github.com/cloudfoundry/java-buildpack/blob/master/docs/extending-repositories.md[here]).
-
-
-. Select between Oracle JDK or Open JDK
-
-+
-The Anypoint Platform buildpack uses by default OpenJDK JRE. If you prefer to use Oracle JDK, please amend the appropriate entry on the `config/components.yml` file, on the `jres` section.
-
-+
-[NOTE]
-Due to licensing restrictions, if using Oracle JDK, you need to provision a JavaBuildpack versioned-component repository with the JDK distribution, and reference this repository on the `repository_root` parameter of the `config/oracle_jre` file. Information on how to set-up a custom JavaBuildpack versioned component repository can be found link:https://github.com/cloudfoundry/java-buildpack/blob/master/docs/extending-repositories.md[here]
-
-. Add a runtime license digest**
+. Unzip the buildpack and customize files or configuration depend on requirement.
 
 +
 Generate a runtime license digest using link:https://mulelicenseverifier.cloudhub.io/[MuleSoft License Verifier service] on your web browser:
 
 * Upload your Mule runtime license `.lic` file, obtained through the Customer Onboarding process, and click `Verify` button.
-* Download the digested license by clicking the `Download digested license` link and placing the generated `muleLicenseKey.lic` file in the `resources/mule/conf` directory.
+* Download the digested license by clicking the `Download digested license` link and placing the generated `muleLicenseKey.lic` file in the `resources/mule/conf` directory (create directories if doesnt exist).
 
 . Add additional resources**
 
 +
-The `resources/mule` directory replicates the *Mule runtime* or *API Gateway runtime* directory structure. Files and directories in this location will be **overlaid** on the expanded runtime upon deployment. Typical resources to add include:
+The `resources/mule` directory replicates the *Mule runtime* directory structure. Files and directories in this location will be **overlaid** on the expanded runtime upon deployment. Typical resources to add include:
 
 * Custom shared libraries (jar files) in `resources/mule/lib/user`
 * Patches (jar files) in `resources/mule/lib/user`, `resources/mule/lib/mule` and `resources/mule/plugins`
@@ -68,35 +38,10 @@ The `resources/mule` directory replicates the *Mule runtime* or *API Gateway run
 +
 Create the required directories as necessary. Refer to link:/mule-user-guide/v/3.8/classloader-control-in-mule[Mulesoft documentation] or Support Portal Knowledge Base for specific details on using custom libraries and patches.
 
+. Zip the buildpack with all the changes.
+ * zip -r <buildpack.zip file> <buildpackdir>
 
-. Commit your changes
-
-+
-Commit the above configuration changes, if any, to your local repository in order to keep track of changes. Feel free to use git branches to keep track of different teams or LoB specific customisations.
-
-+
-From this point, you can `cf push` applications using this builpack by referencing your git clone URL, for example:
-
-+
-```
-cf push -b https://github.com/myorg/mycloned-buildpack-repo myapp.zip
-```
-
-
-. Optionally, link:https://docs.run.pivotal.io/buildpacks/custom.html[package] your buildpack for installation:
-
-* If packaging an **online** buildpack, on the root of the git repo, execute `bundle exec rake package`.
-* If packaging an **offline** buildpack, on the root of the git repo, execute `bundle exec rake package OFFLINE=true`,
-
-+
-The package script will produce a zip file on the `build` directory, named `cf-mule-buildpack-<commit hash>.zip` or `cf-mule-buildpack-offline-<commit hash>.zip` if using the offline flag.
-
-+
-[NOTE]
-Observe that offline buildpacks can ONLY contain a SINGLE version of the Mule or API Gatweay runtime, the latest available on the configured repository described on step 2 above. Refer to link:https://github.com/cloudfoundry/java-buildpack#offline-package[CloudFoundry Java buildpack] for more information.
-
-
-. Optionally, link:https://docs.run.pivotal.io/buildpacks/custom.html[install] your buildpack on your PCF environment**
+. link:https://docs.run.pivotal.io/buildpacks/custom.html[install] your buildpack on your PCF environment**
 
 +
 Install the buildpack on your PCF environment/space by executing:
@@ -104,33 +49,24 @@ Install the buildpack on your PCF environment/space by executing:
 +
 `cf create-buildpack <BUILDPACK_NAME> <BUILDPACK_ZIP_PATH> <POSITION>`.
 
+* If you are using anypoint-onpremise for managing your apps then <BUILDPACK_NAME> should be in format `mule_runtime_buildpack_<runtime_version_number>`
+  For example: `mule_runtime_buildpack_3_8_1`
+
 +
 For example:
 
 +
-`cf create-buildpack anypoint-buildpack-3.8 build/cf-mule-buildpack-offline-a5587b4.zip 1`.
-
+`cf create-buildpack mule_runtime_buildpack_3_8_1 mule-runtime-buildpack-3.8.1.zip 1 --enable`.
 
 
 == Operation
 
-=== Application desing and configuration considerations
+=== Application design and configuration considerations
 
 ==== Inbound HTTP endpoints
 
 When designing your applications, keep in mind that CloudFoundry will automatically allocate an internal port on the container linked to the routes defined on the CF Router for the application. This port is supplied to the application through the java property `${http.port}`. *This will be the only port on which your application will receive inbound traffic*. Additionally, *applications can only provide a single HTTP listener component*.
 
-[NOTE]
-If using the API Gateway runtime, the runtime provides a pre-defined shared listener already configured to use this property, called `http-lc-0.0.0.0-8081`. Your application should reference this listener, for example:
-
-[source, xml, linenums]
-----
-xml
-  <flow ...>
-	<http:listener config-ref="http-lc-0.0.0.0-8081" path="/api/*" doc:name="HTTP"/>
-	...
-  </flow>
-----
 
 [NOTE]
 *Make sure your application DOES NOT provide the `http.port` variable on the `mule-app.properties` file, or configuration files loaded through Spring Properties Placeholders, as this overrides the port supplied through Cloud Foundry environment variables mechanims, preventing connectivity to your app once deployed.*
@@ -152,30 +88,10 @@ See a *minimal* example `manifest.yml` file below:
 ---
 applications:
 - name: simpleapi
-  buildpack: https://github.com/mulesoft-consulting/cf-java-buildpack
+  buildpack: mule_runtime_buildpack_3_8_1
   env:
     MYCUSTOM_ENV_VARIABLE: -mycustomflag=1234
 ----
-
-==== Deploying behind a proxy
-
-If your Cloud Foundry environment sits behind a proxy, and you are using an **online** buildpack, you'll need to supply proxy details to your app through the manifest file as described link:https://docs.cloudfoundry.org/buildpacks/proxy-usage.html[here].
-
-See an example `manifest.yml` file for this scenario below:
-
-[source, yaml, linenums]
-----
----
-applications:
-- name: simpleapi
-  buildpack: https://github.com/mulesoft-consulting/cf-java-buildpack
-  env:
-    GIT_SSL_NO_VERIFY: true
-    HTTP_PROXY: http://myusername:mypassword@proxy.myorg.com:80
-    HTTPS_PROXY: http://myusername:mypassword@proxy.myorg.com:80
-    NO_PROXY: host1.donotneedproxy.myorg.com, host2.donotneedproxy.myorg.com
-----
-
 
 ==== Memory allocation
 
@@ -190,116 +106,15 @@ JVM-specific configuration parameters can be supplied through the `JAVA_OPTS` me
 * a `JAVA_OPTS` [application environment variable](#application-specific-configuration),
 * the `config/java_opts` configuration file.
 
-
-==== Selecting a specific version of the runtime for an application
-
-If you need to specify a particular version of the *Mule Runtime* or the *API Gateway runtime* for your application, and you are using an **online* buildpack, you can request it through the application manifest file or the Cloud Foundry App Manager user interface, by supplying a `JBP_CONFIG_MULE` environment variable as below:
-
-----
-JBP_CONFIG_MULE={ version: <version number>, repository_root: "https://<client_id>:<client_secret>@pcf-buildpack-nexus-proxy.cloudhub.io/api/https/<nexusUsername>/<nexusPassword>/repository.mulesoft.org/443/releases-ee/com.mulesoft.muleesb.distributions/mule-ee-distribution-standalone" }
-----
-
-Replace the parameters as described on Step 2 [here](#Installation). More information about overriding components configuration options can be found link:https://github.com/cloudfoundry/java-buildpack#configuration-and-extension[here].
-
-See an example manifest file below, for an application that will use *Mule runtime* version `3.8.0`:
-
-[source, yaml, linenums]
-----
----
-applications:
-- name: simpleapi
-  buildpack: https://github.com/mulesoft-consulting/cf-java-buildpack
-  env:
-    JBP_CONFIG_MULE: { version: 3.8.0, repository_root: "https://430838984830283942:9384g1h9178219dgh213@pcf-buildpack-nexus-proxy.cloudhub.io/api/https/nexususer/dyen384yd/repository.mulesoft.org/443/releases-ee/com.mulesoft.muleesb.distributions/mule-ee-distribution-standalone" }
-----
-
-
 === Applying patches to Mule runtime
 
 Add MuleSoft patches (jar files) to the `resources/mule` directory structure as described [here](#application-specific-configuration).
 
 [NOTE]
-Pay special attention to the version of the runtime that patches apply to, and ensure it matches the versions the buildpack will consider as defined on the `config/mule.yml` file.
+Pay special attention to the version of the runtime that patches apply to, and ensure it matches the versions the buildpack will consider as defined on the `user_config.yml` file.
 
 
 == Integration with third-party components
-
-=== Anypoint API Manager integration
-
-*Only applies for API Gateway 2.x or Mule 3.8.+ runtimes*
-
-The *Anypoint API Manager* integration allows you to enforce policies (traffic shaping, security and custom cross-cutting concerns) and collect analytics on your applications deployed on Cloud Foundry, through the link:/api-manager/[API Manager] component.
-
-In order to manage an application through API Manager, you will need to provide the following environment variables to your applicationas, as described on section (#Application-specific-configuration):
-
-----
-ANYPOINT_PLATFORM_CLIENT_ID=<supply your anypoint org client id>
-ANYPOINT_PLATFORM_CLIENT_SECRET=<supply your anypoint org client secret>
-ANYPOINT_PLATFORM_BASE_URI: <base services URL of your APIManager instance>
-ANYPOINT_PLATFORM_CORESERVICE_BASE_URI: <core services URL of your APIManager instance>
-----
-
-
-For example, if using the cloud-based version of *Anypoint API Manager*, an application `manifest.yml` file will look like this:
-
-[source, yaml, linenums]
-----
----
-applications:
-- name: simpleapi
-  buildpack: https://github.com/mulesoft-consulting/cf-java-buildpack
-  env:
-    ANYPOINT_PLATFORM_BASE_URI: https://anypoint.mulesoft.com/apiplatform
-    ANYPOINT_PLATFORM_CORESERVICE_BASE_URI: https://anypoint.mulesoft.com/accounts
-    ANYPOINT_PLATFORM_CLIENT_ID: 49d79437365517a6b96e29549744a3e1
-    ANYPOINT_PLATFORM_CLIENT_SECRET: 8b037d2eea669bed28A7693418FeB297
-----
-
-Observe that these environment variables can be combined with Runtime Manager variables if both components are to be used.
-
-Additionally, you'll need to add an *API Autodiscovery* element on your application, to link it with the corresponding API entry on the API Manager component. For example:
-
-[source, xml, linenums]
-----
-<mule ...>
-	...
-	<api-platform-gw:api apiName="sAPI - Clients" version="1.0" flowRef="api-main" create="true" apikitRef="api-config" doc:name="API Autodiscovery"/>
-	...
-</mule>
-----
-
-Find more information about API Autodiscovery link:/anypoint-platform-for-apis/api-auto-discovery[here].
-
-
-
-=== Integration with Anypoint Runtime Manager
-
-To manage and control an application or API through the [Runtime Manager](https://docs.mulesoft.com/runtime-manager/) component, add the following environment variables to your app as described on section (#Application-specific-configuration):
-
-----
-ANYPOINT_ARM_HOST: <hostname of your Runtime Manager instance>
-ANYPOINT_ARM_ONPREM: true #remove this to use the cloud-based version of the Anypoint Platform
-ANYPOINT_USERNAME: <Anypoint Platform username with runtime registration privileges>
-ANYPOINT_PASSWORD: <Anypoint Platform user password>
-ANYPOINT_ENVIRONMENT: <Anypoint Platform environment>
-----
-
-For example, if using the cloud-based version of the *Anypoint Platform*, an application `manifest.yml` file will look like this:
-
-[source, yaml, linenums]
-----
----
-applications:
-- name: simpleapi
-  buildpack: https://github.com/mulesoft-consulting/cf-java-buildpack
-  env:
-    ANYPOINT_USERNAME: mythicaluser
-    ANYPOINT_PASSWORD: !123mySecurePassword123$
-    ANYPOINT_ENVIRONMENT: Production
-----
-
-Observe that these environment variables can be combined with API Manager variables if both components are to be used.
-
 
 === AppDynamics integration
 
@@ -312,37 +127,6 @@ See more details aboud App Dynamics integration link:https://github.com/cloudfou
 Other components/agents that are originally supported by the official link:https://github.com/cloudfoundry/java-buildpack[`java-buildpack`] can be enabled through the `config/components.yml` file, uncommenting entries as appropriate. Although these components/agents should use the Java Buildpack standard extension mechanisms to provide required flags to the JVM, bear in mind that these components are not tested nor supported by MuleSoft.
 
 == Debugging and troubleshooting
-
-=== Buildpack diagnostics information
-
-Run the following command on the buildpack clone repository root to produce diagnostics information of buildpack version and updated files:
-
-----
-$ ./cf-mule-buildpack-info
-----
-
-The output of this command will look like this:
-
-----
-
-Anypoint Platform buildpack diagnostics information
-===================================================
-Generated on the Mon 11 Jul 2016 17:05:57 BST
-
-Remotes:
-origin	https://github.com/mulesoft-consulting/cf-mule-buildpack (fetch)
-origin	https://github.com/mulesoft-consulting/cf-mule-buildpack (push)
-
-Latest commit from upstream (origin/master branch)
-* 1607833 (origin/master, origin/HEAD) Initial documentation for June 2016 release.
-
-Local customisations:
- 100.0% config/
-----
-
-This provides useful information about the version of the buildpack being used, the origin upstream repository where it was "cloned" from, and verifies that local customisations are on supported places.
-
-
 
 === Debugging buildpack provisioning process
 
@@ -380,7 +164,7 @@ More information on enabling SSH access can be found here: https://docs.cloudfou
 . Find JVM process PID**
 
 +
-You can determine the JVM process running the Mule runtime or API Gateway runtime through the following command:
+You can determine the JVM process running the Mule runtime through the following command:
 
 +
 ----


### PR DESCRIPTION
Published documentation is related to old way of updating mule build pack. In the latest release (1.5.0-beta), we are providing only zip file and users need to unzip the file and add files or update config and zip the build pack again to use.