### PR TITLE
Updating button label for adding items to Exchange

### DIFF
--- a/getting-started/v/latest/anypoint-exchange.adoc
+++ b/getting-started/v/latest/anypoint-exchange.adoc
@@ -109,7 +109,7 @@ Users must sign up with Anypoint Platform, log in, and be assigned either the �
 
 NOTE: All preloaded content from MuleSoft in Anypoint Exchange is read-only.
 
-A “Submit Item” button on the top left of Exchange is displayed for users with the entitlements to create an entry in the organization’s Exchange.
+An “Add Item” button on the top left of Exchange is displayed for users with the entitlements to create an entry in the organization’s Exchange.
 When a user submits an item, they are required to pick the item type from a drop down list. The item type denotes what fields are displayed on the item submission form. Irrespective of the content type selected, a number of standard metadata items are available to describe the item:
 
 * *Name:* Name of the item to be displayed. (Mandatory)


### PR DESCRIPTION
The label for the button in Anypoint Exchange is "Add Item" instead of "Submit Item"