### PR TITLE
Clarification on Quota Manager

### DIFF
--- a/api-manager/v/latest/rate-limiting-and-throttling-sla-based-policies.adoc
+++ b/api-manager/v/latest/rate-limiting-and-throttling-sla-based-policies.adoc
@@ -59,3 +59,9 @@ X-RateLimit-Remaining: 14
 X-RateLimit-Reset: 19100
 ----
 Within the next 19100 milliseconds, only 14 more requests are allowed by the SLA, which is set to allow 20 within this time-window.
+
+== Rate Limiting and Throttling in a Mule cluster
+
+When either of these policies is applied to a clustered environment a component called *cluster quota manager* is kicked in. This component manages the quota you set and distributes it among each of the members of the cluster. This behavior implies that each node must request a quota allowance to the quota manager in order to serve requests, if that quota is exhausted it will have to request more. If the quota manager doesn't allow for more quota, then the node will not be able to handle any more requests.
+
+Due to the normal latency in network communication, if you set a time period for request allowance that's too short it may happen that the time required to request and receive the quota between a node and the quota manager exceeds the quota lifetime and it will be already expired by the time it's received. Because of this we recommend not to use very short periods for these policies when running in a cluster. The minimal window would depend on many variables, such as workload and network speed, but as a rule of thumb period shouldn't be shorter than 20 seconds, a 1 minute period is recommended.

--- a/api-manager/v/latest/rate-limiting-and-throttling.adoc
+++ b/api-manager/v/latest/rate-limiting-and-throttling.adoc
@@ -15,6 +15,8 @@ Under the following conditions, you need to divide the rate limit by the number 
 +
 Use a load balancer that distributes requests equally.
 
+== Rate Limiting and Throttling in a Mule cluster
 
+When either of these policies is applied to a clustered environment a component called *cluster quota manager* is kicked in. This component manages the quota you set and distributes it among each of the members of the cluster. This behavior implies that each node must request a quota allowance to the quota manager in order to serve requests, if that quota is exhausted it will have to request more. If the quota manager doesn't allow for more quota, then the node will not be able to handle any more requests.
 
-
+Due to the normal latency in network communication, if you set a time period for request allowance that's too short it may happen that the time required to request and receive the quota between a node and the quota manager exceeds the quota lifetime and it will be already expired by the time it's received. Because of this we recommend not to use very short periods for these policies when running in a cluster. The minimal window would depend on many variables, such as workload and network speed, but as a rule of thumb period shouldn't be shorter than 20 seconds, a 1 minute period is recommended.


### PR DESCRIPTION
I've just added a short paragraph explaining quota manager for throttling policies in a cluster and adding a recommendation not to use a very short time window. This comes after discussing with engineering for a couple support cases we had,