### PR TITLE
fix AsciiDoc syntax in MEL pages

### DIFF
--- a/mule-user-guide/v/3.8/_sources/mule-expression-language-basic-syntax.xml
+++ b/mule-user-guide/v/3.8/_sources/mule-expression-language-basic-syntax.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-	xmlns:spring="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
-http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+    xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+    xmlns:http="http://www.mulesoft.org/schema/mule/http"
+    xmlns:spring="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-current.xsd
+        http://www.mulesoft.org/schema/mule/core
+        http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/http
+        http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
     <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="8081" doc:name="HTTP Listener Configuration"/>
     <sub-flow name="mel_exampleSub_Flow">
         <set-payload value="#[message.inboundProperties.username]" doc:name="Set Payload"/>

--- a/mule-user-guide/v/3.8/mule-expression-language-basic-syntax.adoc
+++ b/mule-user-guide/v/3.8/mule-expression-language-basic-syntax.adoc
@@ -38,7 +38,7 @@ A few definitions before diving into syntax rules.
 
 ==== Expression
 
-In Mule, an expression is a string, enclosed with `#[ ]`. At runtime, Mule uses MEL (as the default expression evaluator) to determine the value of the expression. Mule supports other types of expressions as well (which must also be enclosed in `#[ ]` ), they are used to evaluate your expression if it can't be recognized as MEL.
+In Mule, an expression is a string, enclosed with `+#[ ]+`. At runtime, Mule uses MEL (as the default expression evaluator) to determine the value of the expression. Mule supports other types of expressions as well (which must also be enclosed in `+#[ ]+`), they are used to evaluate your expression if it can't be recognized as MEL.
 
 MEL expressions follow a Java-like syntax. Overall, the basic operators and operands are conventional and predictable (for example, `2 + 2 == 4` returns `true`).  The simplest kind of expression is the one that provides access to information from the message (for example, `message.id`). The <<Examples>> in a section below offers some insight into how you can use MEL expressions to access information, perform comparisons, and invoke methods.  
 
@@ -60,131 +60,193 @@ image:flowVars-syntax.png[flowVars-syntax]
 
 The tables below list the Context Objects and Variables available for use in Mule, and the corresponding Fields you can use with them. 
 
-[%header,cols="34,33,33"]
+[%header,cols="1s,1,1a"]
 |===
 |Context Objects |Description |Field
-|*server* |The operating system on which the message processor is running. |dateTime +
-env +
-fileSeparator +
-host +
-ip +
-locale +
-javaVendor +
-javaVersion +
-nanoSeconds +
-osArch +
-osName +
-osVersion +
-systemProperties +
-timeZone +
-tmpDir +
-userDir +
-userHome +
+
+|server
+|The operating system on which the message processor is running.
+|
+[%hardbreaks]
+dateTime
+env
+fileSeparator
+host
+ip
+locale
+javaVendor
+javaVersion
+nanoSeconds
+osArch
+osName
+osVersion
+systemProperties
+timeZone
+tmpDir
+userDir
+userHome
 userName
-|*mule* |The Mule instance on which the application is running. |clusterId +
-home +
-nodeId +
+
+|mule
+|The Mule instance on which the application is running.
+|
+[%hardbreaks]
+clusterId
+home
+nodeId
 version 
-|*application* |The user application within which the current flow is deployed. |encoding +
-name +
-registry +
-standalone +
+
+|application
+|The user application within which the current flow is deployed.
+|
+[%hardbreaks]
+encoding
+name
+registry
+standalone
 workDir
-|*message* |The package (payload, attachments, properties) that the message processor is processing. |id +
-rootId +
-correlationId +
-correlationSequence +
-correlationGroupSize +
-replyTo +
-dataType +
-payload +
-inboundProperties +
-inboundAttachments +
-outboundProperties +
+
+|message
+|The package (payload, attachments, properties) that the message processor is processing.
+|
+[%hardbreaks]
+id
+rootId
+correlationId
+correlationSequence
+correlationGroupSize
+replyTo
+dataType
+payload
+inboundProperties
+inboundAttachments
+outboundProperties
 outboundAttachments
 |===
 
