### PR TITLE
Update dataweave-examples.adoc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-examples.adoc
+++ b/mule-user-guide/v/3.8/dataweave-examples.adoc
@@ -1366,7 +1366,7 @@ books: {
 }
 ----
 ....
-[tab,title="Output"]
+[tab,title="Output: XML"]
 ....
 
 .Output
@@ -1472,7 +1472,7 @@ The first item that makes up the payload contains an array of "price" objects, u
 ----
 
 ....
-[tab,title="Output"]
+[tab,title="Output: JSON"]
 ....
 
 .Output
@@ -1610,7 +1610,7 @@ payload
 
 
 ....
-[tab,title="Output: JSON"]
+[tab,title="Output: XML"]
 ....
 .Output
 [source,xml,linenums]
@@ -1663,7 +1663,7 @@ Note that the code above includes not just the DW transformation, but the XML of
 
 [tabs]
 ------
-[tab,title="Input: JSON"]
+[tab,title="Input: CSV"]
 ....
 
 .Input
@@ -1676,7 +1676,7 @@ Steven Wilson; 13/16 Raven st., Somewhere but not Here; 1234567
 ----
 
 ....
-[tab,title="Output: XML"]
+[tab,title="Output: CSV"]
 ....
 
 .Output


### PR DESCRIPTION
Fixed/enhanced some of the Input and Output tab descriptors of the DataWeave examples.