### PR TITLE
Update mock-message-processor.adoc

### DIFF
--- a/munit/v/1.3.1/mock-message-processor.adoc
+++ b/munit/v/1.3.1/mock-message-processor.adoc
@@ -413,14 +413,17 @@ Assume you have the following script in your classpath:
 
 [source, xml, linenums]
 ----
-<script:script name="groovyScriptPayloadGenerator" engine="groovy"><![CDATA[
+<mule xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting" ...
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd ...">
+  
+<scripting:script name="groovyScriptPayloadGenerator" engine="groovy"><![CDATA[
   List<String> lists = new ArrayList<String>();
   lists.add("item1");
   lists.add("item2");
   lists.add("item3");
 
   return lists;]]>
-</script:script>
+</scripting:script>
 ----
 
 In order to return the mock payload as the result of the `groovyScriptPayloadGenerator` script.


### PR DESCRIPTION
script:script was changed to scripting:script to improve consistency and namespace was added.