### PR TITLE
Update component-authorization-using-spring-security.adoc

### DIFF
--- a/mule-user-guide/v/3.8/component-authorization-using-spring-security.adoc
+++ b/mule-user-guide/v/3.8/component-authorization-using-spring-security.adoc
@@ -57,11 +57,11 @@ This bean is responsible for passing requests through a chain of `Authentication
 [source, xml, linenums]
 ----
 <bean id="authenticationManager" class="org.springframework.security.authentication.ProviderManager">
-      <property name= "providers">
+      <constructor-arg>
             <list>
                  <ref local="daoAuthenticationProvider"/>
             </list>
-      </property>
+      </constructor-arg>
 </bean>
 ----
 
@@ -71,12 +71,12 @@ This bean specifies that a user can access the protected methods if they have an
 
 [source, xml, linenums]
 ----
-<bean id="accessDecisionManager" class='org.springframework.security.access.vote.AffirmativeBased'>
-      <property name="decisionVoters">
+<bean id="accessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">
+      <constructor-arg>
             <list>
                   <ref bean="roleVoter"/>
             </list>
-      </property>
+      </constructor-arg>
 </bean>
 ----
 
@@ -97,7 +97,7 @@ This bean defines a proxy for the protected bean. When an application asks Sprin
             <value>myComponent</value>
         </list>
     </property>
-    <property name='proxyTargetClass' value="true"/>
+    <property name="proxyTargetClass" value="true"/>
 </bean>
 ----
 
@@ -136,7 +136,7 @@ The use of Spring Security strategies is particularly useful for asynchronous sy
 ----
 <mule-ss:security-manager>
     <mule-ss:delegate-security-provider name="memory-dao" delegate-ref="authenticationManager">
-        <mule-ss::security-property name="securityMode" value="MODE_GLOBAL"/>
-    </mule-ss::delegate-security-provider>
+        <mule-ss:security-property name="securityMode" value="MODE_GLOBAL"/>
+    </mule-ss:delegate-security-provider>
 </mule-ss:security-manager>
 ----


### PR DESCRIPTION
Removed superfluous colons.  For consistency, changed single-quotes to double-quotes for attribute definitions.  Corrected spring properties to be constructor arguments where necessary.