### PR TITLE
Add a clear warning about using maxBufferSize

### DIFF
--- a/mule-user-guide/v/3.2/tuning-performance.adoc
+++ b/mule-user-guide/v/3.2/tuning-performance.adoc
@@ -74,6 +74,16 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+
+In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
+
 === Calculating the Flow Threads
 
 Even if you will be performing synchronous messaging only, you must calculate the flow threads so that you can correctly calculate the receiver threads. This section describes how to calculate the flow threads.
@@ -175,9 +185,9 @@ Attributes of <default-threading-profile...>"
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -229,9 +239,9 @@ Attributes of <default-receiver-threading-profile...>:
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -283,9 +293,9 @@ Attributes of <default-dispatcher-threading-profile...>:
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -341,9 +351,9 @@ Attributes of <receiver-threading-profile...>
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -395,9 +405,9 @@ Attributes of <dispatcher-threading-profile...>:
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -461,9 +471,9 @@ Attributes of <queued-asynchronous-processing-strategy...>:
 *Type*: integer +
 *Required*: no +
 *Default*: none
-|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up. 
+|poolExhaustedAction |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. If you configure a threading profile with `poolExhaustedAction=WAIT` and a `maxBufferSize` of a positive value, the thread pool does not grow from `maxThreadsIdle (corePoolSize)` towards `maxThreadsActive (maxPoolSize)` unless the queue is completely filled up.
 
-Possible values for poolExhaustedAction are: 
+Possible values for poolExhaustedAction are:
 
 * WAIT - Wait until a thread becomes available. Don't use this value if the minimum number of threads is zero, in which case a thread may never become available.
 * DISCARD - Throw away the current request and return.
@@ -503,7 +513,7 @@ Each pooled component has its own pooling profile. You configure the pooling pro
 *Type*: string +
 *Required*: no +
 *Default*: none
-|initialisationPolicy |Determines how components in a pool should be initialized. The possible values are: 
+|initialisationPolicy |Determines how components in a pool should be initialized. The possible values are:
 
 * INITIALISE_NONE - Do not load any components into the pool on startup.
 * INITIALISE_ONE - Loads one initial component into the pool on startup.
@@ -512,7 +522,7 @@ Each pooled component has its own pooling profile. You configure the pooling pro
 *Type*: INITIALISE_NONE, INITIALISE_ONE, INITIALISE_ALL +
 *Required*: no +
 *Default*: `INITIALISE_ONE`
-|exhaustedAction |Specifies the behavior of the Mule component pool when the pool is exhausted. Possible values are: 
+|exhaustedAction |Specifies the behavior of the Mule component pool when the pool is exhausted. Possible values are:
 
 * WHEN_EXHAUSTED_FAIL - Throws `NoSuchElementException`
 * WHEN_EXHAUSTED_WAIT - Blocks by invoking Object.wait(long) until a new or idle object is available

--- a/mule-user-guide/v/3.3/tuning-performance.adoc
+++ b/mule-user-guide/v/3.3/tuning-performance.adoc
@@ -74,6 +74,16 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+
+In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
+
 === Calculating the Flow Threads
 
 Even if you will be performing synchronous messaging only, you must calculate the flow threads so that you can correctly calculate the receiver threads. This section describes how to calculate the flow threads.

--- a/mule-user-guide/v/3.4/tuning-performance.adoc
+++ b/mule-user-guide/v/3.4/tuning-performance.adoc
@@ -74,6 +74,16 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+
+In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
+
 === Calculating the Flow Threads
 
 Even if you will be performing synchronous messaging only, you must calculate the flow threads so that you can correctly calculate the receiver threads. This section describes how to calculate the flow threads.

--- a/mule-user-guide/v/3.5/tuning-performance.adoc
+++ b/mule-user-guide/v/3.5/tuning-performance.adoc
@@ -74,9 +74,15 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 Where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
-*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
 
 === Calculating the Flow Threads
 

--- a/mule-user-guide/v/3.6/tuning-performance.adoc
+++ b/mule-user-guide/v/3.6/tuning-performance.adoc
@@ -75,9 +75,15 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 Where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
-*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
 
 === Calculating the Flow Threads
 

--- a/mule-user-guide/v/3.7/tuning-performance.adoc
+++ b/mule-user-guide/v/3.7/tuning-performance.adoc
@@ -74,9 +74,15 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 Where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
-*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
+==========
 
 === Calculating the Flow Threads
 
