### PR TITLE
fixing typos in PCE LB doc

### DIFF
--- a/anypoint-private-cloud/v/1.6/install-create-lb.adoc
+++ b/anypoint-private-cloud/v/1.6/install-create-lb.adoc
@@ -1,6 +1,6 @@
 = To Configure a Load Balancer for Anypoint Platform Private Cloud Edition
 
-Anypoint Platform Private Cloud Edition must be run in production environment with multiple servers. To distribute traffic amonng servers and to restrict access to specifi ports, you must install and configure a load balancer.
+Anypoint Platform Private Cloud Edition must be run in production environment with multiple servers. To distribute traffic among servers and to restrict access to specific ports, you must install and configure a load balancer.
 
 [NOTE]
 In a single server development environment, MuleSoft recommends using a load balancer.


### PR DESCRIPTION
Fixing two minor typos:

- changing "amonng" to "among" 
- changing "specifi" to "specific"