### PR TITLE
Added the missing example for /orders post method

### DIFF
--- a/getting-started/v/latest/design-an-api.adoc
+++ b/getting-started/v/latest/design-an-api.adoc
@@ -170,6 +170,20 @@ baseUri: http://server/api
   displayName: orders
   post:
     description: Places a new T-Shirt order
+    body:
+      application/json:
+        example: |
+          {
+            "size": "M",
+            "email": "robin@mail.com",
+            "name": "Robin Pille",
+            "address1": "77 Geary St.",
+            "address2": "Apt 7",
+            "city": "San Francisco",
+            "stateOrProvince": "CA",
+            "country": "US",
+            "postalCode": "94131"
+          }    
 ----
 
 


### PR DESCRIPTION
This example is missing in the earlier example and suddenly pops up later in the full RAML, confusing the user.