### PR TITLE
Update twilio-connector.adoc

### DIFF
--- a/mule-user-guide/v/3.7/twilio-connector.adoc
+++ b/mule-user-guide/v/3.7/twilio-connector.adoc
@@ -28,3 +28,16 @@ image:TwilioSetup3.png[TwilioSetup3]
 
 [TIP]
 As you copy fields from the Twilio website to the Anypoint Studio connector configuration, be sure that you do not copy in additional leading/trailing characters or spaces. It is a good idea to visually confirm that your copy and paste functions did not capture surrounding characters.
+
+== Configuring the Global Element
+
+To use the Twilio connector in your Mule application, you must configure a global element that can be leveraged by all the Twilio connectors in your application. Note that using the Global Element creation wizard to define the Twilio configuration will only create part of the required xml construct (namely the outer twilio: config element with the provided accountSid and authToken attributes). In order to avoid a schema validation error when deploying the application, it is necessary to embed at a minimum the following construct: <twilio:http-callback-config />. 
+
+To do so, switch to the Configuration XML view of the application, locate the outer:twilio element and include the twilio:http-callback-config element as its direct child. For example:
+
+[source,xml]
+<twilio:config name="Twilio" accountSid=“ABCedfg" authToken=“123sdfgh" doc:name="Twilio">
+   <twilio:http-callback-config />
+</twilio:config> 
+
+


### PR DESCRIPTION
The proposed change allows creating a global element for the Twilio connector that will pass schema validation at runtime. The documented step details how to complement the XML generated by the global element creation wizard.