### PR TITLE
Proxy must be configured in both, wrapper.conf and mule-agent.yml

### DIFF
--- a/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
@@ -833,7 +833,7 @@ The hostnames that you should include in your Layer 7 Firewall rules include:
 
 You can configure the Runtime Manager Agent to send websocket messages through an HTTP proxy.
 
-The Runtime Manager Agent reads its proxy configuration from the same file that Anypoint API Gateway uses for its proxy configuration. This file is `wrapper.conf`, located under Mule's `conf/` directory.
+The Runtime Manager Agent reads its proxy configuration from the `wrapper.conf` file, located under Mule's `conf/` directory.
 
 === Default wrapper.conf File
 

--- a/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
@@ -833,7 +833,7 @@ The hostnames that you should include in your Layer 7 Firewall rules include:
 
 You can configure the Runtime Manager Agent to send websocket messages through an HTTP proxy.
 
-By default, the Runtime Manager Agent reads its proxy configuration from the same file that Anypoint API Gateway uses for its proxy configuration. This file is `wrapper.conf`, located under Mule's `conf/` directory. However, you can override the values stored in this file with values specific to the Runtime Manager Agent, by editing the agent's configuration file.
+The Runtime Manager Agent reads its proxy configuration from the same file that Anypoint API Gateway uses for its proxy configuration. This file is `wrapper.conf`, located under Mule's `conf/` directory.
 
 === Default wrapper.conf File
 
@@ -846,11 +846,11 @@ In this file the properties that define proxy configuration are:
 * `anypoint.platform.proxy_username`
 * `anypoint.platform.proxy_password`
 
+To send the insights and monitoring information, the Runtime Manager Agent calls the auth-proxy service. To connect to this service, the Runtime Manager Agent reads the proxy configuration from the file `mule-agent.yml`, in the `conf/` directory.
+
 === Agent-specific mule-agent.yml File
 
 `$MULE_HOME/conf/mule-agent.yml`.
-
-To define proxy configuration specific to the Runtime Manager Agent, edit the configuration properties in this file as shown below. The properties in this file override those stored in the default `wrapper.conf` file.
 
 [source, yaml, linenums]
 ----


### PR DESCRIPTION
The connection to Runtime Manager Console must be configured in the wrapper.conf file.
But since Runtime Manager Agent 1.5.1 the connection to the Auth Proxy endpoint, that the Agent uses to send the Insights and the server monitoring retrieves the proxy information from the mule-agent.yml file.

The wrapper.conf configuration doesn't replace the one in the mule-agent.yml.