### PR TITLE
Update dataweave-memory-management.adoc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-memory-management.adoc
+++ b/mule-user-guide/v/3.8/dataweave-memory-management.adoc
@@ -13,7 +13,7 @@ To change the threshold value at which memory is no longer used as a buffer, you
 
 The value you assign to this property affects your entire Mule application, affecting each instance of the Transform Message component individually.
 
-Please note that for mule runtime versions up to 3.8.3, all indexed readers have a maximum limit of 2 GB for the payload. And text length for a single field can not be bigger than 1 M (this applies for CSV, JSON and XML).
+Please note that for Mule runtime versions 3.8.3 and older, all indexed readers can process payloads with a maximum limit of 2 GB. Also, the text length for a single field can not be larger than 1 MB (this applies for CSV, JSON and XML).
 
 
 == Immediate vs Deferred Execution

--- a/mule-user-guide/v/3.8/dataweave-memory-management.adoc
+++ b/mule-user-guide/v/3.8/dataweave-memory-management.adoc
@@ -13,6 +13,8 @@ To change the threshold value at which memory is no longer used as a buffer, you
 
 The value you assign to this property affects your entire Mule application, affecting each instance of the Transform Message component individually.
 
+Please note that for mule runtime versions up to 3.8.3, all indexed readers have a maximum limit of 2 GB for the payload. And text length for a single field can not be bigger than 1 M (this applies for CSV, JSON and XML).
+
 
 == Immediate vs Deferred Execution
 


### PR DESCRIPTION
- For SE-5517, added the DataWeave limitations for:
    - the size for the whole payload
    - the size for single fields