### PR TITLE
"Avoiding Public Discoverability" section updated

### DIFF
--- a/runtime-manager/v/latest/cloudhub-networking-guide.adoc
+++ b/runtime-manager/v/latest/cloudhub-networking-guide.adoc
@@ -135,6 +135,8 @@ If you have a link:/runtime-manager/virtual-private-cloud[Virtual Private Cloud]
 
 == See Also
 
+*Important:* If you don't have any link:/runtime-manager/cloudhub-dedicated-load-balancer[Cloudhub Dedicated Load Balancer for your VPCs], performing the first step will be sufficient to ensure that applications deployed in your VPCs will not be publicly accessible.
+
 * link:/runtime-manager/developing-applications-for-cloudhub#providing-an-external-http-https-port[Providing an External HTTP/HTTPS Port when deploying to CloudHub]
 * link:/runtime-manager/cloudhub-architecture[CloudHub architecture]
 * link:/runtime-manager/virtual-private-cloud[Virtual Private Cloud]


### PR DESCRIPTION
"Avoiding Public Discoverability for Applications on CloudHub" section is a bit confusing. Readers could easily conclude that they need dedicated load balancers in order to prevent their applications deployed in VPC from being publicly accessible. A whitelist in a dedicated load balancer is something different and should not be confused with public accessibility to the applications in VPC.

Therefore, I added a sentence emphasizing this.