-[%header%autowidth.spread]
+[%header,cols="1s,1,1"]
 |===
 |Variables |Description |Field 
-|*flowVars* |A variable set on the message; flow variables persist only within the flow in which they were created. |n/a
-|*sessionVars* |A session variable set on the message; session variables persist across flows within an application. |n/a
+
+|flowVars
+|A variable set on the message; flow variables persist only within the flow in which they were created.
+|n/a
+
+|sessionVars
+|A session variable set on the message; session variables persist across flows within an application.
+|n/a
 |===
 
 [TIP]
+.Shortcut for payload
 ====
-*Shortcut*
-
-Mule accepts the expression `#[payload]` as a shortcut for `#[message.payload]`. This shortcut only applies with the payload field.
+Mule accepts the expression `+#[payload]+` as a shortcut for `+#[message.payload]+`. This shortcut only applies with the payload field.
 ====
 
 === Basic Syntax Rules
 
 For a full list of syntax rules, see full link:/mule-user-guide/v/3.8/mule-expression-language-reference[MEL reference] material. +
 
-[%header,cols="34,33,33"]
-|=====
-|  |Example |Description
-|**#[  ]**  |`#[message.id]` |Always bounds an expression.
-|*Simple expressions* |`#[message.field]` +
-`#[sessionVars.age` |The simplest type of expression, these consist of just a context object and a field, or simply a variable. Provides access to information from the message including payload, properties, and variables.  
-|*Multi line expressions* a|
-`#[calendar = Calendar.getInstance();`
+[%header,cols="1s,1m,1",separator=!]
+|===
+!  !Example !Description
 
-`message.payload = ``new` `org.mule.el.datetime.DateTime(calendar);]`
+!+#[  ]+
+!#[message.id]
+!Always bounds an expression.
 
- |You can include several lines in a single expression, each must end with a ;
-|*Operators* |`#['Cookie' + flowVars.cookie]` |Performs operations in expressions. Can be unary, comparison, logical, bitwise, arithmetic, and more.
-|*Boolean expressions* a|
-`#['foo'=='bar']`
+!Simple expressions
+!#[message.field] +
+#[sessionVars.age]
+!The simplest type of expression, these consist of just a context object and a field, or simply a variable. Provides access to information from the message including payload, properties, and variables.  
 
-`#[2 + 2 == 4]`
+!Multiline expressions
+!#[calendar = Calendar.getInstance(); +
+message.payload = new org.mule.el.datetime.DateTime(calendar);]
+!You can include several lines in a single expression, each must end with a ;
 
- |Produces Boolean values. 
-|*Bean Property Access* |`#[payload.property1.property2]` |Access information from bean.
-|*Method invocations* |`#[message.header.get()]` |Calls a method, then performs it on an object according to the parameter (if any) specified within the parentheses. Method calls always follow the syntax: `object.method()`
-|*Assignments* |`#[payload = 'sample']` |Evaluates to assign a value. The example at left resolves dynamically to set the payload to `sample`.
-|*Literals* |`'expression'` +
-`255 ` +
-`null`  |Strings, numbers, Boolean values, types, and nulls.
-|*xpath and regex* |`xpath3('/orders/order[0]')` 
-//regex('^(To|From|Cc):')
-//bars in cell
-|*xpath3* and *regex* provide ways of extracting context information that doesn’t already exist as a single value. 
-|*Wildcards* |`wildcard("Hello*")` |Matches a value (the message payload, by default) against a wildcard pattern, these use the meta-characters '?' to represent any single character and '*' for a repetition of any character. It's case sensitive by default. link:http://www.mulesoft.org/documentation/display/current/Mule+Expression+Language+Reference#MuleExpressionLanguageReference-wildcard[See more]
-|=====
+!Operators
+!#['Cookie' + flowVars.cookie]
+!Performs operations in expressions. Can be unary, comparison, logical, bitwise, arithmetic, and more.
 
