### PR TITLE
fix incomplete link macros

### DIFF
--- a/anypoint-b2b/v/latest/partner-configuration.adoc
+++ b/anypoint-b2b/v/latest/partner-configuration.adoc
@@ -124,7 +124,7 @@ If this checkbox is deselected, then certificates for this partner that exist in
 . Click *Import*.
 
 == Promoting a Partner
-APM provides the ability to _promote_ - that is, copy, a trading partner from one environment to another. For information about scenarios in which you might want to promote a partner, see link:/anypoint-b2b/scenarios#promotion-scenarios.
+APM provides the ability to _promote_ - that is, copy, a trading partner from one environment to another. For information about scenarios in which you might want to promote a partner, see link:/anypoint-b2b/examples#promotion-scenarios[Promotion Scenarios].
 
 
 NOTE: Only users with the appropriate role or permissions will be able to promote partners.

--- a/anypoint-connector-devkit/v/3.4/packaging-your-connector-for-release.adoc
+++ b/anypoint-connector-devkit/v/3.4/packaging-your-connector-for-release.adoc
@@ -39,11 +39,11 @@ MuleSoft's program certifies and publishes third party connectors to be distribu
 
 == Uploading your Connector to Exchange
 
-Anypoint Studio identifies each connector by a *Feature ID* that spans all versions of the connector. In order to expose your connector via the link:/mule-user-guide/v/3.8/anyp
+Anypoint Studio identifies each connector by a *Feature ID* that spans all versions of the connector. In order to expose your connector via the link:/getting-started/anypoint-exchange[Anypoint Exchange], you will be prompted by the Exchange to provide this Feature ID when uploading your connector asset, as well as a version number.
 
-\
+Follow the steps below to obtain this ID:
 
-
+. Unzip the file containing your connector's Update Site
 . In the created folder, look for the `context.xml` file and open it with a text editor
 
 . In this file, search for a string that follows the following pattern: `id=’org.mule.tooling.ui.extension.<connector name>.feature.group’`. That entire value is your connector’s Feature ID. As a more concrete example, your Feature ID could be something like ’org.mule.tooling.ui.extension.cloudhub.3.6.0.feature.group’

--- a/anypoint-connector-devkit/v/3.5/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
+++ b/anypoint-connector-devkit/v/3.5/creating-a-connector-for-a-soap-service-via-cxf-client.adoc
@@ -104,7 +104,7 @@ The sections below describe the steps to create the stub client and add it to yo
 
 === Preparations
 
-You must download a copy of the WSDL file to your local disk and include it in your Maven project.  For the Web service in this example, you can download the WSDL from link:http://www.webservicex.net/sunsetriseservice.asmx?WSDL.
+You must download a copy of the WSDL file to your local disk and include it in your Maven project.  For the Web service in this example, you can download the WSDL from http://www.webservicex.net/sunsetriseservice.asmx?WSDL.
 
 See link:/anypoint-connector-devkit/v/3.5/setting-up-your-api-access[Setting Up Your API Access] for steps that may be required to gain access to other APIs, including how to get access to the WSDL file.
 

--- a/anypoint-connector-devkit/v/3.7/creating-a-connector-for-a-restful-api-using-restcall-annotations.adoc
+++ b/anypoint-connector-devkit/v/3.7/creating-a-connector-for-a-restful-api-using-restcall-annotations.adoc
@@ -221,7 +221,7 @@ Notes:
 
 Define any entity classes that represent the data passed to and returned from the Web service requests, and how JSON documents map to Java classes used with the connector. 
 
-Given a JSON schema or sample documents for the service, you can generate classes using the tool *JSONSchema2POJO*, available at link:http://www.jsonschema2pojo.org/. (The link:https://github.com/joelittlejohn/jsonschema2pojo/wiki[wiki on GitHub] provides getting started and reference documentation for JSONSchema2POJO.) 
+Given a JSON schema or sample documents for the service, you can generate classes using the tool *JSONSchema2POJO*, available at http://www.jsonschema2pojo.org/. (The link:https://github.com/joelittlejohn/jsonschema2pojo/wiki[wiki on GitHub] provides getting started and reference documentation for JSONSchema2POJO.) 
 
 After you create your data model classes, add them to your project, and import them into your `@Connector` class.
 

