### PR TITLE
fix AsciiDoc syntax

### DIFF
--- a/healthcare-toolkit/v/1.3/hl7-connector.adoc
+++ b/healthcare-toolkit/v/1.3/hl7-connector.adoc
@@ -68,7 +68,7 @@ This tab only contains the *Name* field, where you may optionally type a meaning
 |===
 |Name |Description |XML
 |Name (Studio Only) |Name of the building block as it appears in the flow |`name="connectorName"`
-
+|===
 
 image:hl7_gloabl_advanced.png[hl7_gloabl_advanced]
 

--- a/mule-management-console/v/3.3/managing-users-and-roles.adoc
+++ b/mule-management-console/v/3.3/managing-users-and-roles.adoc
@@ -145,3 +145,4 @@ Server permissions include the following and apply to the specified server group
 link:/mule-management-console/v/3.3/setting-up-alert-destinations-and-notifications[<< Previous: Setting Up Alert Destinations and Notifications]
 |
 link:/mule-management-console/v/3.3/enabling-ldap-authentication[Next: Enabling Authentication Through LDAP >>]
+|===

--- a/mule-user-guide/v/3.2/studio-cloud-connectors.adoc
+++ b/mule-user-guide/v/3.2/studio-cloud-connectors.adoc
@@ -38,6 +38,7 @@ image:salesforce.png[salesforce] |Salesforce |A Web-based API for querying, crea
 
 
 image:twitter.png[twitter] |Twitter |An online API service that supports Web-based social networking and micro-blogging. |link:/mule-user-guide/v/3.2/twitter-cloud-connector-reference[Twitter Cloud Connector Reference]
+|===
 
 == Configuring Cloud Connectors
 

--- a/mule-user-guide/v/3.2/studio-filters.adoc
+++ b/mule-user-guide/v/3.2/studio-filters.adoc
@@ -36,6 +36,7 @@ image:Filter-24x16.png[Filter-24x16] |Regex |Applies a regular expression patter
 
 
 image:Filter-24x16.png[Filter-24x16] |Wildcard Filter |Matches string messages against a wildcard pattern. |link:/mule-user-guide/v/3.2/wildcard-filter[Wildcard Filter Reference]
+|===
 
 == About Filter Logic
 

--- a/mule-user-guide/v/3.3/jdbc-transport-example.adoc
+++ b/mule-user-guide/v/3.3/jdbc-transport-example.adoc
@@ -54,29 +54,26 @@ If you do not have access to a database to be able to see the application in act
 image:scripts_studio.png[scripts_studio]
 
 . Copy the contents of the `procs.ddl` and `tables.ddl` files and run those scripts on your database.
-
-
 +
-[%header%autowidth.spread]
+[autowidth.spread,cols=2*]
 |===
-|image:check.png[check] a|
+|image:check.png[check]
+a|
 
-*Need More Details?* +
+*Need More Details?*
 
- View Granular Instructions
+View Granular Instructions
 
 . Double-click the `procs.ddl` file to open it in a new Studio *Canvas* pane.
-. Double-click the `tables.ddl` file to open it in a new Studio canvas pane. +
- +
- image:open_canvases.png[open_canvases]
+. Double-click the `tables.ddl` file to open it in a new Studio canvas pane.
++
+image:open_canvases.png[open_canvases]
 
 . Access your database. For example, you can access your Oracle database through Oracle SQL Developer.
 . Copy all the contents of the `procs.ddl` file (open in a Studio canvas pane) into your database development tool.
 . Copy all the contents of the `tables.ddl` file (open in a Studio canvas pane) into your database development tool.
 . Run the two scripts on your database to create stored procedures and a table in your database.
-
 |===
-
 
 . In the expanded `src/main/resources` in the package explorer pane in Studio, double-click the `db.properties` file to open it in a new Studio canvas pane.
 . On line 5 of the file, after `database.connection=`, type the connection information of your database so that the JDBC application can connect to it.
@@ -107,15 +104,15 @@ image:standalone_scripts2.png[standalone_scripts2]
 
 . Click to expand the `scripts.oracle` folder, if you are using an Oracle database, or `scripts.sybase` folder, if you are using a Sybase database.
 . Copy the contents of the `procs.ddl` and `tables.ddl` files and run those scripts on your database.
-
 +
