### PR TITLE
Part of text is moved to the correct section

### DIFF
--- a/runtime-manager/v/latest/cloudhub-networking-guide.adoc
+++ b/runtime-manager/v/latest/cloudhub-networking-guide.adoc
@@ -133,9 +133,9 @@ If you have a link:/runtime-manager/virtual-private-cloud[Virtual Private Cloud]
 . Create a link:/runtime-manager/cloudhub-dedicated-load-balancer#whitelists[whitelist in your dedicated load balancer] with the IPs you want to authorize.
 .. You can only do this using the link:/runtime-manager/anypoint-platform-cli#cloudhub-load-balancer-whitelist-add[cloudhub load-balancer whitelist add] command from the CLI.
 
-== See Also
-
 *Important:* If you don't have any link:/runtime-manager/cloudhub-dedicated-load-balancer[Cloudhub Dedicated Load Balancer for your VPCs], performing the first step will be sufficient to ensure that applications deployed in your VPCs will not be publicly accessible.
+
+== See Also
 
 * link:/runtime-manager/developing-applications-for-cloudhub#providing-an-external-http-https-port[Providing an External HTTP/HTTPS Port when deploying to CloudHub]
 * link:/runtime-manager/cloudhub-architecture[CloudHub architecture]


### PR DESCRIPTION
"Important" part is moved under the section "Avoiding Public Discoverability for Applications on CloudHub". It was previously below "See Also" section and it was not supposed to be there.