### PR TITLE
Update custom-application-alerts.adoc

### DIFF
--- a/runtime-manager/v/latest/custom-application-alerts.adoc
+++ b/runtime-manager/v/latest/custom-application-alerts.adoc
@@ -65,6 +65,18 @@ In the *New Alert* dialog:
 
 This creates your alert. Now, trigger your notification again by going to your application's URL, for example: `http://YOURAPP.cloudhub.io/`. You then receive an email with your notification in it!
 
+If *Custom Properties* where send with the notification. i.e:
+
+[source,xml, linenums]
+----
+<cloudhub:create-notification message="Error processing transaction." priority="ERROR"> 
+  <cloudhub:custom-properties > 
+    <cloudhub:custom-property key="originalPayload">#[flowVars.originalPayload]</cloudhub:custom-property> 
+  </cloudhub:custom-properties> 
+</cloudhub:create-notification> 
+----
+Then, they can be accessed as normal properties in the message. i.e.: ${originalPayload} 
+
 == Sending an Error Notification
 
 In addition to sending notifications from business events, you may want to send notifications when errors happen so they can be acted upon. To do this, you can use the CloudHub connector inside a catch exception strategy. To do this, add the following XML to your mule-config.xml:


### PR DESCRIPTION
Added details on how to use custom properties from the CH connector:

Extracted from case comment:

<cloudhub:create-notification config-ref="Cloudhub_Outbound" domain="${cloud-hub.domain}" 
message="#['Alert from: ' + flowVars.flow_name]" priority="INFO" doc:name="Cloudhub"> 
<cloudhub:custom-properties > 
<cloudhub:custom-property key="message">#[flowVars.cloudHubMessage]</cloudhub:custom-property> 
<cloudhub:custom-property key="originalPayload">#[flowVars.originalPayload]</cloudhub:custom-property> 
</cloudhub:custom-properties> 
</cloudhub:create-notification> 

and then for particular application 

manage application -> Alerts -> (for any specific alert) , you can send an email and can refer to the custom properties as 

The application ${app} has a new notification: 

${message} 
${originalPayload}