-[%header%autowidth.spread]
+[%autowidth.spread,cols=2*]
 |===
-|image:check.png[check] a|
+|image:check.png[check]
+a|
 
-*Need More Details?* +
+*Need More Details?*
 
- View Granular Instructions
+View Granular Instructions
 
 . Double-click the `procs.ddl` file to open it in your text editor.
 . Double-click the `tables.ddl` file to open it in your text editor.
@@ -123,9 +120,7 @@ image:standalone_scripts2.png[standalone_scripts2]
 . Copy all the contents of the `procs.ddl` file (open in your text editor) into your database development tool.
 . Copy all the contents of the `tables.ddl` file (open in your text editor) into your database development tool.
 . Run the two scripts on your database to create stored procedures and a table in your database.
-
 |===
-
 
 . On your hard drive, navigate to `mule-enterprise-standalone-3.3.0` > `apps`, then double-click `mule-example-jdbc-3.3.0.zip` to unzip the file.
 . When unzipped, navigate to `mule-example-jdbc-3.3.0` > `classes`, then double-click the `db.properties` file to open it in your text editor.
@@ -139,12 +134,11 @@ image:db_properties2.png[db_properties2]
 . Paste the copy of your driver file in the `user` folder.
 . Start Mule and run the JDBC example.
 +
-
 [TIP]
 ====
 *Need More Details?*
 
- Learn how to start Mule
+Learn how to start Mule
 
 . *PC*: Open the *Console*.
  *Mac*: Open the *Terminal* application (`Applications` > `Utilities` > `Terminal`).
@@ -152,7 +146,6 @@ image:db_properties2.png[db_properties2]
 . Access the zip file itself. For example, type `cd ..`
 . Run Mule. For example, type `./bin/mule`
 ====
-
 
 . To stop the application from running, type *CTRL-C* in your PC's Console window, or *Command-C* in your Mac's Terminal app.
 . Open your Web browser, type `http://localhost:8084/services/jdbc` in the address bar, then press *enter*.

--- a/mule-user-guide/v/3.3/studio-components.adoc
+++ b/mule-user-guide/v/3.3/studio-components.adoc
@@ -84,3 +84,4 @@ Web Service components provide the developer with the framework to reference cla
 |image:Rest-24x16.png[Rest-24x16] |REST |Makes a REST web service available to the application flow via Jersey. |link:/mule-user-guide/v/3.3/rest-component-reference[REST Component Reference]
 
 |image:Soap-24x16.png[Soap-24x16] |SOAP |Makes a web service available to the application flow via CXF. |link:/mule-user-guide/v/3.3/soap-component-reference[SOAP Component Reference]
+|===

--- a/mule-user-guide/v/3.4/anypoint-connectors.adoc
+++ b/mule-user-guide/v/3.4/anypoint-connectors.adoc
@@ -76,6 +76,7 @@ image:Studio_AC_Salesforce.png[Studio_AC_Salesforce] |Salesforce |Using this con
 
 
 image:Studio_AC_twitter.png[Studio_AC_twitter] |Twitter |Using this connector, your Mule application can interact with the Twitter REST API, which provides simple interfaces for most Twitter functionality. |http://www.mulesoft.org/extensions/twitter[Mule Twitter Connector]
+|===
 
 If you are developing your applications in an XML editor outside of Mule Studio, you can install Anypoint connectors as Maven dependencies. To make the connector available to a Mavenized Mule application, add the connector repositories to your `pom.xml` file, add the module as a dependency, and add it to the packaging process of your applications.
 

--- a/mule-user-guide/v/3.4/connect-with-salesforce-example.adoc
+++ b/mule-user-guide/v/3.4/connect-with-salesforce-example.adoc
@@ -19,7 +19,7 @@ This document describes the details of the example within the context of Mule St
 
 Though a simple example, this application nonetheless employs complex functionality to demonstrate a basic use case. The application accepts CSV files which contain contact information – name, phone number, email – and uploads them into a Salesforce account, automatically inserting the correct data into each Salesforce field. 
 
-image:contacts-to-SFDC.png[contacts-to-SFDC]
+image::contacts-to-SFDC.png[contacts-to-SFDC]
 
 == Set Up and Run the Example
 
