### PR TITLE
Removed the `per minute`

### DIFF
--- a/runtime-manager/v/latest/flow-metrics.adoc
+++ b/runtime-manager/v/latest/flow-metrics.adoc
@@ -41,8 +41,8 @@ image:flow-metrics-e26c4.png[]
 
 This tab contains charts for the following three metrics:
 
-* Mule messages per minute
-* Errors per minute
+* Mule messages
+* Errors
 * Flow response time
 
 All metrics are displayed as an average relative to the selected time scale.


### PR DESCRIPTION
The lapse of the metric depends on the period of time you are selecting.