### PR TITLE
Update external-oauth-2.0-token-validation-policy.adoc

### DIFF
--- a/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
+++ b/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
@@ -26,6 +26,27 @@ In the required *Access Token validation endpoint url* field, you must enter the
 +
 image::external-oauth-2.0-token-validation-policy-ba3c0.png[external-oauth-2.0-token-validation-policy-ba3c0,height=375,width=404]
 
+== Configuring the Proxy Connection to External Authentication Provider
+
+In Mule 3.8.x, you optionally enable or disable the proxy network connection between the API and External Authentication Provider by setting the following parameter:
+
+`external_authentication_provider_enable_proxy_setting`
+
+This parameter is located in the following wrapper configuration file: `$MULE_HOME/conf/wrapper.conf`
+
+Set the parameter to true or false. For example:
+
+`wrapper.java.additional.<n>=-Dexternal_authentication_provider_enable_proxy_setting=true`
+
+// default changing in 3.9 
+
+By default, the parameter is false, so the proxy connection between the API and External Authentication Provider is disabled because the following proxy settings are ignored:
+
+----
+wrapper.java.additional.<n>=-Danypoint.platform.proxy_host=localhost
+wrapper.java.additional.<n>=-Danypoint.platform.proxy_port=8080
+----
+
 == Obtaining API User Information
 
 In some cases, you might want to get information about externally authenticated users who use your API. Place the following script between the inbound and outbound endpoints of the proxy application to which you applied the policy. The script executes after the enforcement of the policy:


### PR DESCRIPTION
Please add the fragment with the proxy config if behind a reverse proxy which explains the addition of the anypoint.platform.external_authentication_provider_enable_proxy_settings to the configuration of Mule RT