-Further, you can use expressions inline to create lists, maps and arrays. Learn more about link:/mule-user-guide/v/3.8/mule-expression-language-reference[accessing maps, lists and arrays]from within a MEL expression.
+!Boolean expressions
+!#['foo'=='bar'] +
+#[2 + 2 == 4]
+!Produces Boolean values. 
+
+!Bean Property Access
+!#[payload.property1.property2]
+!Access information from bean.
+
+!Method invocations
+!#[message.header.get()]
+!Calls a method, then performs it on an object according to the parameter (if any) specified within the parentheses. Method calls always follow the syntax: `object.method()`
+
+!Assignments
+!#[payload = 'sample']
+!Evaluates to assign a value. The example at left resolves dynamically to set the payload to `sample`.
+
+!Literals
+!'expression' +
+255 +
+null
+!Strings, numbers, Boolean values, types, and nulls.
+
+!xpath and regex
+!xpath3('/orders/order[0]') +
+regex('^(To|From|Cc):')
+!*xpath3* and *regex* provide ways of extracting context information that doesn’t already exist as a single value. 
+
+!Wildcards
+!wildcard("Hello*")
+!Matches a value (the message payload, by default) against a wildcard pattern, these use the meta-characters '?' to represent any single character and '*' for a repetition of any character. It's case sensitive by default. link:http://www.mulesoft.org/documentation/display/current/Mule+Expression+Language+Reference#MuleExpressionLanguageReference-wildcard[See more]
+|===
+
+Further, you can use expressions inline to create lists, maps and arrays. Learn more about link:/mule-user-guide/v/3.8/mule-expression-language-reference[accessing maps, lists and arrays] from within a MEL expression.
 
 [%autowidth.spread]
 |===
-|*Inline list* |`[item1, item2, . . .]` |Evaluates to produce a list.
-|*Inline map* |`[key1 : value1, key2: value2, ...]` |Evaluates to produce a map.
-|*Inline array* | `{item1, item2, . . .}` |Evaluates to produce an array.
+s|Inline list m|[item1, item2, . . .] |Evaluates to produce a list.
+s|Inline map m|[key1 : value1, key2: value2, ...] |Evaluates to produce a map.
+s|Inline array m|{item1, item2, . . .} |Evaluates to produce an array.
 |===
 
 == Examples
 
 There is really no such thing as a single _typical_ MEL expression. That said, a few example expressions can help illustrate how MEL expressions resolve. As the following table of examples demonstrates, the values that MEL expressions return can be numerical values, logical values (`true` or `false`), strings, or virtually any data type. MEL expressions can also perform operations, invoke methods, and execute functions. Explore all the possibilities by consulting the complete link:/mule-user-guide/v/3.8/mule-expression-language-basic-syntax[syntax reference]. Access full link:/mule-user-guide/v/3.8/mule-expression-language-examples[examples] that illustrate how to use MEL expressions in applications.
 
-[%header,cols="2*"]
+[%header,cols="50m,50"]
 |===
