### PR TITLE
Update deploying-to-cloudhub.adoc

### DIFF
--- a/runtime-manager/v/latest/deploying-to-cloudhub.adoc
+++ b/runtime-manager/v/latest/deploying-to-cloudhub.adoc
@@ -189,6 +189,7 @@ There are 5 different worker sizes to choose from, with the compute and memory c
 
 Workers that have less than 1 vCore capacity (0.1 vCores and 0.2 vCores)  offer limited CPU and IO for smaller work loads. Each worker has 8 GB of storage, which is used for both system and application storage. Applications with greater storage needs (verbose logging etc.) should use one of the larger worker sizes - 2 vCores or 4 vCores, which have additional storage as follows:
 
+* 1 vCores workers have an additional 4 GB of SSD storage mounted on /tmp
 * 2 vCores workers have an additional 32 GB of SSD storage mounted on /tmp
 * 4 vCores workers have an additional 80 GB of storage, mounted as two volumes on /tmp (40 GB), and /opt/storage (40 GB)
 


### PR DESCRIPTION
adding following one as it was not clear how much storage is attached to /tmp for 1 vCore workers.
* 1 vCores workers have an additional 4 GB of SSD storage mounted on /tmp