### PR TITLE
Update creating-a-policy-walkthrough.adoc

### DIFF
--- a/api-manager/v/latest/creating-a-policy-walkthrough.adoc
+++ b/api-manager/v/latest/creating-a-policy-walkthrough.adoc
@@ -37,7 +37,7 @@ The prerequisites for creating a custom policy are:
 ** An API created on premises and deployed through API Gateway Runtime 1.3 or later to Anypoint Platform
 ** An API created on premises and deployed through the Mule 3.8 unified runtime
 +
-* API administrator permissions
+* User must have Organization Administrators Role
 
 == Create the Custom Policy Definition
 


### PR DESCRIPTION
user need to have Organization Administrators role in order to be able to create custom policy and there is no API administrator permissions at all.