-|*Expression* |*Description*
-|`#[2 + 2] ` |This expression evaluates to 4.
-|`#[2 + 2 == 4]` |This expression uses an operator to perform a comparison. It evaluates to true.
-|`#[message]` |This expression references a context object in MEL (`message`, `app`, `mule`, and `server`). The value of this expression is the message.
-|`#[message.id]` |This expression accesses the ID field of the message context object. The value of this expression is the unique message id that Mule automatically assigns to the message.
-|`#[payload.firstname]` |This expression accesses an object within the field (payload) associated with the context object (message). If the object is a map item whose key is 'firstname' then this expression evaluates to the value associated with the key 'firstname'. If the object is a bean, the property is returned.
-|`#[payload[4]]` |Same as above, but in this case – provided the field is a list – the expression returns the value of the 5th item in the list. (4 refers to the 5th item because the first item in the list is the 0 item.)
-|`#[message.header.get()]` |This expression calls the "get" method and performs it on the object, according to the parameter (if any) specified within the parentheses.
+|Expression |Description
+
+|#[2 + 2]
+|This expression evaluates to 4.
+
+|#[2 + 2 == 4]
+|This expression uses an operator to perform a comparison. It evaluates to true.
+
+|#[message]
+|This expression references a context object in MEL (`message`, `app`, `mule`, and `server`). The value of this expression is the message.
+
+|#[message.id]
+|This expression accesses the ID field of the message context object. The value of this expression is the unique message id that Mule automatically assigns to the message.
+
+|#[payload.firstname]
+|This expression accesses an object within the field (payload) associated with the context object (message). If the object is a map item whose key is 'firstname' then this expression evaluates to the value associated with the key 'firstname'. If the object is a bean, the property is returned.
+
+|#[payload[4]]
+|Same as above, but in this case – provided the field is a list – the expression returns the value of the 5th item in the list. (4 refers to the 5th item because the first item in the list is the 0 item.)
+
+|#[message.header.get()]
+|This expression calls the `get()` method and performs it on the object, according to the parameter (if any) specified within the parentheses.
 |===
 
 === MEL Auto-Complete
 
 If you are configuring a field that supports expressions and need help with syntax, you can access MEL suggestions by one of two methods.
 
-* Place your cursor inside the brackets in a field that has `#[]` pre-populated for you, then press Ctrl + Space Bar.
-* Enter `#[` to open a new MEL expression and display suggestions, as shown below.
+* Place your cursor inside the brackets in a field that has `+#[ ]+` pre-populated for you, then press Ctrl + Space Bar.
+* Enter `+#[+` to open a new MEL expression and display suggestions, as shown below.
 +
 image:auto_complete.png[auto_complete]
 +
@@ -198,21 +260,18 @@ For the complete reference on date and time functions, see link:/mule-user-guide
 
 * Return the system date and time in a dateTime object:
 +
-[source]
 ----
 #[server.dateTime]
 ----
 
 * Return current system time in nanoseconds as an integer:
 +
-[source]
 ----
 #[server.nanoTime()]
 ----
 
 * Return a dateTime object with the specified calendar and server locale:
 +
-[source, code, linenums]
 ----
 #[calendar = Calendar.getInstance();
 message.payload = new org.mule.el.datetime.DateTime(calendar);]
@@ -220,7 +279,6 @@ message.payload = new org.mule.el.datetime.DateTime(calendar);]
 
 * Set the message payload to a Java calendar representation of the server date and time:
 +
-[source]
 ----
 #[message.payload = server.dateTime.toCalendar()]
 ----
@@ -230,11 +288,15 @@ message.payload = new org.mule.el.datetime.DateTime(calendar);]
 
 * MEL performs link:http://en.wikipedia.org/wiki/Type_coercion[type coercion] at runtime. 
 * When writing in Studio's XML editor, you cannot use double quotes to express String literals, because MEL expressions already appear enclosed in double quotes in configuration files. Instead, you can either: +
-** use single quotes                   `('expression')`
-** escape quotes with &quot;      `(&quot;expression&quot;)`
-** escape quotes with \u0027      `(\u0027expression\u0027)`
 +
-If you're writing on Studio's visual editor, Studio transforms double quotes into escaped quotes `(&quot;) `in the XML view.
+[%autowidth,cols="s,m",frame=none]
+|===
+|enclose in single quotes |'expression'
+|enclose in escaped double quotes using \&quot; |+&quot;expression&quot;+
+|enclose in escaped double quotes using \u0027 |\u0027expression\u0027
+|===
++
+If you're writing on Studio's visual editor, Studio transforms double quotes into escaped quotes (i.e., \&quot;) in the XML view.
 
 * While Mule Expression Language was introduced in Mule 3.3, Mule has supported expressions since Mule 2.1. Prior to Mule 3.3, link:http://www.mulesoft.org/documentation/display/current/Using+Non-MEL+Expressions[expression evaluators] provided this functionality. An *evaluator* is a piece of code that follows a set of rules and logic to extract the value of expressions. Each expression evaluator has its own rules and syntax. Mule expression evaluators continue to be fully supported within Mule, but given the availability of Mule Expression Language, their use is no longer recommended.
 

