### PR TITLE
Mule-Api-Version should be 1.0

### DIFF
--- a/mule-user-guide/v/3.6/windows-gateway-services-guide.adoc
+++ b/mule-user-guide/v/3.6/windows-gateway-services-guide.adoc
@@ -85,7 +85,7 @@ The authentication of the connector is done through a security token included in
 GET: https://localhost:9333/msmq?count=50
 Authorization: mule test-token
 Mule-Msmq-Queue-Name: .\private$\out
-Mule-Api-Version: 1
+Mule-Api-Version: 1.0
 ----
 
 Configure the token on the connector and also in the Gateway configuration file. The following configuration sections show how the token is configured in both sides.

--- a/mule-user-guide/v/3.7/windows-gateway-services-guide.adoc
+++ b/mule-user-guide/v/3.7/windows-gateway-services-guide.adoc
@@ -112,7 +112,7 @@ As said, the authentication is done through this unique security token used by b
 GET: https://localhost:9333/msmq?count=50
 Authorization: mule 3nGdw7W+G1fSO2YBEHDmpo4N1Tg=
 Mule-Msmq-Queue-Name: .\private$\out
-Mule-Api-Version: 1
+Mule-Api-Version: 1.0
 ----
 
 The authorization token should match on the connector and the Gateway configuration file. The following configuration setting shows how the token is set within the Gateway configuration file  `Mule.SelfHost.exe.config` :

--- a/mule-user-guide/v/3.8/windows-gateway-services-guide.adoc
+++ b/mule-user-guide/v/3.8/windows-gateway-services-guide.adoc
@@ -105,7 +105,7 @@ As said, the authentication is done through this unique security token used by b
 GET: https://localhost:9333/msmq?count=50
 Authorization: mule 3nGdw7W+G1fSO2YBEHDmpo4N1Tg=
 Mule-Msmq-Queue-Name: .\private$\out
-Mule-Api-Version: 1
+Mule-Api-Version: 1.0
 ----
 
 The authorization token should match on the connector and the Gateway configuration file. The following configuration setting shows how the token is set within the Gateway configuration file  `Mule.SelfHost.exe.config` :


### PR DESCRIPTION
The Windows Gateway Service responds with "API version not specified or invalid" when Mule-Api-Version: "1".  Works with "1.0".