### PR TITLE
Update mock-message-processor.adoc

### DIFF
--- a/munit/v/1.2.1/mock-message-processor.adoc
+++ b/munit/v/1.2.1/mock-message-processor.adoc
@@ -16,7 +16,7 @@ Defining a mock entails several tasks, listed in the sections below.
 
 Using the parameters entailed in the above tasks, you can tell MUnit how to replace the normal behavior of the message processor with the one you define.
 
-NOTE: It is not possible to mock flow control message processors, such as Filter or Choice.
+NOTE: It is not possible to mock flow control message processors, such as Filter, Choice or APIKit Router.
 
 For the purpose of this documentation, we assume we are testing the following Mule code:
 


### PR DESCRIPTION
Added a clarification that mocking APIKit router is not supported