--- a/anypoint-data-gateway/v/latest/managing-gateways.adoc
+++ b/anypoint-data-gateway/v/latest/managing-gateways.adoc
@@ -82,7 +82,7 @@ image:notifications-1.2.png[notifications-1.2]
 
 == Left-Hand Menu
 
-The left-hand menu (item 2 in the image  link:#ManagingGateways-image) allows you to perform several tasks, detailed in this section.
+The left-hand menu allows you to perform several tasks, detailed in this section.
 
 === Gateways
 
@@ -140,7 +140,7 @@ This section describes how to work with existing gateways. For information on cr
 
 To modify the status of an existing gateway:
 
-. Go to the gateway list in Gateway designer by clicking *Gateways* in the global left-hand menu (see image  link:#ManagingGateways-image).
+. Go to the gateway list in Gateway designer by clicking *Gateways* in the global left-hand menu.
 . In the gateway list, locate the gateway you wish to modify, then click the *Edit* menu on the right.
 +
 image:modifying_gw_status-1.2.png[modifying_gw_status-1.2]

--- a/anypoint-studio/v/5/using-datamapper-lookup-tables.adoc
+++ b/anypoint-studio/v/5/using-datamapper-lookup-tables.adoc
@@ -168,7 +168,7 @@ image:ex.lookup.assign.key.png[ex.lookup.assign.key]
 +
 [TIP]
 To use more than one lookup search key, click the plus icon to add additional keys. Studio inserts these additional keys into the SQL statement in order.
-. Click *OK*. At this point, the mapping is complete. Running a link:/anypoint-studio/v/5/previewing-datamapper-results-on-sample-datapreview] of the mapping gives the following result:
+. Click *OK*. At this point, the mapping is complete. Running a link:/anypoint-studio/v/5/previewing-datamapper-results-on-sample-data[preview] of the mapping gives the following result:
 +
 [source, code, linenums]
 ----

--- a/api-manager/v/latest/create-policy-definition-task.adoc
+++ b/api-manager/v/latest/create-policy-definition-task.adoc
@@ -62,4 +62,4 @@ link:_attachments/mypolicy.yaml[Download the mypolicy.yaml example file]
 
 == See Also
 
-link:/api-manager/custom-policy-referenceCustom Policy Reference.
+* link:/api-manager/custom-policy-reference[Custom Policy Reference]

--- a/api-manager/v/latest/creating-an-api-notebook.adoc
+++ b/api-manager/v/latest/creating-an-api-notebook.adoc
@@ -54,11 +54,11 @@ The design of the API Notebook follows the literate programming paradigm: Code s
 There are two ways to create an API Notebook:
 
 * Edit an API portal. Create the Notebook within the portal using the left navigation of the portal to add a new API Notebook. A line of code that creates the necessary API client for your RAML-based API is generated when you add the API Notebook.
-* Use the following site to create a new Notebook: `link:https://api-notebook.anypoint.mulesoft.com`
+* Use the following site to create a new Notebook: https://api-notebook.anypoint.mulesoft.com
 +
 . Log in to your GitHub account.
 . Authorize your application to write to the gist.
-. Log into the `https://api-notebook.anypoint.mulesoft.com` site using your GitHub account credentials.
+. Log into the https://api-notebook.anypoint.mulesoft.com site using your GitHub account credentials.
 . Create the API Notebook.
 . Click the *save* icon.
 +

--- a/api-manager/v/latest/using-api-alerts.adoc
+++ b/api-manager/v/latest/using-api-alerts.adoc
@@ -90,4 +90,4 @@ After an alert fires, and API Manager sends the first set of two notification em
 
 * link:/runtime-manager/alerts-on-runtime-manager[Runtime Manager alerts]
 * link:/api-manager/designing-your-api#access-api-designer-from-anypoint-platform[Access API Designer]
-* link:/implemented as link:https://www.techopedia.com/definition/869/sliding-window[Sliding windows]
+* implemented as link:https://www.techopedia.com/definition/869/sliding-window[Sliding windows]

--- a/healthcare-toolkit/v/1.3/index.adoc
+++ b/healthcare-toolkit/v/1.3/index.adoc
@@ -81,7 +81,7 @@ image:hl7_palette.png[hl7_palette]
 
 == See Also
 
-* Use the link:/healthcare-toolkit/v/1.3/testing-with-hapi-testpanelHAPI TestPanel] to test your HL7 application.
+* Use the link:/healthcare-toolkit/v/1.3/testing-with-hapi-testpanel[HAPI TestPanel] to test your HL7 application.
 
 
 

