### PR TITLE
Update design-an-api.adoc

### DIFF
--- a/getting-started/v/latest/design-an-api.adoc
+++ b/getting-started/v/latest/design-an-api.adoc
@@ -448,7 +448,7 @@ baseUri: http://server/api/
           description: Provide a valid order Id.
           required: true
           type: integer
-          example: "4321"
+          example: 4321
         email:
           description: Provide a valid email address.
           pattern: ^[_a-z0-9-]+(\.[_a-z0-9-]+)*@mule.com

--- a/getting-started/v/latest/mule-message.adoc
+++ b/getting-started/v/latest/mule-message.adoc
@@ -298,7 +298,7 @@ Now that you're familiar with how to access information about your message and i
 +
 [source]
 ----
-#[app.name] running on Mule version #[mule.version] on #[server.userName] arrived with the path #[flowVars.pay]
+#[app.name] running on Mule version #[mule.version] on #[server.userName] arrived with the path #[flowVars.path]
 ----
 +
 image:logger-config-mel.png[logger-config-mel]


### PR DESCRIPTION

<img width="964" alt="screen shot 2017-03-04 at 15 53 30" src="https://cloud.githubusercontent.com/assets/19574208/23580098/e06bc832-00f2-11e7-96b0-f2d07c2beaea.png">
Removed the double quotes for 'example' property in queryParameters, as the type is an Integer. API Manager complains about this error.