--- a/mule-user-guide/v/3.8/mule-expression-language-mel.adoc
+++ b/mule-user-guide/v/3.8/mule-expression-language-mel.adoc
@@ -33,21 +33,20 @@ An *expression language*, such as MEL, is similar, but not the same as, a *scr
 Based on information Mule extracts from the message or its environment at runtime, Mule evaluates expressions to complete three types of tasks:
 
 * *Extract* information that it can use to process the current message; this can be useful when set inside an expression component or expression transformer: 
-** `#[payload]`
-** `#[message.inboundProperties.'propertyName']`
-** `#[payload.methodCall(parameters)]`
-** `#[xpath3('//root/element1')]` 
+** `+#[payload]+`
+** `+#[message.inboundProperties.'propertyName']+`
+** `+#[payload.methodCall(parameters)]+`
+** `+#[xpath3('//root/element1')]+`
 * *Evaluate conditions* using the contents of the current message; this can be extremely useful to filter messages from being processed:
-** `#[payload.age > 21]`
-** `#[message.inboundProperties.'locale'  ==  'en_us']`
+** `+#[payload.age > 21]+`
+** `+#[message.inboundProperties.'locale' == 'en_us']+`
 * *Define a target*, other than the message payload, in which to store the result of an expression evaluation; typically, this is helpful when set inside a message enricher
-** `#[flowVars.output]`
+** `+#[flowVars.output]+`
 
 [TIP]
+.Shortcut for payload
 ====
-*Shortcut*
-
-Mule accepts the expression `\#[payload]` as a shortcut for `#[message.payload]`. This shortcut only applies to the payload field.
+Mule accepts the expression `+#[payload]+` as a shortcut for `+#[message.payload]+`. This shortcut only applies to the payload field.
 ====
 
 The following examples illustrate a few ways in which you can use MEL.
@@ -89,9 +88,9 @@ If the payload is an object and you can call a method to extract information, th
 
 == Expressions in Mule
 
-It's important to know that MEL has not always been the _de facto_ expression language Mule uses. Prior to version 3.3.0, expressions in Mule varied in syntax according to their specific evaluator. Thus, although these expressions supported a wide variety of functionality, the variation in syntax rules was time-consuming to learn. This older style of expression was written in the format: `#[evaluator:expression]`. A colon separated the evaluator from the expression itself.
+It's important to know that MEL has not always been the _de facto_ expression language Mule uses. Prior to version 3.3.0, expressions in Mule varied in syntax according to their specific evaluator. Thus, although these expressions supported a wide variety of functionality, the variation in syntax rules was time-consuming to learn. This older style of expression was written in the format: `+#[evaluator:expression]+`. A colon separated the evaluator from the expression itself.
 
-Mule 3.3.0 introduced Mule Expression Language (MEL), which implements a single set of syntax rules that no longer contains an evaluator. The evaluator, by default, is MEL itself, and it can interpret expressions formerly associated with dozens of different evaluators. MEL expressions are written according to the following format: `#[expression]`. Note the absence of the colon, which signals to Mule that this is a MEL expression; thus Mule evaluates the expression using MEL logic rather than the rules of a specific evaluator.
+Mule 3.3.0 introduced Mule Expression Language (MEL), which implements a single set of syntax rules that no longer contains an evaluator. The evaluator, by default, is MEL itself, and it can interpret expressions formerly associated with dozens of different evaluators. MEL expressions are written according to the following format: `+#[expression]+`. Note the absence of the colon, which signals to Mule that this is a MEL expression; thus Mule evaluates the expression using MEL logic rather than the rules of a specific evaluator.
 
 *Note*: Only use MEL expressions in your application.
 


### PR DESCRIPTION
- properly escape MEL expressions so they display correctly
- use styles to control formatting of table cells
- use a cleaner layout for tables