--- a/mule-management-console/v/3.6/adding-and-managing-alerts-and-slas.adoc
+++ b/mule-management-console/v/3.6/adding-and-managing-alerts-and-slas.adoc
@@ -23,7 +23,7 @@ image:new-alert1.png[new-alert1]
 +
 image:new-alert-type.png[new-alert-type]
 
-* Specify the parameters for this type of alert. After you specify the type of alert, the Add Alert dialog prompts you for the parameters for that type of alert. For URL Health alerts, you provide a name for the alert, a description, select a severity level, check the Active box, indicate the URL of the external site, the expected status code that would raise the alert, and the wait period (in seconds). Once all parameters are specified, click Save. In this example, the URL is link:http://www.google.com and the expected status code is 200.
+* Specify the parameters for this type of alert. After you specify the type of alert, the Add Alert dialog prompts you for the parameters for that type of alert. For URL Health alerts, you provide a name for the alert, a description, select a severity level, check the Active box, indicate the URL of the external site, the expected status code that would raise the alert, and the wait period (in seconds). Once all parameters are specified, click Save. In this example, the URL is http://www.google.com and the expected status code is 200.
 +
 image:new-alert2.png[new-alert2]
 

--- a/mule-user-guide/v/3.2/xml-module-reference.adoc
+++ b/mule-user-guide/v/3.2/xml-module-reference.adoc
@@ -132,4 +132,4 @@ The XML module contains two splitters, a filter-based splitter and a round-robin
 
 In most cases, link:http://www.saxproject.org/about.html[SAX] is used to parse your XML. If you are using CXF or the XmlToXMLStreamReader, link:https://web.archive.org/web/20150526105309/http://stax.codehaus.org/Home[Stax] is used instead.
 
-If you're using SAX, the SAX XML parser is determined by your JVM. If you want to change your SAX implementation, see link:http://www.saxproject.org/quickstart.html.
+If you're using SAX, the SAX XML parser is determined by your JVM. If you want to change your SAX implementation, see http://www.saxproject.org/quickstart.html.

--- a/mule-user-guide/v/3.3/installing-anypoint-enterprise-security.adoc
+++ b/mule-user-guide/v/3.3/installing-anypoint-enterprise-security.adoc
@@ -21,7 +21,7 @@ image:launch_Studio.png[launch_Studio]
 +
 
 . Under the *Help* menu, select *Install New Software...*
-. Mule opens the Install wizard. In the *Work with* field, paste the following link: 
+. Mule opens the Install wizard. In the *Work with* field, paste the following link:
 +
 http://s3.amazonaws.com/security-update-site-1.2.5
 . Click the *Add* button next to the *Work with* field.

--- a/mule-user-guide/v/3.4/installing-anypoint-enterprise-security.adoc
+++ b/mule-user-guide/v/3.4/installing-anypoint-enterprise-security.adoc
@@ -29,7 +29,7 @@ image:Studio_launch.png[Studio_launch]
 
 . Under the Help menu, select **Install New Software...**
 . Mule opens the Install wizard. Click the **Add...** button next to the *Work with* field.
-. In the Add Repository panel, enter a *Name* for the repository, such as Anypoint Enterprise Security, and in the *Location* field, paste the following link: 
+. In the Add Repository panel, enter a *Name* for the repository, such as Anypoint Enterprise Security, and in the *Location* field, paste the following link:
 +
 *http://security-update-site.s3.amazonaws.com/* +
 +

--- a/mule-user-guide/v/3.5/atom-module-reference.adoc
+++ b/mule-user-guide/v/3.5/atom-module-reference.adoc
@@ -180,7 +180,7 @@ The following example shows how to create an Abdera context that builds a JCR re
 </beans>
 ----
 