@@ -168,7 +174,7 @@ The default threading profile, used by components and by endpoints for dispatchi
 |`poolExhaustedAction` |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. Possible values are: WAIT (wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available), DISCARD (throw away the current request and return), DISCARD_OLDEST (throw away the oldest request and return), ABORT (throw a RuntimeException), and RUN (the default; the thread making the execute request runs the task itself, which helps guard against lockup). +
 *Type*: `WAIT`/`DISCARD`/`DISCARD_OLDEST`/`ABORT`/`RUN` +
 *Required*: no +
-*Default*: none 
+*Default*: none
 |`threadWaitTimeout` |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it will wait indefinitely. +
 *Type*: `integer` +
 *Required*: no +
@@ -218,7 +224,7 @@ The default receiving threading profile, which modifies the default-threading-pr
 |`poolExhaustedAction` |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. Possible values are: WAIT (wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available), DISCARD (throw away the current request and return), DISCARD_OLDEST (throw away the oldest request and return), ABORT (throw a RuntimeException), and RUN (the default; the thread making the execute request runs the task itself, which helps guard against lockup). +
 *Type*: `WAIT`/`DISCARD`/`DISCARD_OLDEST`/`ABORT`/`RUN` +
 *Required*: no +
-*Default*: none 
+*Default*: none
 |`threadWaitTimeout` |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it will wait indefinitely. +
 *Type*: `integer` +
 *Required*: no  +
@@ -269,7 +275,7 @@ The default dispatching threading profile, which modifies the default-threading-
 |`poolExhaustedAction` |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. Possible values are: WAIT (wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available), DISCARD (throw away the current request and return), DISCARD_OLDEST (throw away the oldest request and return), ABORT (throw a RuntimeException), and RUN (the default; the thread making the execute request runs the task itself, which helps guard against lockup). +
 *Type*: `WAIT`/`DISCARD`/`DISCARD_OLDEST`/`ABORT`/`RUN` +
 *Required*: no +
-*Default*: none 
+*Default*: none
 |`threadWaitTimeout` |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it will wait indefinitely. +
 *Type*: `integer` +
 *Required*: no  +
@@ -321,7 +327,7 @@ The threading profile to use when a connector receives messages.
 |`poolExhaustedAction` |When the maximum pool size or queue size is bounded, this value determines how to handle incoming tasks. Possible values are: WAIT (wait until a thread becomes available; don't use this value if the minimum number of threads is zero, in which case a thread may never become available), DISCARD (throw away the current request and return), DISCARD_OLDEST (throw away the oldest request and return), ABORT (throw a RuntimeException), and RUN (the default; the thread making the execute request runs the task itself, which helps guard against lockup). +
 *Type*: `WAIT`/`DISCARD`/`DISCARD_OLDEST`/`ABORT`/`RUN` +
 *Required*: no +
-*Default*: none 
+*Default*: none
 |`threadWaitTimeout` |How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it will wait indefinitely. +
 *Type*: `integer` +
 *Required*: no  +

--- a/mule-user-guide/v/3.8/tuning-performance.adoc
+++ b/mule-user-guide/v/3.8/tuning-performance.adoc
@@ -81,7 +81,8 @@ Where `maxThreadsActive` is the number of threads that run concurrently and `max
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
 
-Incorrect combinations of thread configurations and maxBufferSize values can cause difficult to identify outages with no apparent cause. Stress should be used to find and validate appropriate configurations.
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficulties to identify outages with no apparent cause. +
+Stress should be used to find and validate appropriate configurations.
 ==========
 
 === Calculating the Flow Threads

--- a/mule-user-guide/v/3.8/tuning-performance.adoc
+++ b/mule-user-guide/v/3.8/tuning-performance.adoc
@@ -75,9 +75,14 @@ Concurrent user requests = `maxThreadsActive` + `maxBufferSize`
 
 Where `maxThreadsActive` is the number of threads that run concurrently and `maxBufferSize` is the number of requests that can wait in the queue for threads to be released.
 
-*Note*:  `maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
+[WARNING]
+==========
+`maxBufferSize` defines the maximum number of requests that are buffered instead of requesting a new thread. New threads create until reaching `minThreads`. After that, a request is buffered until `maxBufferSize` requests are queued. Then new threads create until `maxThreads` is reached.
 
 In other words, if you configure a threading profile with `poolExhaustedAction=WAIT` with a `maxBufferSize` greater than zero, the thread pool does not grow from `minThreads` towards `maxThreads` until the queue completely fills up.
+
+Incorrect combinations of thread configurations and maxBufferSize values can cause difficult to identify outages with no apparent cause. Stress should be used to find and validate appropriate configurations.
+==========
 
 === Calculating the Flow Threads
 


### PR DESCRIPTION
This change should be pushed to previous Mule versions of this page.