### PR TITLE
fix AsciiDoc syntax errors that pertain to image macros

### DIFF
--- a/anypoint-connector-devkit/v/3.8/connector-reference-documentation.adoc
+++ b/anypoint-connector-devkit/v/3.8/connector-reference-documentation.adoc
@@ -38,20 +38,21 @@ The DevKit-supported Javadoc tags are described in this table and are used in ex
 `* @param document`
 `* a {@link org.bson.Document} instance.`
 
-image:javadoc-link-sample.png[javadoc-link]
+image::javadoc-link-sample.png[javadoc-link]
 |`@see` | Provides an in-line link to a URL, for example to a page where a related class or method is described a| If you want URLs inside your Javadoc comments to be parsed as hyperlinks, you can use the Javadoc tag `@see` to create an in-line link that will parse `+{@see http://example.com}+` +
 or instead +
 `{@see <a href="http://example.com">http://example.com</a>}` to display the full URL. For a more detailed discussion of its usage, see link:http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see[Javadoc reference]
 |`@api.doc`|Adds a new section to the documentation intended to provide a link to a service API’s documentation. You have the option whether or not to use html after the tag a|
 `* @api.doc <a href="http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_create.htm">create()</a>`
 
-image:apidoc-ref-sample.png[apidoc-ref-sample]
+image::apidoc-ref-sample.png[apidoc-ref-sample]
 |`@javadoc` | Can be used on the connector class, for example, `@javadoc.url`, followed by the name of a Java package name and the Javadoc URL, which the `@link` tag can use to reference a data type referenced in javadoc | See <<Annotation for Non-Java Data Types,Annotation for Non-Java Data Types>> for the code comment snippet.
 |`@param` | Used underneath the description of a method. `@param` adds the parameter name and its description to the reference material. The description should be listed on the line below a|
 `* @param collection`
 
 `* the name of the collection to update`
-image:apidoc-param-sample.png[apidoc-param]
+
+image::apidoc-param-sample.png[apidoc-param]
 |`@return` | Adds the description of the function's return type to the "Returns" section of the documentation. a|
 `* @return the id that was just inserted`
 

--- a/anypoint-studio/v/5/studio-visual-debugger.adoc
+++ b/anypoint-studio/v/5/studio-visual-debugger.adoc
@@ -62,26 +62,23 @@ Complete the following macro-steps to use the Visual Debugger in Studio.
 
 === Setting Breakpoints
 
-. Right-click a building block, then select *Toggle breakpoint*. +
-
+. Right-click a building block, then select *Toggle breakpoint*.
 +
 image:2-set.breakp.1.png[2-set.breakp.1]
-+
 
-. Studio applies a red dot to the building block's icon on the canvas. +
-
+. Studio applies a red dot to the building block's icon on the canvas.
 +
 image:2-set.breakp.2.png[2-set.breakp.2]
-+
 
 When you run your application in Debug mode, Studio stops the flow execution at the breakpoint you have set, allowing you to check the message contents in the <<Mule Debugger View>>.
 
 === Running in Debug Mode
 
-. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window. +
- image:confirm.perspective.switch.png[confirm.perspective.switch] +
+. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window.
++
+image:confirm.perspective.switch.png[confirm.perspective.switch]
 
-. Click *Yes* to open the Debug perspective, from which you can access the full functionality of the Visual Debugger.  +
+. Click *Yes* to open the Debug perspective, from which you can access the full functionality of the Visual Debugger.
 
 === Viewing Message Data at a Breakpoint
 

--- a/anypoint-studio/v/5/using-subversion-with-studio.adoc
+++ b/anypoint-studio/v/5/using-subversion-with-studio.adoc
@@ -1,43 +1,43 @@
 = Using Subversion with Studio
 :keywords: anypoint studio, studio, mule esb, version control, versioning, subversion
 
-
 http://subversion.apache.org/[Subversion] facilitates the tracking and versioning of changes developers make to a software project; this enables several people to work on the same project simultaneously without creating conflicts among the changes and additions they make.
 
 Studio enables you to work with Subversion (SVN) in two ways: you can save your Studio project to an SVN repository, or you can import your existing projects from SVN into Studio. To move projects between Studio and SVN, you must first install Subversion's *Subeclipse plugin* in Studio.
 
 == Installing the Subversion Plugin
 
-. From Studio, click *Help*, then select *Install New Software...* +
- image:InstallNewSoftware+copy.png[InstallNewSoftware+copy]
+. From Studio, click *Help*, then select *Install New Software...*
 +
-. In the *Available Software* panel, click *Add* and provide the following name and URL. +
- *Note*: Use "1.8.x" as shown (the .x is not a placeholder): +
- +
-`Subclipse Update Site – http://subclipse.tigris.org/update_1.8.x ` +
- +
- image:subeclipse_select.png[subeclipse_select]
+image:InstallNewSoftware+copy.png[InstallNewSoftware+copy]
+
+. In the *Available Software* panel, click *Add* and provide the following name and URL.
 +
+*Note*: Use "1.8.x" as shown (the .x is not a placeholder):
++
+ Subclipse Update Site — http://subclipse.tigris.org/update_1.8.x
++
+image:subeclipse_select.png[subeclipse_select]
+
 . Click the check box to select both *Subclipse* and *SVNKit*. 
-. _DESELECT_   ` Subclipse Integration for Mylyn 3.x (Optional) 3.0.0  ` so that Studio does not install this portion. +
- +
-image:subeclipse.png[subeclipse] +
+. _DESELECT_   ` Subclipse Integration for Mylyn 3.x (Optional) 3.0.0  ` so that Studio does not install this portion.
++
+image:subeclipse.png[subeclipse]
 
 . Click *Next* to continue.
 . In the *Install Details* panel, click *Next* to continue installation.
 . In the *Review Licenses* panel, select *I accept the terms of the license agreement* then click *Finish*.
-. When Mule completes installation of the `Subeclipse` plugin, click *Restart Now* to complete the installation and restart Studio. +
- +
+. When Mule completes installation of the `Subeclipse` plugin, click *Restart Now* to complete the installation and restart Studio.
++
 image:restart.png[restart]
 
 . Starting from Studio's application menu, click *Window*, (or *Application Studio* in Mac), and click *Preferences*.
 . Click the expand arrow next to *Team*, then select *SVN*.
