### PR TITLE
dead link

### DIFF
--- a/mule-user-guide/v/3.8/box-connector.adoc
+++ b/mule-user-guide/v/3.8/box-connector.adoc
@@ -22,7 +22,7 @@ This document assumes that you are familiar with Mule, link:/mule-user-guide/v/3
 
 To use the Box connector, you must have the following:
 
-* **Anypoint Studio:** if you don't use Anypoint Studio for development, follow the link:#mavenized-app[instructions] on specifying Maven dependencies in your `pom.xml` file.
+* **Anypoint Studio:** if you don't use Anypoint Studio for development, follow the link:/mule-user-guide/v/3.8/box-connector#using-the-connector-in-a-mavenized-mule-app[instructions] about specifying Maven dependencies in your `pom.xml` file.
 * A **Developer account** or other valid Box instance. You can obtain one from the https://developer.box.com/[Box Developer Platform].
 
 


### PR DESCRIPTION
Link is dead and seems like it should point to https://docs.mulesoft.com/mule-user-guide/v/3.8/box-connector#using-the-connector-in-a-mavenized-mule-app.