### PR TITLE
Update index.adoc

### DIFF
--- a/munit/v/1.3/index.adoc
+++ b/munit/v/1.3/index.adoc
@@ -60,7 +60,7 @@ compatibility rules are followed:
 +
 NOTE: The *x* at the end of each version number refers to the latest version within that minor version.
 +
-TIP: Currently the latest released versions of Mule MUnit Support are:  *3.6.5*, *3.7.5*, *3.8.2*.
+TIP: Currently the latest released versions of Mule MUnit Support are:  *3.6.5*, *3.7.5*, *3.8.2*, *3.8.3*.
 
 
 [[studio]]


### PR DESCRIPTION
updated the mule runtime version and added 3.8.3 as per Munit 1.3.2 release note:
https://docs.mulesoft.com/release-notes/munit-1.3.2-release-notes

But needs to clarify if it also supports 3.8.4 as well for both release note document update and this page.