-. In the *SVN Interface* pane, use the drop down menu in the *Client* field to select *SVNKit* and click *OK*: +
- `SVNKit (Pure Java) SVNKit v1.7.9.9659`
-
+. In the *SVN Interface* pane, use the drop down menu in the *Client* field to select *SVNKit* and click *OK*:
++
+ SVNKit (Pure Java) SVNKit v1.7.9.9659
 +
 image:preferences.png[preferences]
-+
 
 . If you are using Mac OS, see http://subclipse.tigris.org/wiki/JavaHL for additional information.
 
@@ -46,26 +46,27 @@ image:preferences.png[preferences]
 You can save a Studio project to an SVN repository so that multiple developers can save changes to the project in a single, shared location. When you have completed your individual work on a Studio project, you can check the project into the SVN repository, thus avoiding version conflicts with other users.
 
 [WARNING]
-This procedure assumes that you have already created ---and have read-write access to — a shared Subversion repository.
+This procedure assumes that you have already created and have read-write access to a shared Subversion repository.
 
-. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Share Project...**. +
- +
+. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Share Project...**.
++
 image:team_share.png[team_share]
 
-. In the *Share Project* wizard, specify the location of your SVN project in the *URI* field, then click *Next*. +
- +
+. In the *Share Project* wizard, specify the location of your SVN project in the *URI* field, then click *Next*.
++
 image:repo_info2.png[repo_info2]
++
 [NOTE]
-If you have already configured an SVN repository in Studio, you can select *Use existing repository location* to commit your project to the existing repository. +
- +
- image:existing_repo.png[existing_repo]
+If you have already configured an SVN repository in Studio, you can select *Use existing repository location* to commit your project to the existing repository.
++
+image:existing_repo.png[existing_repo]
 
-. In the next wizard panel, specify the name of your project's folder within the SVN repository. +
- +
+. In the next wizard panel, specify the name of your project's folder within the SVN repository.
++
 image:folder_name.png[folder_name]
 
-. Click *Next*, then edit the commit comments, if you wish, to describe the changes you have made to the project. +
- +
+. Click *Next*, then edit the commit comments, if you wish, to describe the changes you have made to the project.
++
 image:comment_2.png[comment_2]
 
 . Click *Finish*.
@@ -78,14 +79,14 @@ image:perspective-1.png[perspective-1]
 You may wish to check out a Subversion project and import it into Studio in order to leverage Studio's graphical user interface. To do so, you must first install an SVN plugin, then access your SVN project from Studio.
 
 [WARNING]
-This procedure assumes that you have already created ---and have read-write access to — a shared Subversion repository, and that you have saved to that repository the project you wish to access in Studio.
+This procedure assumes that you have already created and have read-write access to a shared Subversion repository, and that you have saved to that repository the project you wish to access in Studio.
 
-. Starting from Studio's application menu, click *Window*, navigate to *Open Perspective,* then select *Other...* +
- +
+. Starting from Studio's application menu, click *Window*, navigate to *Open Perspective,* then select *Other...*
++
 image:open_persp_crop.png[open_persp_crop]
 
-. In the pop-up panel, select *SVN Repository Exploring*, then click *OK*. +
- +
+. In the pop-up panel, select *SVN Repository Exploring*, then click *OK*.
++
 image:SVN_repo.png[SVN_repo]
 +
 [TIP]
@@ -93,25 +94,25 @@ To switch back to the *Mule* perspective, click the Mule icon next to *SVN Repos
 +
 image:perspectives.png[perspectives]
 
-. After Studio opens the new perspective, *SVN Repository Exploring*, right-click within the *SVN Repositories* explorer tab, select *New*, then **Repository Location...**. +
- +
+. After Studio opens the new perspective, *SVN Repository Exploring*, right-click within the *SVN Repositories* explorer tab, select *New*, then **Repository Location...**.
++
 image:repo_location2.png[repo_location2]
 
-. In the *Url* field, enter the location of your SVN repository and click *Finish*. +
- +
+. In the *Url* field, enter the location of your SVN repository and click *Finish*.
++
 image:add_SVN_cropped.png[add_SVN_cropped]
 
-. In the SVN Repository Exploring tab, right click your project name and select *Checkout*. Within context of Subversion, you are checking out the project from your SVN repository. +
- +
+. In the SVN Repository Exploring tab, right click your project name and select *Checkout*. Within context of Subversion, you are checking out the project from your SVN repository.
++
 image:checkout_2.png[checkout_2]
 
-. Click the *Mule* perspective to work on the project in Studio. +
- +
+. Click the *Mule* perspective to work on the project in Studio.
++
 image:mule_pers.png[mule_pers]
 
 . After you have completed your changes to your Studio project, you must commit your changes to the SVN repository. In the Mule perspective, click *File*, then *Save*.
-. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Commit...**. +
- +
+. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Commit...**.
++
 image:commit_3.png[commit_3]
 
 . In the *Commit message* field of the *Commit Changes* panel, enter notes to describe what you have added or changed in the Studio project.

--- a/anypoint-studio/v/6/studio-visual-debugger.adoc
+++ b/anypoint-studio/v/6/studio-visual-debugger.adoc
@@ -64,26 +64,23 @@ Complete the following macro-steps to use the Visual Debugger in Studio.
 
 === Setting Breakpoints
 
-. Right-click a building block, then select *Toggle breakpoint*. +
-
+. Right-click a building block, then select *Toggle breakpoint*.
 +
 image:2-set.breakp.1.png[2-set.breakp.1]
-+
 
-. Studio applies a red dot to the building block's icon on the canvas. +
-
+. Studio applies a red dot to the building block's icon on the canvas.
 +
 image:2-set.breakp.2.png[2-set.breakp.2]
-+
 
 When you run your application in Debug mode, Studio stops the flow execution at the breakpoint you have set, allowing you to check the message contents in the <<Mule Debugger View>>.
 
 === Running in Debug Mode
 
-. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window. +
- image:confirm.perspective.switch.png[confirm.perspective.switch] +
+. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window.
++
+image:confirm.perspective.switch.png[confirm.perspective.switch] +
 
-. Click *Yes* to open the Debug perspective, from which you can access the full functionality of the Visual Debugger.  +
+. Click *Yes* to open the Debug perspective, from which you can access the full functionality of the Visual Debugger.
 
 === Viewing Message Data at a Breakpoint
 