-*Note*: In the code example, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see link:http://www.springframework.org/schema/beans/.
+*Note*: In the code example, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see http://www.springframework.org/schema/beans/.
 
 The `<a:provider>` creates an Abdera DefaultProvider and allows you to add workspaces and collections to it. This `provider` reference is used by the the `<atom:component/>` in Mule to store any events sent to the component.
 

--- a/mule-user-guide/v/3.5/salesforce-connector.adoc
+++ b/mule-user-guide/v/3.5/salesforce-connector.adoc
@@ -11,8 +11,8 @@ This document assumes that you are familiar with Mule, the link:/anypoint-studi
 To use the Salesforce connector, you need:
 
 * *Studio* - An instance of link:http://www.mulesoft.org/download-mule-esb-community-edition[Anypoint Studio]. If you don't use Anypoint Studio for development, follow the instructions below to configure Salesforce Maven dependencies in your  `pom.xml`  file.
-* *Salesforce developer account* - Sign up for one at http://developer.force.com/
-* *Security token* -** **Sign into link:http://developer.force.com/, click your name** ** in the upper right corner, then click *Setup* > *My Personal Information* >  *Reset Security Token*. Then, click *Reset My Security Token*. Salesforce sends your security token via email to your registered email address.
+* *Salesforce developer account* - Sign up for one at http://developer.force.com/.
+* *Security token* -** **Sign into http://developer.force.com/, click your name** ** in the upper right corner, then click *Setup* > *My Personal Information* >  *Reset Security Token*. Then, click *Reset My Security Token*. Salesforce sends your security token via email to your registered email address.
 * *Consumer key and Secret* - If you are using the Salesforce connector to access an *OAuth API*, you also need a consumer key and secret. Refer to the detailed documentation on how to link:/mule-user-guide/v/3.7/using-a-connector-to-access-an-oauth-api[use the Salesforce connector to access an OAuth API]. 
 
 To use a Salesforce Connector in your Mule application, be sure to include the namespace and schema location.

--- a/mule-user-guide/v/3.6/index.adoc
+++ b/mule-user-guide/v/3.6/index.adoc
@@ -18,4 +18,4 @@ This section offers information about how to use *Mule ESB* and *Anypoint Studio
 * link:/mule-management-console/v/3.6/setting-up-mmc[Set up the Mule Management Console]
 * link:/runtime-manager/cloudhub[Run Mule Applications on CloudHub]
 * link:/anypoint-connector-devkit/v/3.7[Extend the Mule ESB with the DevKit]
-* link:https://www.mulesoft.com/webinars/api/mule-101-anypoint-platform-overview [Watch the Mule 101 Webinar to learn the basic Mule concepts]
+* link:https://www.mulesoft.com/webinars/api/mule-101-anypoint-platform-overview[Watch the Mule 101 Webinar to learn the basic Mule concepts]

--- a/mule-user-guide/v/3.6/installing-anypoint-enterprise-security.adoc
+++ b/mule-user-guide/v/3.6/installing-anypoint-enterprise-security.adoc
@@ -19,7 +19,7 @@ _Enterprise Edition, CloudHub_
 . Launch Anypoint Studio.
 . Under the Help menu, select *Install New Software...*
 . Mule opens the Install wizard. Click the *Add...* button next to the *Work with* field.
-. In the Add Repository panel, enter a *Name* for the repository, such as Anypoint Enterprise Security, and in the *Location* field, paste the following link: 
+. In the Add Repository panel, enter a *Name* for the repository, such as Anypoint Enterprise Security, and in the *Location* field, paste the following link:
 +
 `http://security-update-site-1.4.s3.amazonaws.com`
 +

--- a/mule-user-guide/v/3.6/salesforce-connector.adoc
+++ b/mule-user-guide/v/3.6/salesforce-connector.adoc
@@ -12,8 +12,8 @@ This document assumes that you are familiar with Mule, the link:/anypoint-studi
 To use the Salesforce connector, you need:
 
 * *Studio* - An instance of link:http://www.mulesoft.org/download-mule-esb-community-edition[Anypoint Studio]. If you don't use Anypoint Studio for development, follow the instructions below to install Salesforce Maven dependencies in your  `pom.xml`  file.
