### PR TITLE
Update custom-log-appender.adoc

### DIFF
--- a/runtime-manager/v/latest/custom-log-appender.adoc
+++ b/runtime-manager/v/latest/custom-log-appender.adoc
@@ -20,7 +20,7 @@ integrate with their own logging systems.
 running out of disk space, or other side effects.
 * To configure logs to flow to both your log system and CloudHub, read the directions below. Note that the UI will continue to
 warn you that logs in CloudHub will not be available.
-* When you disable default CloudHub application logs only system logs are available. For application worker logs, please check your own application logging system. Additionaly, the download logs option is unavailable in this scenario.
+* When you disable the default CloudHub application logs, then only the system logs are available. For application worker logs, please check your own application's logging system. Downloading logs is not an option in this scenario.
 ====
 
 To enable your own log4j appender, you need to first create a log4j2.xml configuration with your log

--- a/runtime-manager/v/latest/custom-log-appender.adoc
+++ b/runtime-manager/v/latest/custom-log-appender.adoc
@@ -19,7 +19,8 @@ integrate with their own logging systems.
 * MuleSoft is also not responsible for misconfigurations that result in performance degradation,
 running out of disk space, or other side effects.
 * To configure logs to flow to both your log system and CloudHub, read the directions below. Note that the UI will continue to
-warn you that logs in CloudHub will not be available. This will be addressed in a future release.
+warn you that logs in CloudHub will not be available.
+* When you disable default CloudHub application logs only system logs are available. For application worker logs, please check your own application logging system. Additionaly, the download logs option is unavailable in this scenario.
 ====
 
 To enable your own log4j appender, you need to first create a log4j2.xml configuration with your log


### PR DESCRIPTION
Clarify that the log files are not downloadable from the UI when custom-log-appender is enabled

Also, removed the "This will be addressed in a future release." because we don't have a date for ETA