### PR TITLE
Small fix in code snippet type in Dataweave introduction

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
+++ b/mule-user-guide/v/3.8/dataweave-language-introduction.adoc
@@ -489,7 +489,7 @@ A selector allows for the navigation and querying the multiple levels of a data-
 [tab,title="Input: XML"]
 ....
 .Input
-[source, json,linenums]
+[source, xml,linenums]
 ----
 <users>
   <user>Mariano</user>


### PR DESCRIPTION
I think this should fix this garbled xml snippet:

<img width="812" alt="screen shot 2017-01-20 at 14 52 53" src="https://cloud.githubusercontent.com/assets/5757489/22159543/2cd0bb32-df20-11e6-8e5e-86cfb40f71d3.png">