--- a/anypoint-studio/v/6/using-subversion-with-studio.adoc
+++ b/anypoint-studio/v/6/using-subversion-with-studio.adoc
@@ -1,43 +1,43 @@
 = Using Subversion with Studio
 :keywords: anypoint studio, studio, mule esb, version control, versioning, subversion
 
-
 http://subversion.apache.org/[Subversion] facilitates the tracking and versioning of changes developers make to a software project; this enables several people to work on the same project simultaneously without creating conflicts among the changes and additions they make.
 
 Studio enables you to work with Subversion (SVN) in two ways: you can save your Studio project to an SVN repository, or you can import your existing projects from SVN into Studio. To move projects between Studio and SVN, you must first install Subversion's *Subeclipse plugin* in Studio.
 
 == Installing the Subversion Plugin
 
-. From Studio, click *Help*, then select *Install New Software...* +
- image:InstallNewSoftware+copy.png[InstallNewSoftware+copy]
+. From Studio, click *Help*, then select *Install New Software...*
 +
-. In the *Available Software* panel, click *Add* and provide the following name and URL. +
- *Note*: Use "1.8.x" as shown (the .x is not a placeholder): +
- +
-`Subclipse Update Site – http://subclipse.tigris.org/update_1.8.x ` +
- +
- image:subeclipse_select.png[subeclipse_select]
+image:InstallNewSoftware+copy.png[InstallNewSoftware+copy]
+
+. In the *Available Software* panel, click *Add* and provide the following name and URL.
 +
+*Note*: Use "1.8.x" as shown (the .x is not a placeholder):
++
+ Subclipse Update Site – http://subclipse.tigris.org/update_1.8.x
++
+image:subeclipse_select.png[subeclipse_select]
+
 . Click the check box to select both *Subclipse* and *SVNKit*. 
-. _DESELECT_   ` Subclipse Integration for Mylyn 3.x (Optional) 3.0.0  ` so that Studio does not install this portion. +
- +
-image:subeclipse.png[subeclipse] +
+. _DESELECT_   ` Subclipse Integration for Mylyn 3.x (Optional) 3.0.0  ` so that Studio does not install this portion.
++
+image:subeclipse.png[subeclipse]
 
 . Click *Next* to continue.
 . In the *Install Details* panel, click *Next* to continue installation.
 . In the *Review Licenses* panel, select *I accept the terms of the license agreement* then click *Finish*.
-. When Mule completes installation of the `Subeclipse` plugin, click *Restart Now* to complete the installation and restart Studio. +
- +
+. When Mule completes installation of the `Subeclipse` plugin, click *Restart Now* to complete the installation and restart Studio.
++
 image:restart.png[restart]
 
 . Starting from Studio's application menu, click *Window*, (or *Application Studio* in Mac), and click *Preferences*.
 . Click the expand arrow next to *Team*, then select *SVN*.