-* *Salesforce developer account* - Sign up for one at link:http://developer.force.com/
-* *Security token* -** **Sign into link:http://developer.force.com/, click your name** ** in the upper right corner, then click *Setup* > *My Personal Information* >  *Reset Security Token*. Then, click *Reset My Security Token*. Salesforce sends your security token via email to your registered email address.
+* *Salesforce developer account* - Sign up for one at http://developer.force.com/.
+* *Security token* -** **Sign into http://developer.force.com/, click your name** ** in the upper right corner, then click *Setup* > *My Personal Information* >  *Reset Security Token*. Then, click *Reset My Security Token*. Salesforce sends your security token via email to your registered email address.
 * *Consumer key and Secret* - If you are using the Salesforce connector to access an *OAuth API*, you also need a consumer key and secret. Refer to the detailed documentation on how to link:/mule-user-guide/v/3.6/using-a-connector-to-access-an-oauth-api[use the Salesforce connector to access an OAuth API]. 
 
 To use a Salesforce Connector in your Mule application, be sure to include the namespace and schema location.

--- a/mule-user-guide/v/3.7/atom-module-reference.adoc
+++ b/mule-user-guide/v/3.7/atom-module-reference.adoc
@@ -447,7 +447,7 @@ No Child Elements of <object-to-feed-transformer...>
 
 == Schema
 
-link:http://www.mulesoft.org/docs/site/current3/schemadocs/namespaces/http_www_mulesoft_org_schema_mule_atom/namespace-overview.html
+http://www.mulesoft.org/docs/site/current3/schemadocs/namespaces/http_www_mulesoft_org_schema_mule_atom/namespace-overview.html
 
 == Javadoc API Reference
 

--- a/mule-user-guide/v/3.7/jdbc-transport-reference.adoc
+++ b/mule-user-guide/v/3.7/jdbc-transport-reference.adoc
@@ -1102,7 +1102,7 @@ Converts a `List` of `Map` objects to a CSV file. The Map List is the same as wh
 |Name |Type |Required |Default |Description
 |delimiter |string |no |  |Delimiter used in CSV file. Default is comma.
 |mappingFile |string |no |  a|
-Name of the "mapping file" used to describe the CSV file. See link:http://flatpack.sourceforge.net for details.
+Name of the "mapping file" used to describe the CSV file. See http://flatpack.sourceforge.net for details.
 
 |ignoreFirstRecord |boolean |no |  |Whether to ignore the first record. If the first record is a header, you should ignore it.
 |qualifier |string |no |  |The character used to escape text that contains the delimiter.
@@ -1124,7 +1124,7 @@ Converts a CSV file to a `List` of `Map` objects. The Map List is the same as wh
 |delimiter |string |no |  |Delimiter used in CSV file. Default is comma.
 |mappingFile |string |no |  a|
 Name of the "mapping file" used to describe the CSV file.
-See link:http://flatpack.sourceforge.net for details.
+See http://flatpack.sourceforge.net for details.
 
 |ignoreFirstRecord |boolean |no |  |Whether to ignore the first record. If the first record is a header, you should ignore it.
 |qualifier |string |no |  |The character used to escape text that contains the delimiter.

--- a/mule-user-guide/v/3.8/atom-module-reference.adoc
+++ b/mule-user-guide/v/3.8/atom-module-reference.adoc
@@ -453,7 +453,7 @@ No Child Elements of <object-to-feed-transformer...>
 
 == Schema
 
-link:http://www.mulesoft.org/docs/site/current3/schemadocs/namespaces/http_www_mulesoft_org_schema_mule_atom/namespace-overview.html
+http://www.mulesoft.org/docs/site/current3/schemadocs/namespaces/http_www_mulesoft_org_schema_mule_atom/namespace-overview.html
 
 == Javadoc API Reference
 

--- a/mule-user-guide/v/3.8/bpm-configuration-reference.adoc
+++ b/mule-user-guide/v/3.8/bpm-configuration-reference.adoc
@@ -1,7 +1,7 @@
 = BPM Configuration Reference
 :keywords: connectors, anypoint, studio, esb, bpm
 
