### PR TITLE
Add link to full match operator description

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-operators.adoc
+++ b/mule-user-guide/v/3.8/dataweave-operators.adoc
@@ -1839,8 +1839,7 @@ Given a string, it returns the index position within the string at which a match
 
 Match a string against a regular expression. Match returns an array that contains the entire matching expression, followed by all of the capture groups that match the provided regex.
 
-[NOTE]
-The match operator can also be applied with the result of any evaluated expression, and can return any evaluated expression. See link:/mule-user-guide/v/3.8/dataweave-language-introduction[the Match operator in the DataWeave Language Introduction]. 
+It can be applied to the result of any evaluated expression, and can return any evaluated expression. See the Match operator in link:/mule-user-guide/v/3.8/dataweave-language-introduction[the DataWeave Language Introduction]. 
 
 
 .Transform

--- a/mule-user-guide/v/3.8/dataweave-operators.adoc
+++ b/mule-user-guide/v/3.8/dataweave-operators.adoc
@@ -1839,6 +1839,10 @@ Given a string, it returns the index position within the string at which a match
 
 Match a string against a regular expression. Match returns an array that contains the entire matching expression, followed by all of the capture groups that match the provided regex.
 
+[NOTE]
+The match operator can also be applied with the result of any evaluated expression, and can return any evaluated expression. See link:/mule-user-guide/v/3.8/dataweave-language-introduction[the Match operator in the DataWeave Language Introduction]. 
+
+
 .Transform
 [source,DataWeave, linenums]
 ----


### PR DESCRIPTION
This is in the Language Introduction (which is confusing, since this is a core operator. We at least need to link back to the information).