-. In the *SVN Interface* pane, use the drop down menu in the *Client* field to select *SVNKit* and click *OK*: +
- `SVNKit (Pure Java) SVNKit v1.7.9.9659`
-
+. In the *SVN Interface* pane, use the drop down menu in the *Client* field to select *SVNKit* and click *OK*:
++
+ SVNKit (Pure Java) SVNKit v1.7.9.9659`
 +
 image:preferences.png[preferences]
-+
 
 . If you are using Mac OS, see http://subclipse.tigris.org/wiki/JavaHL for additional information.
 
@@ -46,31 +46,32 @@ image:preferences.png[preferences]
 You can save a Studio project to an SVN repository so that multiple developers can save changes to the project in a single, shared location. When you have completed your individual work on a Studio project, you can check the project into the SVN repository, thus avoiding version conflicts with other users.
 
 [WARNING]
-This procedure assumes that you have already created ---and have read-write access to — a shared Subversion repository.
+This procedure assumes that you have already created and have read-write access to a shared Subversion repository.
 
-. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Share Project...**. +
- +
+. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Share Project...**.
++
 image:team_share.png[team_share]
 
-. In the *Share Project* wizard, specify the location of your SVN project in the *URI* field, then click *Next*. +
- +
+. In the *Share Project* wizard, specify the location of your SVN project in the *URI* field, then click *Next*.
++
 image:repo_info2.png[repo_info2]
++
 [NOTE]
-If you have already configured an SVN repository in Studio, you can select *Use existing repository location* to commit your project to the existing repository. +
- +
- image:existing_repo.png[existing_repo]
+If you have already configured an SVN repository in Studio, you can select *Use existing repository location* to commit your project to the existing repository.
++
+image:existing_repo.png[existing_repo]
 
-. In the next wizard panel, specify the name of your project's folder within the SVN repository. +
- +
+. In the next wizard panel, specify the name of your project's folder within the SVN repository.
++
 image:folder_name.png[folder_name]
 
-. Click *Next*, then edit the commit comments, if you wish, to describe the changes you have made to the project. +
- +
+. Click *Next*, then edit the commit comments, if you wish, to describe the changes you have made to the project.
++
 image:comment_2.png[comment_2]
 
 . Click *Finish*.
 . Studio displays a panel that gives you the option to automatically open *Synchronize View*, which ensures that your local workspace does not conflict with your team's repository. Click *Yes* to open the view and begin synchronizing your workspaces; click *No* to simply return to your local workspace in Studio.
-
++
 image:perspective-1.png[perspective-1]
 
 == Checking Out a Project
@@ -78,14 +79,14 @@ image:perspective-1.png[perspective-1]
 You may wish to check out a Subversion project and import it into Studio in order to leverage Studio's graphical user interface. To do so, you must first install an SVN plugin, then access your SVN project from Studio.
 
 [WARNING]
-This procedure assumes that you have already created ---and have read-write access to — a shared Subversion repository, and that you have saved to that repository the project you wish to access in Studio.
+This procedure assumes that you have already created and have read-write access to a shared Subversion repository, and that you have saved to that repository the project you wish to access in Studio.
 
-. Starting from Studio's application menu, click *Window*, navigate to *Open Perspective,* then select *Other...* +
- +
+. Starting from Studio's application menu, click *Window*, navigate to *Open Perspective,* then select *Other...*
++
 image:open_persp_crop.png[open_persp_crop]
 
-. In the pop-up panel, select *SVN Repository Exploring*, then click *OK*. +
- +
+. In the pop-up panel, select *SVN Repository Exploring*, then click *OK*.
++
 image:SVN_repo.png[SVN_repo]
 +
 [TIP]
@@ -93,25 +94,25 @@ To switch back to the *Mule* perspective, click the Mule icon next to *SVN Repos
 +
 image:perspectives.png[perspectives]
 
-. After Studio opens the new perspective, *SVN Repository Exploring*, right-click within the *SVN Repositories* explorer tab, select *New*, then **Repository Location...**. +
- +
+. After Studio opens the new perspective, *SVN Repository Exploring*, right-click within the *SVN Repositories* explorer tab, select *New*, then **Repository Location...**.
++
 image:repo_location2.png[repo_location2]
 
-. In the *Url* field, enter the location of your SVN repository and click *Finish*. +
- +
+. In the *Url* field, enter the location of your SVN repository and click *Finish*.
++
 image:add_SVN_cropped.png[add_SVN_cropped]
 
-. In the SVN Repository Exploring tab, right click your project name and select *Checkout*. Within context of Subversion, you are checking out the project from your SVN repository. +
- +
+. In the SVN Repository Exploring tab, right click your project name and select *Checkout*. Within context of Subversion, you are checking out the project from your SVN repository.
++
 image:checkout_2.png[checkout_2]
 
-. Click the *Mule* perspective to work on the project in Studio. +
- +
+. Click the *Mule* perspective to work on the project in Studio.
++
 image:mule_pers.png[mule_pers]
 
 . After you have completed your changes to your Studio project, you must commit your changes to the SVN repository. In the Mule perspective, click *File*, then *Save*.
-. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Commit...**. +
- +
+. In *Package Explorer*, right click your project name, navigate to *Team*, then select **Commit...**.
++
 image:commit_3.png[commit_3]
 
 . In the *Commit message* field of the *Commit Changes* panel, enter notes to describe what you have added or changed in the Studio project.

--- a/mule-management-console/v/3.7/mmc-walkthrough.adoc
+++ b/mule-management-console/v/3.7/mmc-walkthrough.adoc
@@ -36,8 +36,8 @@ Login to MMC with the following credentials:
 * Password: `admin`
 
 The console Dashboard "Quick Start" panel, which displays when you first login, indicates that there are no servers to register. Close the Quick Start panel by clicking the *X* in the upper right corner.
- +
-image:MMC-quickstartpanel-annotated.png[MMC-quickstartpanel-annotated] +
+
+image:MMC-quickstartpanel-annotated.png[MMC-quickstartpanel-annotated]
 
 == Registering the Server
 

--- a/mule-management-console/v/3.8/mmc-walkthrough.adoc
+++ b/mule-management-console/v/3.8/mmc-walkthrough.adoc
@@ -37,8 +37,8 @@ Login to MMC with the following credentials:
 * Password: `admin`
 
 The console Dashboard "Quick Start" panel, which displays when you first login, indicates that there are no servers to register. Close the Quick Start panel by clicking the *X* in the upper right corner.
- +
-image:MMC-quickstartpanel-annotated.png[MMC-quickstartpanel-annotated] +
+
+image:MMC-quickstartpanel-annotated.png[MMC-quickstartpanel-annotated]
 
 == Registering the Server
 

--- a/mule-user-guide/v/3.4/studio-visual-debugger.adoc
+++ b/mule-user-guide/v/3.4/studio-visual-debugger.adoc
@@ -187,7 +187,9 @@ Linux and Windows:
 Complete the following steps to test a Mule expression against the message processor set with a breakpoint.
 
 . Ensure that Studio has stopped flow execution at the desired breakpoint. When stopped, the breakpoint appears surrounded by a dotted blue line in the canvas, and Studio populates the <<Mule Debugger View>> with information.
-. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).image:/docs/download/attachments/95393509/expr.eval.window1-2.png?version=1&modificationDate=1374598696363[image]
+. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).
++
+image:/docs/download/attachments/95393509/expr.eval.window1-2.png?version=1&modificationDate=1374598696363[image]
 
 . Type the Mule expression you wish to evaluate in the provided input field, then press *enter*. Studio evaluates the expression, then displays the result in the *Name*, *Value* and *Type* columns.
 

--- a/mule-user-guide/v/3.5/mule-versus-web-application-server.adoc
+++ b/mule-user-guide/v/3.5/mule-versus-web-application-server.adoc
@@ -29,49 +29,55 @@ Mule specializes in three things:
 |===
 |Mule |Web Application Servers
 a|
-image:soft-soft.png[soft-soft]Mule was built to make _software-to-software_ interactions easier. 
+image::soft-soft.png[soft-soft]
 
- a|
-image:soft-people.png[soft-people]Web application servers are designed to make _software-to-end-user_ interactions easier. 
+Mule was built to make _software-to-software_ interactions easier. 
 
 a|
-image:icon-gears-blue-small.png[icon-gears-blue-small]
+image::soft-people.png[soft-people]
+
+Web application servers are designed to make _software-to-end-user_ interactions easier. 
+
+a|
+image::icon-gears-blue-small.png[icon-gears-blue-small]
 
 Mule specializes in integration between different applications, databases, and cloud services.
 
- a|
-image:icon-team-blue-small.png[icon-team-blue-small]Web applications specialize in interaction with end users.
+a|
+image::icon-team-blue-small.png[icon-team-blue-small]
+
+Web applications specialize in interaction with end users.
 
 a|
-image:icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
+image::icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
 
 Mule applications are stateless and event-driven.
 
- a|
-image:icon-time-blue-small.png[icon-time-blue-small]
+a|
+image::icon-time-blue-small.png[icon-time-blue-small]
 
 Web applications are stateful.
 
 a|
-image:icon-concept-blue-small.png[icon-concept-blue-small]
+image::icon-concept-blue-small.png[icon-concept-blue-small]
 
 Mule supports service-oriented architecture.
 
- |image:tiers.png[tiers]Web applications support multitier architecture.
+a|
+image::tiers.png[tiers]
+
+Web applications support multitier architecture.
 
 a|
 *Mule applications* are built as a series of lightweight, stateless components in an event-driven processing chain called a flow.
 
 Data travels in, through, and out of a Mule application, connecting other applications, databases, enterprise systems, or cloud services to one another. By keeping individual services at either end of the flow discrete, Mule supports http://en.wikipedia.org/wiki/Service-oriented_architecture[service-oriented architecture].
 
- a|
+a|
 *Web application servers* support a http://en.wikipedia.org/wiki/Multitier_architecture[multitier architecture], which allocates presentation, processing, and data management into logically separate layers.
 
 Using a web application server makes it easy to deliver a graphical user interface on the presentation layer, but it doesn't include the integration capabilities of Mule that would allow it to connect seamlessly to databases or other services. For that, you'd have to write custom code. 
-
 |===
-
-
 
 You can successfully link:/mule-user-guide/v/3.6/embedding-mule-in-a-java-application-or-webapp[embed Mule within a web application server] like Tomcat or JBoss, or you could embed any other kind of web container inside a Mule flow. Leveraging Mule for the integration and service orchestration tasks that it was designed for and using an application server to handle the end-user interactions can provide a full spectrum of functionality. 
 

--- a/mule-user-guide/v/3.5/studio-visual-debugger.adoc
+++ b/mule-user-guide/v/3.5/studio-visual-debugger.adoc
@@ -189,7 +189,9 @@ Linux and Windows:
 Complete the following steps to test a Mule expression against the message processor set with a breakpoint.
 
 . Ensure that Studio has stopped flow execution at the desired breakpoint. When stopped, the breakpoint appears surrounded by a dotted blue line in the canvas, and Studio populates the <<Mule Debugger View>> with information.
-. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).image:/docs/download/attachments/122752267/expr.eval.window1-2.png?version=1&modificationDate=1358885208220[image]
+. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).
++
+image:/docs/download/attachments/122752267/expr.eval.window1-2.png?version=1&modificationDate=1358885208220[image]
 
 . Type the Mule expression you wish to evaluate in the provided input field, then press *enter*. Studio evaluates the expression, then displays the result in the *Name*, *Value* and *Type* columns.
 

--- a/mule-user-guide/v/3.6/mule-versus-web-application-server.adoc
+++ b/mule-user-guide/v/3.6/mule-versus-web-application-server.adoc
@@ -29,49 +29,55 @@ Mule specializes in three things:
 |===
 |Mule |Web Application Servers
 a|
-image:soft-soft.png[soft-soft]Mule was built to make _software-to-software_ interactions easier. 
+image::soft-soft.png[soft-soft]
 
- a|
-image:soft-people.png[soft-people]Web application servers are designed to make _software-to-end-user_ interactions easier. 
+Mule was built to make _software-to-software_ interactions easier. 
 
 a|
-image:icon-gears-blue-small.png[icon-gears-blue-small]
+image::soft-people.png[soft-people]
+
+Web application servers are designed to make _software-to-end-user_ interactions easier. 
+
+a|
+image::icon-gears-blue-small.png[icon-gears-blue-small]
 
 Mule specializes in integration between different applications, databases, and cloud services.
 
- a|
-image:icon-team-blue-small.png[icon-team-blue-small]Web applications specialize in interaction with end users.
+a|
+image::icon-team-blue-small.png[icon-team-blue-small]
+
+Web applications specialize in interaction with end users.
 
 a|
-image:icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
+image::icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
 
 Mule applications are stateless and event-driven.
 
- a|
-image:icon-time-blue-small.png[icon-time-blue-small]
+a|
+image::icon-time-blue-small.png[icon-time-blue-small]
 
 Web applications are stateful.
 
 a|
-image:icon-concept-blue-small.png[icon-concept-blue-small]
+image::icon-concept-blue-small.png[icon-concept-blue-small]
 
 Mule supports service-oriented architecture.
 
- |image:tiers.png[tiers]Web applications support multitier architecture.
+a|
+image::tiers.png[tiers]
+
+Web applications support multitier architecture.
 
 a|
 *Mule applications* are built as a series of lightweight, stateless components in an event-driven processing chain called a flow.
 
 Data travels in, through, and out of a Mule application, connecting other applications, databases, enterprise systems, or cloud services to one another. By keeping individual services at either end of the flow discrete, Mule supports http://en.wikipedia.org/wiki/Service-oriented_architecture[service-oriented architecture].
 
- a|
+a|
 *Web application servers* support a http://en.wikipedia.org/wiki/Multitier_architecture[multitier architecture], which allocates presentation, processing, and data management into logically separate layers.
 
 Using a web application server makes it easy to deliver a graphical user interface on the presentation layer, but it doesn't include the integration capabilities of Mule that would allow it to connect seamlessly to databases or other services. For that, you'd have to write custom code. 
-
 |===
-
-
 
 You can successfully link:/mule-user-guide/v/3.6/embedding-mule-in-a-java-application-or-webapp[embed Mule within a web application server] like Tomcat or JBoss, or you could embed any other kind of web container inside a Mule flow. Leveraging Mule for the integration and service orchestration tasks that it was designed for and using an application server to handle the end-user interactions can provide a full spectrum of functionality. 
 

--- a/mule-user-guide/v/3.6/studio-visual-debugger.adoc
+++ b/mule-user-guide/v/3.6/studio-visual-debugger.adoc
@@ -58,24 +58,21 @@ Complete the following macro-steps to use the Visual Debugger in Studio.
 
 === Setting Breakpoints
 
-. Right-click a building block, then select *Toggle breakpoint*. +
-
+. Right-click a building block, then select *Toggle breakpoint*.
 +
 image:2-set.breakp.1.png[2-set.breakp.1]
-+
 
-. Studio applies a red dot to the building block's icon on the canvas. +
-
+. Studio applies a red dot to the building block's icon on the canvas.
 +
 image:2-set.breakp.2.png[2-set.breakp.2]
-+
 
 When you run your application in Debug mode, Studio stops the flow execution at the breakpoint you have set, allowing you to check the message contents in the <<Mule Debugger View>>.
 
 === Running in Debug Mode
 
-. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window. +
- image:confirm.perspective.switch.png[confirm.perspective.switch] +
+. In the *Package Explorer* pane, right-click your application, then select *Debug As* > *Mule Application*. Studio begins running the application in Debug mode, and displays the *Confirm Perspective Switch* window.
++
+image:confirm.perspective.switch.png[confirm.perspective.switch] +
 
 . Click *Yes* to open the Debug perspective, from which you can access the full functionality of the Visual Debugger.  +
 
@@ -193,7 +190,9 @@ Linux and Windows:
 Complete the following steps to test a Mule expression against the message processor set with a breakpoint.
 
 . Ensure that Studio has stopped flow execution at the desired breakpoint. When stopped, the breakpoint appears surrounded by a dotted blue line in the canvas, and Studio populates the <<Mule Debugger View>> with information.
-. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).image:/documentation/download/attachments/122752267/expr.eval.window1-2.png?version=1&modificationDate=1358885208220[image]
+. Click the *Evaluate Mule Expression* icon  above the right-hand pane in the Mule Debugger View. Studio displays the expression evaluation window (with yellow background in the image below).
++
+image:/documentation/download/attachments/122752267/expr.eval.window1-2.png?version=1&modificationDate=1358885208220[image]
 
 . Type the Mule expression you wish to evaluate in the provided input field, then press *enter*. Studio evaluates the expression, then displays the result in the *Name*, *Value* and *Type* columns.
 

--- a/mule-user-guide/v/3.7/microsoft-sharepoint-2013-connector.adoc
+++ b/mule-user-guide/v/3.7/microsoft-sharepoint-2013-connector.adoc
@@ -195,7 +195,6 @@ If any of these fields are selected to be returned by the query, two types of re
 
 * *not checked*: A summary object containing the reference object's ID and the reference object list's ID:
 +
-
 [source, json, linenums]
 ----
 {
@@ -214,15 +213,14 @@ If any of these fields are selected to be returned by the query, two types of re
     }
 }
 ----
-
-This object can later be used in another connector to retrieve the referenced object +
-together with a for each component: +
- +
- image:MSSPListItemQuery.png[MSSPListItemQuery] 
++
+This object can later be used in another connector to retrieve the referenced object
+together with a for each component:
++
+image:MSSPListItemQuery.png[MSSPListItemQuery] 
 
 * *checked*. Retrieves the full object graph. In case there is a cycle, the summary reference object displays:
 +
-
 [source, json, linenums]
 ----
 {
@@ -246,11 +244,11 @@ together with a for each component: +
     ]
 }
 ----
-
++
 Example *Query Text*:
-
++
 image:SPExampleQText.png[SPExampleQText]
-
++
 > Warning: Checking this option may cause large item lists with many reference fields to take a long time to retrieve.
 
 Since version 2.1.10 you can use the _internal_ or _title_ field names in DSQL queries (as well as in other list's operations as detailed below).

--- a/mule-user-guide/v/3.7/mule-versus-web-application-server.adoc
+++ b/mule-user-guide/v/3.7/mule-versus-web-application-server.adoc
@@ -29,49 +29,55 @@ Mule specializes in three things:
 |===
 |Mule |Web Application Servers
 a|
-image:soft-soft.png[soft-soft]Mule was built to make _software-to-software_ interactions easier. 
+image::soft-soft.png[soft-soft]
 
- a|
-image:soft-people.png[soft-people]Web application servers are designed to make _software-to-end-user_ interactions easier. 
+Mule was built to make _software-to-software_ interactions easier. 
 
 a|
-image:icon-gears-blue-small.png[icon-gears-blue-small]
+image::soft-people.png[soft-people]
+
+Web application servers are designed to make _software-to-end-user_ interactions easier. 
+
+a|
+image::icon-gears-blue-small.png[icon-gears-blue-small]
 
 Mule specializes in integration between different applications, databases, and cloud services.
 
- a|
-image:icon-team-blue-small.png[icon-team-blue-small]Web applications specialize in interaction with end users.
+a|
+image::icon-team-blue-small.png[icon-team-blue-small]
+
+Web applications specialize in interaction with end users.
 
 a|
-image:icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
+image::icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
 
 Mule applications are stateless and event-driven.
 
- a|
-image:icon-time-blue-small.png[icon-time-blue-small]
+a|
+image::icon-time-blue-small.png[icon-time-blue-small]
 
 Web applications are stateful.
 
 a|
-image:icon-concept-blue-small.png[icon-concept-blue-small]
+image::icon-concept-blue-small.png[icon-concept-blue-small]
 
 Mule supports service-oriented architecture.
 
- |image:tiers.png[tiers]Web applications support multitier architecture.
+a|
+image::tiers.png[tiers]
+
+Web applications support multitier architecture.
 
 a|
 *Mule applications* are built as a series of lightweight, stateless components in an event-driven processing chain called a flow.
 
 Data travels in, through, and out of a Mule application, connecting other applications, databases, enterprise systems, or cloud services to one another. By keeping individual services at either end of the flow discrete, Mule supports link:http://en.wikipedia.org/wiki/Service-oriented_architecture[service-oriented architecture].
 
- a|
+a|
 *Web application servers* support a link:http://en.wikipedia.org/wiki/Multitier_architecture[multitier architecture], which allocates presentation, processing, and data management into logically separate layers.
 
 Using a web application server makes it easy to deliver a graphical user interface on the presentation layer, but it doesn't include the integration capabilities of Mule that would allow it to connect seamlessly to databases or other services. For that, you'd have to write custom code. 
-
 |===
-
-
 
 You can successfully link:/mule-user-guide/v/3.7/embedding-mule-in-a-java-application-or-webapp[embed Mule within a web application server] like Tomcat or JBoss, or you could embed any other kind of web container inside a Mule flow. Leveraging Mule for the integration and service orchestration tasks that it was designed for and using an application server to handle the end-user interactions can provide a full spectrum of functionality. 
 

--- a/mule-user-guide/v/3.7/property-transformer-reference.adoc
+++ b/mule-user-guide/v/3.7/property-transformer-reference.adoc
@@ -148,33 +148,31 @@ port="8081"/>
 
 After you have set a new property, how can you call it and use it elsewhere in your flow?
 
-* If you select any component in your flow that precedes the creation of the property, you will see it in the Metadata Explorer, under the *Outbound Properties* section. +
-
+* If you select any component in your flow that precedes the creation of the property, you will see it in the Metadata Explorer, under the *Outbound Properties* section.
 +
-image:properties+metadata+explorer.jpeg[properties+metadata+explorer] +
-+
+image:properties+metadata+explorer.jpeg[properties+metadata+explorer]
 
 * You can reference it in any field in any component that accepts link:/mule-user-guide/v/3.7/mule-expression-language-mel[Mule Expression Language (MEL)], calling it through the following expression:
-
++
 [source, code, linenums]
 ----
 #[message.outboundProperties.propertyName]
 ----
-
++
 [TIP]
-In Studio, the autocomplete feature can help you out by displaying a list of available properties at that particular part of the flow. +
- +
+In Studio, the autocomplete feature can help you out by displaying a list of available properties at that particular part of the flow.
++
 image:properties+autocomplete.jpeg[properties+autocomplete]
 
 * You can reference it inside any custom Java Class, calling it through the following:
-
++
 [source, code, linenums]
 ----
 message.getOutboundProperty("propertyName");
 ----
-
++
 See a basic Java Class that implements this
-
++
 [source, java, linenums]
 ----
 package org.mule.transformers;
@@ -193,7 +191,7 @@ public class setPropertyAsPayload extends AbstractMessageTransformer{
     }
 } 
 ----
-
++
 [TIP]
 This Java Class takes an existing property named `myProperty` and makes it into the message payload.
 

--- a/mule-user-guide/v/3.7/securing-a-soap-api.adoc
+++ b/mule-user-guide/v/3.7/securing-a-soap-api.adoc
@@ -29,8 +29,7 @@ To the Mule flow that involves an API, add a link:/mule-user-guide/v/3.7/cxf-com
 +
 image:CXFsecuritytab.png[CXFsecuritytab]
 
-. Click the
-image:/documentation/s/en_GB/3391/c989735defd8798a9d5e69c058c254be2e5a762b.76/_/images/icons/emoticons/add.png[(plus)] icon in the *Add Configuration Element* pane to create a new key-value pair.
+. Click the image:/documentation/s/en_GB/3391/c989735defd8798a9d5e69c058c254be2e5a762b.76/_/images/icons/emoticons/add.png[(plus)] icon in the *Add Configuration Element* pane to create a new key-value pair.
 +
 image:Studio-wssecurity-add.png[Studio-wssecurity-add]
 +
@@ -127,10 +126,12 @@ image:Studio-wssecurity-token.png[Studio-wssecurity-token]
 . In the *Bean* field associated with the token validator you have selected, use the drop-down menu to select an existing bean that your token validator will reference to apply, replace, or extend the default behavior associated with a specific security token. 
 +
 [TIP]
-If you have not yet created any beans, click the
-image:/documentation/s/en_GB/3391/c989735defd8798a9d5e69c058c254be2e5a762b.76/_/images/icons/emoticons/add.png[(plus)] button to open a new properties panel in which you can create and configure a new bean. The bean imports the Java class you have built to specify the custom validator's override behavior.
+If you have not yet created any beans, click the image:/documentation/s/en_GB/3391/c989735defd8798a9d5e69c058c254be2e5a762b.76/_/images/icons/emoticons/add.png[(plus)] button to open a new properties panel in which you can create and configure a new bean. The bean imports the Java class you have built to specify the custom validator's override behavior.
++
 image:Studio-wssecurity-custom.png[Studio-wssecurity-custom]
- View Java code for Bean Creation
++
+View Java code for Bean Creation
+
 . Click *OK* to save changes.
 ....
 [tab,title="Studio XML Editor or Standalone"]

--- a/mule-user-guide/v/3.7/workday-connector.adoc
+++ b/mule-user-guide/v/3.7/workday-connector.adoc
@@ -207,6 +207,7 @@ The Workday connector 8.0 is an operation-based connector, which means that whe
 Add a fund using Workday’s Financial Management web service.
 
 image:workday-connector-flow.png[wd example flow]
+
 [tabs]
 ------
 [tab,title="Studio Visual Editor"]

--- a/mule-user-guide/v/3.8/ajax-connector.adoc
+++ b/mule-user-guide/v/3.8/ajax-connector.adoc
@@ -1,5 +1,6 @@
 = Ajax Connector
 :keywords: anypoint, connectors, ajax
+
 image:ajax-icon-no-caption.png[ajax icon]
 
 *Ajax* is an acronym for *Asynchronous JavaScript and XML*, a cluster of related technologies that facilitate the creation of asynchronous Web applications. The *Ajax Connector*, which can be configured as an inbound or outbound endpoint, creates a transport channel to send messages asynchronously to and from an Ajax server, which communicates with external Web resources.

--- a/mule-user-guide/v/3.8/connector-configuration-reference.adoc
+++ b/mule-user-guide/v/3.8/connector-configuration-reference.adoc
@@ -103,14 +103,16 @@ Each incoming message must follow the specific protocol supported by the receivi
 ------
 [tab,title="Studio Visual Editor"]
 ....
-
 The POP3 component is acting as the inbound endpoint in the example flow:
 
 image:connector_conf_inf_3.png[connector_conf_inf_3]
 
 Clicking on the POP3 connector you see the fields specific to the connector instance.
+
 image:connector-configuration-reference-3ab8a.png[]
+
 When you click the plus sign, you find the dialog to set up a configuration:
+
 image:connector-configuration-reference-24b6a.png[]
 ....
 [tab,title="XML Editor"]

--- a/mule-user-guide/v/3.8/database-connector.adoc
+++ b/mule-user-guide/v/3.8/database-connector.adoc
@@ -70,7 +70,6 @@ You can use the *Poll* scope to monitor changes to your database and trigger sub
 +
 . Select the type of *database global element* to configure by clicking the green plus sign and navigate the dropdown to the applicable database engine. Or edit an existing configuration by clicking the "Edit" icon.
 +
-//image:database-connector-fd04e.png[]
 image:add-db-config.png[add-db-config 1]
 +
 . Choose a type of database global element to set up.
@@ -93,6 +92,7 @@ image:database-connector-380c4.png[db config props]
 +
 ////
 The diagram and section below describe how to address these requirements and troubleshoot connection issues.
+
 image:modif_flowchart.png[modif_flowchart]
 ////
 

--- a/mule-user-guide/v/3.8/mule-versus-web-application-server.adoc
+++ b/mule-user-guide/v/3.8/mule-versus-web-application-server.adoc
@@ -29,49 +29,55 @@ Mule specializes in three things:
 |===
 |Mule |Web Application Servers
 a|
-image:soft-soft.png[soft-soft]Mule was built to make _software-to-software_ interactions easier. 
+image::soft-soft.png[soft-soft]
 
- a|
-image:soft-people.png[soft-people]Web application servers are designed to make _software-to-end-user_ interactions easier. 
+Mule was built to make _software-to-software_ interactions easier. 
 
 a|
-image:icon-gears-blue-small.png[icon-gears-blue-small]
+image::soft-people.png[soft-people]
+
+Web application servers are designed to make _software-to-end-user_ interactions easier. 
+
+a|
+image::icon-gears-blue-small.png[icon-gears-blue-small]
 
 Mule specializes in integration between different applications, databases, and cloud services.
 
- a|
-image:icon-team-blue-small.png[icon-team-blue-small]Web applications specialize in interaction with end users.
+a|
+image::icon-team-blue-small.png[icon-team-blue-small]
+
+Web applications specialize in interaction with end users.
 
 a|
-image:icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
+image::icon-stopwatch-blue-small.png[icon-stopwatch-blue-small]
 
 Mule applications are stateless and event-driven.
 
- a|
-image:icon-time-blue-small.png[icon-time-blue-small]
+a|
+image::icon-time-blue-small.png[icon-time-blue-small]
 
 Web applications are stateful.
 
 a|
-image:icon-concept-blue-small.png[icon-concept-blue-small]
+image::icon-concept-blue-small.png[icon-concept-blue-small]
 
 Mule supports service-oriented architecture.
 
- |image:tiers.png[tiers]Web applications support multitier architecture.
+a|
+image::tiers.png[tiers]
+
+Web applications support multitier architecture.
 
 a|
 *Mule applications* are built as a series of lightweight, stateless components in an event-driven processing chain called a flow.
 
 Data travels in, through, and out of a Mule application, connecting other applications, databases, enterprise systems, or cloud services to one another. By keeping individual services at either end of the flow discrete, Mule supports link:http://en.wikipedia.org/wiki/Service-oriented_architecture[service-oriented architecture].
 
- a|
+a|
 *Web application servers* support a link:http://en.wikipedia.org/wiki/Multitier_architecture[multitier architecture], which allocates presentation, processing, and data management into logically separate layers.
 
 Using a web application server makes it easy to deliver a graphical user interface on the presentation layer, but it doesn't include the integration capabilities of Mule that would allow it to connect seamlessly to databases or other services. For that, you'd have to write custom code. 
-
 |===
-
-
 
 You can successfully link:/mule-user-guide/v/3.8/embedding-mule-in-a-java-application-or-webapp[embed Mule within a web application server] like Tomcat or JBoss, or you could embed any other kind of web container inside a Mule flow. Leveraging Mule for the integration and service orchestration tasks that it was designed for and using an application server to handle the end-user interactions can provide a full spectrum of functionality. 
 

--- a/runtime-manager/v/latest/deploying-to-cloudhub.adoc
+++ b/runtime-manager/v/latest/deploying-to-cloudhub.adoc
@@ -226,8 +226,11 @@ Read more about link:/runtime-manager/worker-monitoring[Worker Monitoring].
 Check this box to enable persistent queues on your application. Persistent queues protect against message loss and allow you to distribute workloads across a set of workers. Before you can take advantage of persistent queueing, your application needs to be set up to use queues. See link:/runtime-manager/cloudhub-fabric[CloudHub Fabric] for more information.
 
 [IMPORTANT]
+====
 If your mule application is using link:/mule-user-guide/v/3.8/batch-processing[Batch] component and persistent queues, then you might see batch record being processed multiple times. All batch records are stored in Amazon SQS and by default the visibility of the message is set to 70 seconds. If your batch process takes longer than 70 seconds, then batch process might see the same message again and process it multiple times.  To avoid this issue please set 'persistent.queue.min.timeout' system parameter to a reasonable value, for example if your batch process takes 30 minutes to complete then set value to 'persistent.queue.min.timeout=2700000' milliseconds ( 45 Minutes). Maximum value of 43000000 milliseconds (12 hours) is supported. See screen shot below for setting the value in cloudhub
+
 image:MuleBatchWithPersistentQueueDuplicationSolution.png[MuleBatchWithPersistentQueues]
+====
 
 == Properties Tab
 

--- a/runtime-manager/v/latest/virtual-private-cloud.adoc
+++ b/runtime-manager/v/latest/virtual-private-cloud.adoc
@@ -192,14 +192,19 @@ You can connect a Virtual Private Cloud to a datacenter using any of these metho
 
 . *Public Internet:* Default connectivity to CloudHub VPC.
 
-. *IPsec tunnel with network-to-network configuration:* Connect a network to a CloudHub VPC with an link:http://en.wikipedia.org/wiki/IPsec[IPsec] VPN connection as shown in the diagram below: +
+. *IPsec tunnel with network-to-network configuration:* Connect a network to a CloudHub VPC with an link:http://en.wikipedia.org/wiki/IPsec[IPsec] VPN connection as shown in the diagram below:
++
 image:CHVPC02.png[CHVPC02]
++
 [NOTE]
 IPsec is, in general, the recommended solution for VPC to on-premise connectivity. It provides a standardized, secure way to connect, which integrates well with existing IT infrastructure such as routers/appliances.
 
-. *VPC Peering:* Pair an Amazon VPC directly to a CloudHub VPC. +
-If the services you are connecting to are hosted on AWS, then you can choose to peer your CloudHub VPC and your AWS VPC. +
-The diagram below illustrates connecting a CloudHub VPC and Amazon VPC together directly through VPC peering: +
+. *VPC Peering:* Pair an Amazon VPC directly to a CloudHub VPC.
++
+If the services you are connecting to are hosted on AWS, then you can choose to peer your CloudHub VPC and your AWS VPC.
++
+The diagram below illustrates connecting a CloudHub VPC and Amazon VPC together directly through VPC peering:
++
 image:CHVPC05.png[CHVPC05]
 
 . *CloudHub Direct Connect:* If your network connects to your Amazon VPC using link:https://aws.amazon.com/directconnect/[Amazon Direct Connect], you can create a hosted virtual interface to your CloudHub VPC.


### PR DESCRIPTION
This patch contains AsciiDoc syntax corrections that cannot be safely fixed using the migration script. 

The purpose of the patch is to either convert an inline image into a block image, or put it in a place that allows it to be converted automatically by the migration script.