### PR TITLE
Corrected simple connector typo

### DIFF
--- a/mule-user-guide/v/3.6/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.6/http-listener-connector.adoc
@@ -1319,7 +1319,7 @@ Notice that when setting this attribute to ALWAYS or NEVER,  the HTTP Listener 
 
 You can set the connector to work with HTTPS protocol rather than HTTP protocol. This is set up at a global element level, all connector instances that reference a global element configured to use HTTPS will work with this protocol.
 
-If your connectos's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it will be implementing two-way TLS.
+If your connector's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it will be implementing two-way TLS.
 
 See link:/mule-user-guide/v/3.6/tls-configuration[TLS Configuration] for more details.
 

--- a/mule-user-guide/v/3.7/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.7/http-listener-connector.adoc
@@ -1292,7 +1292,7 @@ Notice that when setting this attribute to ALWAYS or NEVER,  the HTTP Listener
 
 You can set the connector to work with HTTPS protocol rather than HTTP protocol. This is set up at a global element level, all connector instances that reference a global element configured to use HTTPS works with this protocol.
 
-If your connectos's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it is implementing two-way TLS.
+If your connector's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it is implementing two-way TLS.
 
 See TLS Configuration for more details.
 

--- a/mule-user-guide/v/3.8/http-listener-connector.adoc
+++ b/mule-user-guide/v/3.8/http-listener-connector.adoc
@@ -1207,7 +1207,7 @@ Notice that when setting this attribute to ALWAYS or NEVER,  the HTTP Listener
 
 You can set the connector to work with HTTPS protocol rather than HTTP protocol. This is set up at a global element level, all connector instances that reference a global element configured to use HTTPS works with this protocol.
 
-If your connectos's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it is implementing two-way TLS.
+If your connector's TLS/SSL configuration includes a trust store, then this implicitly enforces that incoming requests require client authentication. If your configuration includes both a trust store and a key store, then it is implementing two-way TLS.
 
 See TLS Configuration for more details.
 


### PR DESCRIPTION
Trivial changes - just found 3 instances where connector was misspelled.