### PR TITLE
Last section / client secret is still generate by Anypoint not PF

### DIFF
--- a/api-manager/v/latest/browsing-and-accessing-apis.adoc
+++ b/api-manager/v/latest/browsing-and-accessing-apis.adoc
@@ -51,6 +51,6 @@ The following options describe the various ways that you and/or an API Owner can
 
 == Accessing APIs Protected by PingFederate OAuth Token Enforcement
 
-When you work in an organization that uses PingFederate for identity management, you need to supply additional information to develop your application. Register your application on Anypoint Platform to obtain a client ID and client secret from PingFederate, and work with your organization administrator to get necessary OAuth information.
+When you work in an organization that uses PingFederate for identity management, you need to supply additional information to develop your application. Register your application on Anypoint Platform to obtain a client ID and client secret and register them in PingFederate, and work with your organization administrator to get necessary OAuth information.
 
 When you register applications for access to APIs in a federated organization, you need to provide an *OAuth Grant Type*, *Application URL*, and **OAuth 2.0 Redirect URI**.


### PR DESCRIPTION
The client id/secret is generated by anypoint code, then the client is created in PF using this POST call: https://documentation.pingidentity.com/display/PF72/OAuth+Client+Management+Service#OAuthClientManagementService-1082697
Saying you get the client id and secret from PF is misleading