### PR TITLE
Edit code samples in documentation

### DIFF
--- a/mule-user-guide/v/3.7/creating-custom-transformer-classes.adoc
+++ b/mule-user-guide/v/3.7/creating-custom-transformer-classes.adoc
@@ -1,7 +1,7 @@
 = Creating Custom Transformer Classes
 :keywords: customize, custom transformers
 
-A custom transformer is a user-defined transformer class that implements `org.mule.api.transformer.Transformer.` Your class can extend link:http://www.mulesoft.org/docs/site/3.7.0/apidocs/org/mule/transformer/AbstractTransformer.html[`AbstractTransformer`] or link:http://www.mulesoft.org/docs/site/3.7.0/apidocs/org/mule/transformer/AbstractMessageTransformer.html[`AbstractMessageTransformer`], depending on your needs. This page describes how to create a custom transformer in more detail.
+A custom transformer is a user-defined transformer class that implements `org.mule.api.transformer.Transformer`. Your class can extend link:http://www.mulesoft.org/docs/site/3.7.0/apidocs/org/mule/transformer/AbstractTransformer.html[`AbstractTransformer`] or link:http://www.mulesoft.org/docs/site/3.7.0/apidocs/org/mule/transformer/AbstractMessageTransformer.html[`AbstractMessageTransformer`], depending on your needs. This page describes how to create a custom transformer in more detail.
 
 Access link:/mule-user-guide/v/3.7/transformer-annotation[Transformer Annotation] if you are looking for information about creating a transformer with the Transformer Annotation.
 
@@ -19,7 +19,7 @@ public class OrderToHtmlTransformer extends AbstractTransformer
 }
 ----
 
-If you need to transform the message header and attachments, you can use `AbstractMessageTransformer `instead to change them directly on the message passed in. In this case, you return the transformed message payload by overriding the method `transform(MuleMessage message, String encoding)`. You can use `message.getProperty(Object key)` to retrieve the properties or `message.setProperty(Object key, Object value)` to set properties on the transformed message.
+If you need to transform the message header and attachments, you can use `AbstractMessageTransformer` instead to change them directly on the message passed in. In this case, you return the transformed message payload by overriding the method `transform(MuleMessage message, String encoding)`. You can use `message.getProperty(Object key)` to retrieve the properties or `message.setProperty(Object key, Object value)` to set properties on the transformed message.
 
 For example:
 
@@ -59,7 +59,7 @@ Notice that the above code sets the name of the transformer. Usually, you set th
 
 All objects in Mule have lifecycles associated with them. For transformers, there are two lifecycle methods that are most useful.
 
-By default `AbstractMessageTransformer` and `AbstractTransformer `both implement the `org.mule.api.lifecycle.Initialisable` interface. After all bean properties are set on the transformer (if any), the `doInitialise()` method is called. This is useful for transformers to do any initialization or validation work. For example, if a transformer requires that an external file be loaded before the transformer can operate, you would load the file via the `doInitialise()` method.
+By default `AbstractMessageTransformer` and `AbstractTransformer` both implement the `org.mule.api.lifecycle.Initialisable` interface. After all bean properties are set on the transformer (if any), the `doInitialise()` method is called. This is useful for transformers to do any initialization or validation work. For example, if a transformer requires that an external file be loaded before the transformer can operate, you would load the file via the `doInitialise()` method.
 
 If you want your transformer to clear up resources when the transformer is no longer needed, your transformer must implement `org.mule.api.lifecycle.Disposable` and implement the `dispose()` method.
 


### PR DESCRIPTION
Some sentences were entirely set to `code` style and not just the concerned words