-This page provides details on the process components you configure for BPM. Some of this information is pulled directly from `mule-bpm.xsd` and is cached. For more information on BPM, see link:/mule-user-guide/v/3.8/bpm-module-reference[BPM Module Reference]. Information on jBPM is available at link:http://www.jbpm.org.
+This page provides details on the process components you configure for BPM. Some of this information is pulled directly from `mule-bpm.xsd` and is cached. For more information on BPM, see link:/mule-user-guide/v/3.8/bpm-module-reference[BPM Module Reference]. Information on jBPM is available at http://www.jbpm.org.
 
 == Process
 

--- a/mule-user-guide/v/3.8/jdbc-transport-reference.adoc
+++ b/mule-user-guide/v/3.8/jdbc-transport-reference.adoc
@@ -1111,7 +1111,7 @@ Converts a `List` of `Map` objects to a CSV file. The Map List is the same as wh
 |Name |Type |Required |Default |Description
 |delimiter |string |no |  |Delimiter used in CSV file. Default is comma.
 |mappingFile |string |no |  a|
-Name of the "mapping file" used to describe the CSV file. See link:http://flatpack.sourceforge.net for details.
+Name of the "mapping file" used to describe the CSV file. See http://flatpack.sourceforge.net for details.
 
 |ignoreFirstRecord |boolean |no |  |Whether to ignore the first record. If the first record is a header, you should ignore it.
 |qualifier |string |no |  |The character used to escape text that contains the delimiter.
@@ -1133,7 +1133,7 @@ Converts a CSV file to a `List` of `Map` objects. The Map List is the same as wh
 |delimiter |string |no |  |Delimiter used in CSV file. Default is comma.
 |mappingFile |string |no |  a|
 Name of the "mapping file" used to describe the CSV file.
-See link:http://flatpack.sourceforge.net for details.
+See http://flatpack.sourceforge.net for details.
 
 |ignoreFirstRecord |boolean |no |  |Whether to ignore the first record. If the first record is a header, you should ignore it.
 |qualifier |string |no |  |The character used to escape text that contains the delimiter.

--- a/mule-user-guide/v/3.8/transformers.adoc
+++ b/mule-user-guide/v/3.8/transformers.adoc
@@ -96,7 +96,7 @@ Each transformer in this group changes a Java object into another Java object, a
 *Documentation*: link:/mule-user-guide/v/3.8/object-to-xml-transformer-reference[Object-to-XML Transformer Reference]
 |image:serializable-to-byte-array.png[Serializable to Byte Array] |Serializable to Byte Array |Converts a Java Object to a byte array by serializing the object.
 
-*Documentation*: link:/mule-user-guide/v/3.8/Object to XML Transformer-reference[Object-to-XML Transformer Reference]
+*Documentation*: link:/mule-user-guide/v/3.8/object-to-xml-transformer-reference[Object-to-XML Transformer Reference]
 |image:string-to-byte-array.png[string-to-byte-array] |String to Byte Array |Converts a string into a byte array.
 
 *Documentation*: <<Common Transformer Configuration Fields>>

--- a/mule-user-guide/v/3.8/xmpp-transport-reference.adoc
+++ b/mule-user-guide/v/3.8/xmpp-transport-reference.adoc
@@ -192,7 +192,7 @@ The XMPP transport does not support transactions as the XMPP protocol is not tra
 </mule>
 ----
 
-*Note*: In this code example, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see link:http://www.springframework.org/schema/beans/.
+*Note*: In this code example, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see http://www.springframework.org/schema/beans/.
 
 == XMPP Transport Configuration Reference
 

--- a/release-notes/v/latest/mule-esb-3.1.1-release-notes.adoc
+++ b/release-notes/v/latest/mule-esb-3.1.1-release-notes.adoc
@@ -87,7 +87,7 @@ For instructions on migrating from a previous version, consult the link:/mule-us
 
 == Open Issues in This Release
 
-* link:/mule-user-guide/v/3.2/mule-high-availabilityLimitations to High Availability]
+* link:/mule-user-guide/v/3.2/mule-high-availability[Limitations to High Availability]
 
 Open Issues +
   +

