### PR TITLE
remove hearing a response in 48 hrs

### DIFF
--- a/access-management/v/latest/managing-users.adoc
+++ b/access-management/v/latest/managing-users.adoc
@@ -52,4 +52,4 @@ Field name in the SAML repository that maps to Group.
 +
 . Save your configuration.
 +
-Within 48 hours, you receive confirmation of or follow-up questions to complete the configuration.
+. Sign out and then navigate to the Sign On Url entered above and sign in via your identity provider to test the configuration.


### PR DESCRIPTION
Update docs to remove about hearing from mulesoft within 48 hrs of form submission since this is now self-serve and mulesoft support is no longer involved in entering/validating their configuration.