@@ -36,12 +36,11 @@ To witness end-to-end functionality, you must have an active Salesforce account 
 . In your SaaS Integration application in Mule Studio, click the *Global Elements* tab. 
 . Double-click the Salesforce global element to open its *Global Element Properties* panel. In the *Security Token* field, paste the new Salesforce token you copied from the email. Alternatively, configure the global element in the XML Editor.
 +
-
 [tabs]
 ------
 [tab,title="Studio Visual Editor"]
 ....
-image:global_initial.png[global_initial]
+image::global_initial.png[global_initial]
 ....
 [tab,title="Studio XML Editor"]
 ....
@@ -61,7 +60,7 @@ image:global_initial.png[global_initial]
 . Click and drag the `contacts.csv` file into the `input` folder in the same directory.
 . The File Endpoint in the application polls the `input` folder every ten seconds. It picks up the CSV file, processes it, then deposits it into the `output` folder in the same directory. (Hit *F5* to refresh the contents of the `input` and `output` folders.)
 . In your browser, access your Salesforce account, then navigate to the *Contacts* tab.
-. Use the drop-down menu to display *All Contacts*, then scan your contacts for three new entries:   +
+. Use the drop-down menu to display *All Contacts*, then scan your contacts for three new entries:
 * Charles Bingley
 * Fitzwilliam Darcy
 * George Wickham
@@ -78,12 +77,11 @@ While the application's functionality is relatively straightforward, the beauty 
 
 . Set a File endpoint into your application, completing the simple configuration to enable it poll a specific folder for input files.
 +
-
 [tabs]
 ------
 [tab,title="Studio Visual Editor"]
 ....
-image:file_Endpoint_studio.png[file_Endpoint_studio]
+image::file_Endpoint_studio.png[file_Endpoint_studio]
 
 [cols="2*"]
 |===
@@ -111,11 +109,9 @@ image:file_Endpoint_studio.png[file_Endpoint_studio]
 |===
 ....
 ------
-+
 
 . Next, add a Salesforce Connector to the flow. At this point, you can configure the connector with your Salesforce account-specific details and test the connection to Salesforce. Not only does the embedded Mule DataSense functionality confirm that you have a clear channel for communication, it gathers metadata about Salesforce objects and the type of data it accepts. (The value of this metadata becomes apparent with the introduction of a DataMapper into the flow further in this procedure.)
 +
-
 [tabs]
 ------
 [tab,title="Studio Visual Editor"]
@@ -124,7 +120,7 @@ image:file_Endpoint_studio.png[file_Endpoint_studio]
 .. Select the *Salesforce* global element, then click *OK*.
 .. Enter values in the U *sername*, P *assword* and *Security token* fields, then click *OK*. (See the Set Up section above for details on how to acquire the security token.) Notice that Studio automatically enables DataSense in the global element.
 +
