### PR TITLE
describe firewall now created rules on port range

### DIFF
--- a/runtime-manager/v/latest/create-vpc-cli.adoc
+++ b/runtime-manager/v/latest/create-vpc-cli.adoc
@@ -92,19 +92,15 @@ This command returns:
 ┌───────┬────────────────────┬──────────┬────────────┬──────────┐
 │ Index │ CIDR Block         │ Protocol │ From port  │ To port  │
 ├───────┼────────────────────┼──────────┼────────────┼──────────┤
-│ 0     │ 10.111.0.0/24      │ TCP      │ 8092       │          │
+│ 0     │ 10.111.0.0/24      │ TCP      │ 8091       │ 8092     │
 ├───────┼────────────────────┼──────────┼────────────┼──────────┤
-│ 1     │ 0.0.0.0/0          │ TCP      │ 8082       │          │
-├───────┼────────────────────┼──────────┼────────────┼──────────┤
-│ 2     │ 10.111.0.0/24      │ TCP      │ 8091       │          │
-├───────┼────────────────────┼──────────┼────────────┼──────────┤
-│ 3     │ 0.0.0.0/0          │ TCP      │ 8081       │          │
+│ 1     │ 0.0.0.0/0          │ TCP      │ 8081       │ 8082     │
 └───────┴────────────────────┴──────────┴────────────┴──────────┘
 ----
 
 [TIP]
 --
-Rules `0` and `2` allow inbound connections from your local VPC from ports *8091* and *8092*, while rules `1` and `3` allow traffic from any host to reach your workers through ports 8081 and 8082.
+Rule `0` allows inbound connections from your local VPC from ports *8091* and *8092*, while rule `1` allows traffic from any host to reach your workers through ports 8081 and 8082.
 --
 
 You can use the link:/runtime-manager/anypoint-platform-cli#cloudhub-vpc-delete[vpc firewall-rules delete] command to remove any of the default rules or you  can add new ones using the link:/runtime-manager/anypoint-platform-cli#cloudhub-vpc-firewall-rules-add[vpc firewall-rules add] command.


### PR DESCRIPTION
While creating a test vpc I noticed that I ended up with 2 rules instead of 4 with port ranges 8091 to 8092 and 8081 to 8082.