### PR TITLE
Update windows-gateway-services-guide.adoc

### DIFF
--- a/mule-user-guide/v/3.8/windows-gateway-services-guide.adoc
+++ b/mule-user-guide/v/3.8/windows-gateway-services-guide.adoc
@@ -24,7 +24,7 @@ Release Notes:
 
 == Prerequisites
 
-`Java Cryptography Extensions` needs to be installed on the server where Windows Gateway Service is installed. The JCE package is required to allow the Connector to use HTTPS to communicate securely. You can install JCE for your Java version from the Oracle website:
+`Java Cryptography Extensions` needs to be installed on the server where Mule is installed. The JCE package is required to allow the Connector to use HTTPS to communicate securely. You can install JCE for your Java version from the Oracle website:
 
 http://www.oracle.com/technetwork/java/javase/downloads/index.html
 


### PR DESCRIPTION
JCE libraries are used by Mule not by the Windows Gateway Service