### PR TITLE
Clarifying what are the options for the log path

### DIFF
--- a/mule-user-guide/v/3.8/logging-in-mule.adoc
+++ b/mule-user-guide/v/3.8/logging-in-mule.adoc
@@ -76,7 +76,7 @@ In Anypoint Studio, `log4j2.xml` appears in the `src/main/resources` path.
 
 The default config defines the standard loggers exactly as Mule did before the introduction of asynchronous logging. The only difference is that the new config defines all loggers (including the root one) as asynchronous.
 
-You can override this config at the domain or application level. You can create a custom file at a custom folder location and point to it in the link:/mule-user-guide/v/3.8/mule-application-deployment-descriptor[application's deployment properties]. To do this, open the application's `mule-deploy.properties` file in `src/main/app` and add a `log.configFile` property with this location specified in it.
+You can override this config at the domain or application level. You can create a custom file at a custom folder location and point to it in the link:/mule-user-guide/v/3.8/mule-application-deployment-descriptor[application's deployment properties]. To do this, open the application's `mule-deploy.properties` file in `src/main/app` and add a `log.configFile` property with this location specified in it. The path to the file can be either a relative one to MULE_HOME (the folder where the runtime was installed) or an absolute path.
 
 [source]
 ----


### PR DESCRIPTION
We need to clarify this as It creates some confusion on the customer, who could try, for instance, to use paths relative to the app's classpath