### PR TITLE
Update JRE 1.6 download link for Mac

### DIFF
--- a/anypoint-studio/v/5/download-and-launch-anypoint-studio.adoc
+++ b/anypoint-studio/v/5/download-and-launch-anypoint-studio.adoc
@@ -11,7 +11,7 @@ For details on installing the Mule standalone runtime, the Mule Management Conso
 . Before downloading and launching Anypoint Studio, install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[Java SE JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
 +
 [NOTE]
-If you are using a Mac computer running OS X and if you are installing Anypoint Studio on a new computer or a fresh installation, you must also install link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html[JRE 1.6], which provides important libraries used by later JDK versions. Install JDK 6 first and then install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[JDK 7].
+If you are using a Mac computer running OS X and if you are installing Anypoint Studio on a new computer or a fresh installation, you must also install link:https://support.apple.com/kb/DL1572[JRE 1.6], which provides important libraries used by later JDK versions. Install JDK 6 first and then install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[JDK 7].
 +
 See also: <<Running Studio on a Mac>>
 

--- a/anypoint-studio/v/5/hardware-and-software-requirements.adoc
+++ b/anypoint-studio/v/5/hardware-and-software-requirements.adoc
@@ -17,7 +17,7 @@ a|* 4GB of free memory available
 |*Java Environments*
 a|
 * Oracle JDK 1.8
-* Oracle JDK 1.7.0 (recommended: link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u80-oth-JPR[JDK 1.7.0_79/80]) - *Note*: If you install Anypoint Studio on a new Mac computer, you also need to install link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html[JRE 1.6]
+* Oracle JDK 1.7.0 (recommended: link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u80-oth-JPR[JDK 1.7.0_79/80]) - *Note*: If you install Anypoint Studio on a new Mac computer, you also need to install link:https://support.apple.com/kb/DL1572[JRE 1.6]
 
 |*Operating Systems*
 

--- a/anypoint-studio/v/6/download-and-launch-anypoint-studio.adoc
+++ b/anypoint-studio/v/6/download-and-launch-anypoint-studio.adoc
@@ -10,7 +10,7 @@ For details on installing the Mule standalone runtime, the Mule Management Conso
 
 * Before downloading and launching Anypoint Studio, install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[Java SE JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
 
-* If you are using a Mac computer running OS X and if you are installing Anypoint Studio on a new computer or a fresh installation, you must also install link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html[JRE 1.6], which provides important libraries used by later JDK versions. Install JDK 6 first and then install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
+* If you are using a Mac computer running OS X and if you are installing Anypoint Studio on a new computer or a fresh installation, you must also install link:https://support.apple.com/kb/DL1572[JRE 1.6], which provides important libraries used by later JDK versions. Install JDK 6 first and then install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
 +
 After installing JDK 7 or 8, you need to change the default Java virtual machine (JVM) from v6 to the later version.
 
@@ -59,7 +59,7 @@ If a Java runtime environment is _not_ installed, install link:http://www.or
 
 *OS X*: If you're using OS version Sierra, it's important that you move your extracted app to the `/applications` folder before you launch it
 
-*Linux*: To support some of Studio Themes in Linux, it is recommended to have GTK version 2 installed. 
+*Linux*: To support some of Studio Themes in Linux, it is recommended to have GTK version 2 installed.
 ====
 +
 . Open Anypoint Studio:

--- a/anypoint-studio/v/6/hardware-and-software-requirements.adoc
+++ b/anypoint-studio/v/6/hardware-and-software-requirements.adoc
@@ -19,7 +19,7 @@ a|* 4GB of free memory available
 |*Java Environments*
 a|
 * Oracle JDK 1.8
-* Oracle JDK 1.7.0 (recommended: link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u80-oth-JPR[JDK 1.7.0_79/80]) - *Note*: If you install Anypoint Studio on a new MacOS computer, you also need to install link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html[JRE 1.6]
+* Oracle JDK 1.7.0 (recommended: link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#jdk-7u80-oth-JPR[JDK 1.7.0_79/80]) - *Note*: If you install Anypoint Studio on a new MacOS computer, you also need to install link:https://support.apple.com/kb/DL1572[JRE 1.6]
 
 |*Operating Systems*
 


### PR DESCRIPTION
The link to Oracle download page does not actually contain JRE 1.6 for
Mac. This commit replaces it with Apple's JRE 1.6 download page.