### PR TITLE
Update cloudhub-dedicated-load-balancer.adoc

### DIFF
--- a/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
+++ b/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
@@ -32,8 +32,8 @@ Your CloudHub dedicated Load Balancer has an internal domain name to be used by 
 The structure is `internal-<lb-name>.lb.anypointdns.net` where `<lb-name>` is the name you gave the load balancer when you created it.
 Additionally, your dedicated load balancer exposes an external domain name that you can be reached from outside your VPC network: `<lb-name>.lb.anypointdns.net` where `<lb-name>` is the name you gave the load balancer when you created it.
 
-Each Dedicated Load Balancer has a DNS A Record pairing its external domain name (`<lb-name>.lb.anypointdns.net`) to the IP addresses of your workers. +
-Through your DNS provider, you can add this DNS A record to the DNS CNAME records of your DNS servers and use your own hostnames.
+Each Dedicated Load Balancer has a DNS A Record `<lb-name>.lb.anypointdns.net` resolving to 2 Public IP addresses of its two instances. +
+Through your DNS provider, you can add a CNAME record pointing to this A record and use your own domain names to access.
 
 If you want your load balancer to handle all connections to your application and you don't want your default domain name for your application publicly exposed, then each application needs to be listening over HTTP on port *8091* or *8092*, or you can create a custom mapping policy to redirect outside requests from your load balancer to your specific application.
 

--- a/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
+++ b/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
@@ -28,9 +28,9 @@ Check the <<Creating and Configuring a Dedicated Load Balancer>> section for mor
 
 == Load Balancer Architecture
 
-Your CloudHub dedicated Load Balancer has an internal domain name to be used by applications and clients within the VPC.
+Your CloudHub Dedicated Load Balancer has an internal domain name to be used by applications and clients within the VPC.
 The structure is `internal-<lb-name>.lb.anypointdns.net` where `<lb-name>` is the name you gave the load balancer when you created it.
-Additionally, your dedicated load balancer exposes an external domain name that you can be reached from outside your VPC network: `<lb-name>.lb.anypointdns.net` where `<lb-name>` is the name you gave the load balancer when you created it.
+Additionally, your Dedicated Load Balancer exposes an external domain name resolving to 2 public IP addresses which can be reached from outside of your CloudHub VPC network: `<lb-name>.lb.anypointdns.net` where `<lb-name>` is the name you gave the load balancer when you created it.
 
 Each Dedicated Load Balancer has a DNS A Record `<lb-name>.lb.anypointdns.net` resolving to 2 Public IP addresses of its two instances. +
 Through your DNS provider, you can add a CNAME record pointing to this A record and use your own domain names to access.


### PR DESCRIPTION
1. `<lb-name>.lb.anypointdns.net` resolves to 2 public IP addresses which are 2 DLB instances, NOT workers.
2. The language / wording used to describe CNAME pointing to DLB's DNS (resolving to public IPs) are really confusing, changed it.
3. Use one's own domain names, not ~hostnames~.