--- a/release-notes/v/latest/runtime-manager-agent-1.1.1-release-notes.adoc
+++ b/release-notes/v/latest/runtime-manager-agent-1.1.1-release-notes.adoc
@@ -6,7 +6,7 @@ _Enterprise Edition_
 
 Runtime Manager Agent 1.1.1 provides a new downloadable zip file to easily update Runtime Manager Agent. You can download the zip file from:
 
-link:http://mule-agent.s3.amazonaws.com/1.1.1/mule-agent-1.1.1.zip
+http://mule-agent.s3.amazonaws.com/1.1.1/mule-agent-1.1.1.zip
 
 *Runtime Manager Agent Install Guide*: link:/runtime-manager/installing-and-configuring-runtime-manager-agent[Install the Runtime Manager Agent]
 

--- a/release-notes/v/latest/workday-connector-6.0-release-notes.adoc
+++ b/release-notes/v/latest/workday-connector-6.0-release-notes.adoc
@@ -91,8 +91,8 @@ None.
 
 == See Also
 
-* Refer to the link:/mule-user-guide/v/3.8/workday-connector-6.0-migration-guide to learn how to upgrade to Workday connector v6.0.
+* Refer to the link:/mule-user-guide/v/3.8/workday-connector-6.0-migration-guide[Workday Connector Migration Guide] to learn how to upgrade to Workday connector v6.0.
 * For more information on Workday v24.0 API , refer to the link:https://community.workday.com/custom/developer/API/versions/v24.0/index.html[Workday API documentation].
-* Learn about link:/getting-started/anypoint-exchange#installing-a-connector-from-anypoint-exchange
+* Learn about link:/getting-started/anypoint-exchange#installing-a-connector-from-anypoint-exchange[Installing a Connector from Anypoint Exchange]
 * Access MuleSoft’s link:http://forums.mulesoft.com/[Forum] to pose questions and get help from Mule’s broad community of users.
 * To access MuleSoft’s expert support team, link:https://www.mulesoft.com/support-and-services/mule-esb-support-license-subscription[subscribe] to Mule ESB Enterprise and log into MuleSoft’s link:http://www.mulesoft.com/support-login[Customer Portal].

--- a/runtime-manager/v/latest/managing-applications-on-your-own-servers.adoc
+++ b/runtime-manager/v/latest/managing-applications-on-your-own-servers.adoc
@@ -35,7 +35,7 @@ You can verify info about the servers the application runs on by clicking on the
 
 On all panels, two buttons are displayed:
 
-* The *Manage Server* button, which takes you to the application settings page. This page displays more detailed information about your app and the server it runs on. From here you can also access the apps dashboard, see link:/runtime-manager/monitoring-dashboards#the-dashboard-for-apps on-servers[Monitoring Dashboards] for more on this.
+* The *Manage Server* button, which takes you to the application settings page. This page displays more detailed information about your app and the server it runs on. From here you can also access the apps dashboard, see link:/runtime-manager/monitoring-dashboards#the-dashboard-for-apps-on-servers[Monitoring Dashboards] for more on this.
 +
 image:managing-applications-on-your-own-servers-b0e6f.png[]
 

--- a/tcat-server/v/7.1.0/integrating-with-ldap.adoc
+++ b/tcat-server/v/7.1.0/integrating-with-ldap.adoc
@@ -191,7 +191,7 @@ This example illustrates a simple LDAP configuration, in which the LDAP server a
 This example was created using the following system specifications:
 
 * OS: Linux (Xubuntu 12.04 LTS, based on Debian 7 “Wheezy/Sid”). Homepage: http://xubuntu.org
-* LDAP Server: OpenLDAP. Homepage: link:http://www.openldap.org
+* LDAP Server: OpenLDAP. Homepage: http://www.openldap.org
 * LDAP Browser: Apache Directory Studio. Homepage: http://directory.apache.org/studio/
 
 This example provides a basic overview of the following tasks:


### PR DESCRIPTION
Prompted by #1406, I found many more cases of incomplete link macros.

- superfluous link: prefix
- missing square brackets
- misplaced square bracket

Supersedes #1406.