### PR TITLE
Update cache-scope.adoc

### DIFF
--- a/mule-user-guide/v/3.8/cache-scope.adoc
+++ b/mule-user-guide/v/3.8/cache-scope.adoc
@@ -353,7 +353,7 @@ The example that follows demonstrates the power of the cache scope with a Fibona
 
 In this example, the Mule flow receives and performs two tasks for each request:
 
-. Executes, and returns the answer to, the Fibonacci equation (see below) using a number (_n_) provided by the caller  +
+. Executes, and returns the answer to, the Fibonacci equation (see below) using a number (_n_) provided by the caller as request header. Images below show it as query parameter but it should be passed as request header. Use tool like Postman to pass it  +
 `F(n) = F(n-1) + F(n-2) with F(0) = 0 and F(1) = 1`
 +
 . Records and returns the cost of the calculation, where each individual invocation of a calculation task adds 1 to the cost, that is, add two numbers in the sequence.


### PR DESCRIPTION
Added correction, in fibonacci example provided at the end of the document, 'n' is not query parameter, it should be passed as header