-image:/docs/download/attachments/95393757/global_salesforce.png?version=1&modificationDate=1374599130837[image
+image::/docs/download/attachments/95393757/global_salesforce.png?version=1&modificationDate=1374599130837[image]
 ....
 [tab,title="Studio XML Editor"]
 ....
@@ -142,16 +138,13 @@ image:/docs/download/attachments/95393757/global_salesforce.png?version=1&modifi
 ....
 ------
 
-. When you click OK, Mule tests the connection to Salesforce (see image below). With a valid username, password and security token, the connection test results in success and Mule saves your global element configurations. If any of the values are invalid, the connection test results in failure, and Mule does not save the global element, prompting you to correct the invalid configurations. +
-
+. When you click OK, Mule tests the connection to Salesforce (see image below). With a valid username, password and security token, the connection test results in success and Mule saves your global element configurations. If any of the values are invalid, the connection test results in failure, and Mule does not save the global element, prompting you to correct the invalid configurations.
 +
-image:getting_metadata.png[getting_metadata] +
-+
+image::getting_metadata.png[getting_metadata]
 
-. Back in the Salesforce connector *General Tab*, use the drop-down menus to select the *Operation* and *sObject* Type. Because the DataSense activity has gathered metadata about Salesforce's operations and data sObject types, Mule is able to present a list of Salesforce-specific values in the drop-down menus for each of these fields (see image below). +
-
+. Back in the Salesforce connector *General Tab*, use the drop-down menus to select the *Operation* and *sObject* Type. Because the DataSense activity has gathered metadata about Salesforce's operations and data sObject types, Mule is able to present a list of Salesforce-specific values in the drop-down menus for each of these fields (see image below).
 +
-image:sfdc_options.png[sfdc_options]
+image::sfdc_options.png[sfdc_options]
 +
 [%header%autowidth.spread]
 |===
@@ -159,31 +152,24 @@ image:sfdc_options.png[sfdc_options]
 |Operation |Create
 |sObject Type |Contact
 |===
-+
 
-. Having defined the Salesforce-friendly output, you can then drop a DataMapper between the elements in the flow to map CSV input fields to Salesforce output fields. Because DataSense has already acquired the operation and sObject information from Salesforce, the DataMapper demands that you configure only the input values (below, left). In this example application, we used an existing CSV example to define the input fields in DataMapper (below, right). +
-
+. Having defined the Salesforce-friendly output, you can then drop a DataMapper between the elements in the flow to map CSV input fields to Salesforce output fields. Because DataSense has already acquired the operation and sObject information from Salesforce, the DataMapper demands that you configure only the input values (below, left). In this example application, we used an existing CSV example to define the input fields in DataMapper (below, right).
 +
-image:define_input_both.png[define_input_both] +
-+
+image::define_input_both.png[define_input_both]
 
-. When you save the DataMapper configurations, Mule maps input fields to output. Where the input and output fields have identical names, DataMapper intelligently, and automatically, maps input to output, as with the fields in this example application. Otherwise, you can quickly map input to output manually by clicking and dragging input fields to output fields in the Data Mapping Console (see below). +
-
+. When you save the DataMapper configurations, Mule maps input fields to output. Where the input and output fields have identical names, DataMapper intelligently, and automatically, maps input to output, as with the fields in this example application. Otherwise, you can quickly map input to output manually by clicking and dragging input fields to output fields in the Data Mapping Console (see below).
 +
-image:dataMapper.png[dataMapper] +
-+
+image::dataMapper.png[dataMapper]
 
-. The configuration now complete, you can save, then run the application. Feed CSV files with contact information into the input folder, and watch the new contents appear in your Salesforce account (see image below). +
-
+. The configuration now complete, you can save, then run the application. Feed CSV files with contact information into the input folder, and watch the new contents appear in your Salesforce account (see image below).
 +
-image:sfdc_contact_list.png[sfdc_contact_list]
+image::sfdc_contact_list.png[sfdc_contact_list]
 +
-
 [tabs]
 ------
 [tab,title="Studio Visual Editor"]
 ....
-image:flow_contacts_to_sfdc.png[flow_contacts_to_sfdc]
+image::flow_contacts_to_sfdc.png[flow_contacts_to_sfdc]
 ....
 [tab,title="Studio XML Editor"]
 ....

--- a/mule-user-guide/v/3.4/mule-credentials-vault.adoc
+++ b/mule-user-guide/v/3.4/mule-credentials-vault.adoc
@@ -126,7 +126,7 @@ You can add unencrypted properties to a properties file. In the properties file,
 ====
 
 [cols="2*"]
-|====
+|===
 |encrypted property |`Username=![r8weir09458riwe0r9484oi]`
 |unencrypted property |`Username=Aaron Martinez`
 |===

--- a/mule-user-guide/v/3.4/soap-component-reference.adoc
+++ b/mule-user-guide/v/3.4/soap-component-reference.adoc
@@ -277,7 +277,7 @@ In the *General* tab of the SOAP component's pattern properties panel, configure
 image:client-attribetes-together.png[client-attribetes-together]
 
 [%header%autowidth.spread]
-|======
+|===
 |Attribute |Simple client |JAX-WS client |Proxy client |Value
 |*Operation* |x |x |x |Specify the operation to invoke on the Web service to which your client will make calls. For example, `createNew`.
 |*Service Class* |x |x |x |Specify the Java class CXF should use to construct its service model for the client.

--- a/mule-user-guide/v/3.4/transformers.adoc
+++ b/mule-user-guide/v/3.4/transformers.adoc
@@ -173,7 +173,7 @@ Please note the common characteristics of the Message and Variable Transformers:
 The following table describes the individual *Message and Variable* transformers:
 
 [%header,cols="4*"]
-|=============================
+|===
 |  |Transformer |What it Does |Documentation
 |image:Transformer-24x16.png[Transformer-24x16] |Attachment |In contrast to the *Message Enricher Scope* or the *Append String Transformer*, the *Attachment Transformer* does not add to the string that typically composes the main data payload. Instead, this transformer specifies an attachment to append to each message being processed through the flow. If the name or the value of the attachment is defined through an expression, the exact identity (and content) of the attachment can be calculated at run-time, with the possibility that each message will receive a different payload. Typically, this attachment is treated as a separate, secondary part of the outbound payload. |link:/mule-user-guide/v/3.4/attachment-transformer-reference[Attachment Transformer Reference]
 

--- a/mule-user-guide/v/3.5/components.adoc
+++ b/mule-user-guide/v/3.5/components.adoc
@@ -71,3 +71,4 @@ Web Service components provide the developer with the framework to reference cla
 |  |Components |Description |Documentation
 |image:Rest-24x16.png[Rest-24x16] |REST |Makes a REST web service available to the application flow via Jersey. |link:/mule-user-guide/v/3.7/rest-component-reference[REST Component Reference]
 |image:Soap-24x16.png[Soap-24x16] |CXF |Makes a web service available to the application flow via CXF. |link:/mule-user-guide/v/3.6/cxf-component-reference[CXF Component Reference]
+|===

--- a/mule-user-guide/v/3.5/jdbc-transport-reference.adoc
+++ b/mule-user-guide/v/3.5/jdbc-transport-reference.adoc
@@ -1305,3 +1305,4 @@ The following attirbutes are available on the `mysql-data-source` element:
 |*port* |Database port to connect to. This attribute cannot be used together the with `url` attribute.
 |*url* |JDBC URL to use when conenction to the database. This attribute cannot be used together with the `database`, `host`, or `port` attribute.
 |*user* |User for connecting to the database. This attribute is required.
+|===

--- a/mule-user-guide/v/3.5/mule-credentials-vault.adoc
+++ b/mule-user-guide/v/3.5/mule-credentials-vault.adoc
@@ -126,7 +126,7 @@ You can add unencrypted properties to a properties file. In the properties file,
 ====
 
 [cols="2*"]
-|====
+|===
 |encrypted property |`Username=![r8weir09458riwe0r9484oi]`
 |unencrypted property |`Username=Aaron Martinez`
 |===

--- a/mule-user-guide/v/3.6/components.adoc
+++ b/mule-user-guide/v/3.6/components.adoc
@@ -71,3 +71,4 @@ Web Service components provide the developer with the framework to reference cla
 |  |Components |Description |Documentation
 |image:Rest-24x16.png[Rest-24x16] |REST |Makes a REST web service available to the application flow via Jersey. |link:/mule-user-guide/v/3.6/rest-component-reference[REST Component Reference]
 |image:Soap-24x16.png[Soap-24x16] |CXF |Makes a web service available to the application flow via CXF. |link:/mule-user-guide/v/3.6/cxf-component-reference[CXF Component Reference]
+|===

--- a/mule-user-guide/v/3.6/mule-credentials-vault.adoc
+++ b/mule-user-guide/v/3.6/mule-credentials-vault.adoc
@@ -125,7 +125,7 @@ Note that the first time you add an encrypted a property to a properties file, M
 You can add unencrypted properties to a properties file. In the properties file, an encrypted property is indecipherable, but recognizable by its wrapper.
 
 [cols="2*"]
-|====
+|===
 |encrypted property |`Username=![r8weir09458riwe0r9484oi]`
 |unencrypted property |`Username=Aaron Martinez`
 |===

--- a/release-notes/v/latest/mule-2.2.1-release-notes.adoc
+++ b/release-notes/v/latest/mule-2.2.1-release-notes.adoc
@@ -38,5 +38,5 @@ Mule Community Edition version 2.2.1 builds on the features that were added in v
 |Bug |MULE-5597 |response transformers applied twice on `udp:inbound-endpoint`
 |Bug |MULE-4980 |Custom Interceptors stopped working in 3.0.0M4 version
 |Bug |MULE-4455 |Mule exception-based-router performance degradation at heavy load
-[===
+|===
 


### PR DESCRIPTION
- fix AsciiDoc syntax that was flagged by the migration script
- mostly missing ending block delimiters for tables