### PR TITLE
SMTP Server must use a secure connection

### DIFF
--- a/access-management/v/latest/on-premises-features.adoc
+++ b/access-management/v/latest/on-premises-features.adoc
@@ -41,6 +41,7 @@ After you set your configuration, click the *Save* button below.
 
 [CAUTION]
 --
+Currently, only secure connections are supported for SMTP meaning the SMTP server certificate must be valid.
 You can't configure *Runtime Manager* notifications using this Access Management UI. +
 The *Runtime Manager* notification needs to be configured link:/anypoint-platform-on-premises/v/1.5.0/setting-smtp-manually[during installation].
 


### PR DESCRIPTION
Only valid certificates (no self-signed) are supported for API Manager alerts throw SMTP.