### PR TITLE
Adding Studio 6.3.0 Beta to the beta anypoint site

### DIFF
--- a/_toc.adoc
+++ b/_toc.adoc
@@ -3,5 +3,6 @@
 * link:design-center[Design Center]
 * link:mule-user-guide[Mule Runtime User Guide]
 * link:connectors[Connectors and Modules]
+* link:anypoint-studio[Anypoint Studio 6.3 Beta]
 * link:anypoint-exchange[Anypoint Exchange 2]
 * link:release-notes[Release Notes]

--- a/anypoint-studio/v/6.3/_config.yml
+++ b/anypoint-studio/v/6.3/_config.yml
@@ -1,0 +1,4 @@
+configuration:
+  versionName: 6.3
+  isLatest: true
+  sectionName: Anypoint Studio

--- a/anypoint-studio/v/6.3/_toc.adoc
+++ b/anypoint-studio/v/6.3/_toc.adoc
@@ -1,0 +1,6 @@
+// Anypoint Studio TOC File
+
+* link:/anypoint-studio/v/6.3/index[Anypoint Studio 6.3.0 Beta]
+** link:/anypoint-studio/v/6.3/to-download-and-install-studio-beta[To Download and Install Anypoint Studio 6.3 Beta]
+** link:/anypoint-studio/v/6.3/exchange-integration[Integration with Exchange 2.0 Beta]
+** link:/anypoint-studio/v/6.3/import-api-def-dc[To Import an API Definition from Design Center Beta]

--- a/anypoint-studio/v/6.3/exchange-integration.adoc
+++ b/anypoint-studio/v/6.3/exchange-integration.adoc
@@ -1,0 +1,37 @@
+= Integration with Exchange 2.0 Beta
+
+Anypoint Studio 6.3 Beta allows you to connect to Exchange 2.0 Beta to publish your project as a new asset.
+
+[NOTE]
+The Publish to Exchange feature only works in Mavenized projects.
+
+By default, Studio 6.3 Beta points to the Exchange 2.0 Beta URL +https://anypoint.mulesoft.com/exchange2/+.
+
+== To Publish to Exchange 2.0 Beta
+
+. In a Mavenized project, right click the project folder on your Package Explorer View.
+. Select Anypoint Platform and then Publish to Exchange.
+. Select your Anypoint Platform user and business group.
+:: Additionally you can click the "Add Account" button to use a new Anypoint Platform account.
+. Review the information about your project:
+* Group Id: This field is required. The group Id uniquely identifies your project across others. By default, Studio uses the group Id configured in your pom.xml file.
+* Artifact Id: This field is required. The artifact Id is the name of your project without a version. By default, Studio uses the artifact Id configured in your pom.xml file.
+* Version: This field is required. The version of the asset you are publishing.
+. Select a project type.
+. Select the "Save updated project information to the pom.xml"  if you want to update your pom.xml file with the data you just provided.
++
+[NOTE]
+--
+If selected, the "Save updated project information to the pom.xml" option updates your local project's information with the data configured in the Publish to Exchange window. +
+If not, the project is deployed with the configured data, but your local project information is not updated.
+--
++
+. Click Finish.
+
+You can follow the deployment progress in the Console View. +
+After confirmed, the deployment to Exchange 2.0 cannot be stopped.
+
+
+== See Also
+
+* link:https://docs.mulesoft.com/anypoint-studio/v/6/enabling-maven-support-for-a-studio-project[Mavenize a Studio project].

--- a/anypoint-studio/v/6.3/import-api-def-dc.adoc
+++ b/anypoint-studio/v/6.3/import-api-def-dc.adoc
@@ -1,0 +1,38 @@
+= To Import an API Definition from Design Center
+
+Anypoint Studio 6.3 Beta allows you to import an API Definition from Design Center Beta and implement it either into a new Mule Project, or an existing one.
+
+== To Implement an API imported from Design Center Into a New Project
+
+. Click File > New > Mule Project to create a project, and set the field values in the project wizard:
++
+* Type a name for your project.
+* Select a Mule runtime version.
+* Check Add APIkit Components.
+* In API Definition, click the "..." button to and select Design Center.
+. In the Browse Design Center for APIs window:
+* Select your Anypoint Platform user and business group.
+:: Additionally you can click the "Add Account" button to use a new Anypoint Platform account.
+. From the list of available APIs, select the one you want and click OK.
+. Click Finish.
+
+APIKit generates the Flow based on the API definition imported from Design Center.
+
+== To Implement an API imported from Design Center Into an Existing Project
+
+. Right click your Mule Project on the Package Explorer View.
+. Select Anypoint Platform and then Import from Design Center.
+. Select your Anypoint Platform user and business group.
+:: Additionally you can click the "Add Account" button to use a new Anypoint Platform account.
+. From the list of available APIs, select the one you want and click OK.
+:: Importing an API definition from Design Center into an existing project deletes all your resources from your src/main/api directory.
+. Click Finish.
+
+APIKit generates the Flow based on the API definition imported from Design Center.
+
+
+== See Also
+
+* link:https://docs.mulesoft.com/getting-started/implement-and-test[To Implement and Test an API].
+* link:https://docs.mulesoft.com/apikit/[About APIKit]
+* link:/anypoint-exchange/ex2-studio[Integration with Exchange 2.0 Beta].

--- a/anypoint-studio/v/6.3/index.adoc
+++ b/anypoint-studio/v/6.3/index.adoc
@@ -1,0 +1,16 @@
+= Anypoint Studio 6.3.0 Beta
+:keywords: studio, IDE, development, eclipse, anypoint, visual editor, xml editor
+:imagesdir: _images
+
+Anypoint Studio is MuleSoft's Eclipse-based integration development environment for designing and testing Mule applications. +
+It also allows you to edit API definition files.
+
+Anypoint Studio 6.3.0 Beta introduces support for exporting your Studio Projects to Exchange 2.0 Beta and import API definitions from Design Center Beta.
+
+For a full list of Aynpoint Studio tasks and references, refer to the documentation of the latest general availability release: +https://docs.mulesoft.com/anypoint-studio/v/6/+.
+
+== See Also 
+
+* link:/anypoint-studio/v/6.3/to-download-and-install-studio[To Download and Install Anypoint Studio 6.3 Beta]
+* link:/anypoint-studio/v/6.3/exchange-integration[Integration with Exchange 2.0 Beta]
+* link:/anypoint-studio/v/6.3/import-api-def-dc[To Import an API Definition from Design Center Beta]

--- a/anypoint-studio/v/6.3/to-download-and-install-studio-beta.adoc
+++ b/anypoint-studio/v/6.3/to-download-and-install-studio-beta.adoc
@@ -1,0 +1,65 @@
+= To Download and Install Anypoint Studio 6.3 Beta
+
+* Before downloading and launching Anypoint Studio, install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[Java SE JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
+
+* If you are using a Mac computer running OS X and if you are installing Anypoint Studio on a new computer or a fresh installation, you must also install link:https://support.apple.com/kb/DL1572[JRE 1.6], which provides important libraries used by later JDK versions. Install JDK 6 first and then install link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[JDK 7] or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8].
++
+After installing JDK 7 or 8, you need to change the default Java virtual machine (JVM) from v6 to the later version.
+
+** Open a Terminal and enter this command as shown in the following example:
+
+[source,code,linenums]
+----
+/usr/libexec/java_home -V
+----
+
+It should return
+
+[source,source,linenums]
+----
+Matching Java Virtual Machines (2):
+1.8.0_101, x86_64:	"Java SE 8"	/Library/Java/JavaVirtualMachines/jdk1.8.0_101.jdk/Contents/Home
+1.6.0_65-b14-468, x86_64:	"Java SE 6"	/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+----
+
+** Enter a command such as this that sets the JDK 8 to the default JVM.
+
+[source]
+----
+export JAVA_HOME=`/usr/libexec/java_home -v 1.8.0_101`
+----
+
+== Download and Install
+
+To download and install Anypoint Studio:
+
+. Visit the link:https://www.mulesoft.com/platform/studio[Studio Product Site] and click Download Anypoint Studio.
+. Select the Studio 6.3.0 Beta option and choose the Studio file compatible with your operating system: Windows, Mac, or Linux.
+. Check to confirm that JDK 7 or JDK 8 is in place on your system. From the command line (Terminal app for a Mac, Command Prompt for Windows), run: `java -version`
+. Unzip the zip file.
++
+[WARNING]
+====
+*Windows*: It's important to extract Anypoint Studio into the 'C:\' root folder. Also, if you are using a Windows Anti-Virus application, ensure that the `plugin/` and `features/` directories are under the “trusted” category.
+
+*OS X*: If you're using OS version Sierra, it's important that you move your extracted app to the `/applications` folder before you launch it
+
+*Linux*: To support some of Studio Themes in Linux, it is recommended to have GTK version 2 installed.
+====
++
+. Open Anypoint Studio:
+.. *Windows*: Double-click the *AnypointStudio.exe* file, located in the *AnypointStudio* directory.
+.. *Linux*: Double-click the *AnypointStudio* file icon, located in the *AnypointStudio* directory.
+.. *OSx*: Double-click the *AnypointStudio.app* file icon, located in the *Applications* directory.
+. If the wrong version of Java is present on your computer, the following may occur after you start Studio:
+.. *Mac*: The command triggers a prompt to install the JDK tools directly from Apple. Follow the instructions to download and install JDK 7 or JDK 8.
+.. *Windows*: This message appears when you start Studio:
+Incompatible JVM - Version _<number>_ of the JVM is not suitable for this product. Version 1.7 or greater is required.
+Go to link:http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html[Java SE JDK 7] or  or link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Java SE JDK 8], download the JDK, and install it. Then restart AnypointStudio.exe from where you unzipped the software distribution.
+. Click *OK* to accept the default workspace.
+. Anypoint Studio launches, then displays a Welcome page. Click *Create a Project* to begin development immediately.
+
+== See Also
+
+* link:/anypoint-studio/v/6.3/exchange-integration[Integration with Exchange 2.0 Beta]
+* link:/anypoint-studio/v/6.3/import-api-def-dc[To Import an API Definition from Design Center Beta]

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -19,7 +19,7 @@ Complete repository for connectors, templates, examples and RAML APIs. Discover 
 
 === *Anypoint Studio*
 
-An integrated development environment with visual and XML editors to design, debug and test Mule applications. Using the visual interface, you can drag and drop connectors, loggers, decision items, data transformers, and much more to the design canvas. Navigate the interface to debug and test. For more information, see link:/anypoint-studio/v/6/[Anypoint Studio Essentials] or download from link:http://studio.mulesoft.org[Anypoint Studio].
+An integrated development environment with visual and XML editors to design, debug and test Mule applications. Using the visual interface, you can drag and drop connectors, loggers, decision items, data transformers, and much more to the design canvas. Navigate the interface to debug and test. For more information, see link:/anypoint-studio/v/6.3/[Anypoint Studio Essentials] or download from link:http://studio.mulesoft.org[Anypoint Studio].
 
 === *Anypoint Platform*
 
@@ -132,7 +132,7 @@ A deprecated component that can map input fields to ouptut fields via an easy dr
 
 === *DataSense*
 
-A feature of Anypoint Studio that uses message metadata to facilitate application design. With this functionality, Anypoint Studio proactively acquires information such as data type and structure, in order to prescribe how to accurately map or use this data in your application. See link:/anypoint-studio/v/6/datasense[DataSense].
+A feature of Anypoint Studio that uses message metadata to facilitate application design. With this functionality, Anypoint Studio proactively acquires information such as data type and structure, in order to prescribe how to accurately map or use this data in your application. See link:/anypoint-studio/v/6.3/datasense[DataSense].
 
 === *DataWeave*
 

--- a/index.adoc
+++ b/index.adoc
@@ -8,9 +8,8 @@ This release includes the following new versions:
 
 * link:/mule-user-guide/[Mule runtime 4.0]
 
+* link:/anypoint-studio/[Anypoint Studio version 6.3.0 Beta] supports Exchange 2.
+
 The following new product:
 
 * A new product, link:/design-center/[Design Center]
-
-
-Also, Anypoint Studio version 6.3.0 beta supports Exchange 2.

--- a/release-notes/v/latest/_toc.adoc
+++ b/release-notes/v/latest/_toc.adoc
@@ -3,6 +3,7 @@
 
 * link:/release-notes/v/latest/index[Release Notes]
 ** link:/release-notes/v/latest/design-center-release-notes[Design Center Release Notes]
+** link:/release-notes/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes[Anypoint Studio 6.3 Beta with Mule Runtime 3.8.4 Release]
 ** link:/release-notes/mule-4.0-beta-release-notes[Mule 4.0 Beta Release Notes]
 ** link:/release-notes/rest-connect-release-notes[REST Connect Beta Release Notes]
 ** link:/release-notes/anypoint-exchange-2-release-notes[Anypoint Exchange 2.0 Beta Release Notes]

--- a/release-notes/v/latest/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes.adoc
+++ b/release-notes/v/latest/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes.adoc
@@ -1,0 +1,183 @@
+= Anypoint Studio 6.3 Beta with Mule Runtime 3.8.4 Release Notes
+
+*June 26, 2017* +
+*Build ID: 201706261611*
+
+xref:migration[Skip to Migration Guide]
+
+== Compatibility
+
+[cols="30a,70a"]
+|===
+| *Mule Runtime*
+| Version: 3.8.4 EE
+
+|*Anypoint Studio*
+|Version: 6.3 +
+Build Id: 201706261611
+
+|*APIkit*
+|Versions: 3.8.1 - 3.8.0 - 1.7.3 - 1.6.2 - 1.5.3
+
+|*DataWeave* +
+|Version: 1.1.1
+
+|*MUnit* +
+|Version: 1.2.1, 1.3.0 (munit-studio-plugin)
+
+|*SAP Connector*
+|Versions: 3.0.0
+|===
+
+
+== What's New
+
+This beta release is part of our Crowd Release for Anypoint Platform, with support to our new Design Center and Anypoint Exchange. Crowd Release introduces our brand new Exchange v2.0 and more easy-to-use and powerful API Designer in Design Center. We have updated Studio to support our upgraded platform, and integrate with them for a seamless development cycle. +
+These include:
+
+* Import RAML files from our brand new API Designer (beta) in Design Center into Studio 6.3 beta through a new feature called “Import from Design Center”. Please note that for customers who use legacy API designer inside API Manager, the existing APISync feature in Studio will continue to function, and allow users to conduct two-way syncs between the local RAML file and the one hosted on API Manager. The new “Import from Design Center” feature does not support two-way syncs.
+* Publish a mule project from Studio directly to our newly launched Exchange 2.0, through a new feature called “Publish to Exchange”
+
+In addition, Studio 6.3 continues to deliver quality improvements and bug fixes.
+
+[NOTE]
+--
+Beta status in this release indicates the functionality is open for customers to trial for the purpose of learning the new functionality and/or testing functionality in a non-production environment. Basic functionalities to enable core use cases are complete, and MuleSoft is in the process of verifying design and evolving feature completeness. There is no SLA or technical support obligations for the Beta features. Beta releases are suitable for use in test environments or for limited-use tests.  Please see our link:https://www.mulesoft.com/legal/product-trial-commercialfree-licenses[beta trial license] for full terms of use.
+--
+
+== Hardware Requirements
+
+* 4GB of free memory available
+* 2GHz CPU
+* 10GB free hard drive space
+
+== Software Requirements
+
+[cols="30a,70a"]
+|===
+|Java Environments |* Oracle JDK 1.8.0 +
+* Oracle JDK 1.8.0
+* Oracle JDK 1.7.0
+|Operating Systems |* MacOS 10.10.0 +
+* Windows (32- and 64-bit) Windows 7, Windows 8, Windows 10 +
+* RHEL 7.0 +
+* Ubuntu 15.04 or later
+|Suggested Web Browsers by Platform. +
+_Studio will always use the OS default web browser_ | * Windows: +
+** Microsoft Edge 25.0  +
+** Internet Explorer 11 +
+* Linux +
+** Mozilla Firefox 46.0  +
+* OS X +
+** Safari 9.1
+|===
+
+[NOTE]
+--
+If you are installing Anypoint Studio on a Mac computer with OS X that has no Java installed, the OS may require that you first download and install link:http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html[JDK 1.6]. Install JDK 1.6 first and then install JDK 1.7.
+--
+
+[NOTE]
+--
+If you are running McAfee VirusScan on your Windows OS, Eclipse-based Anypoint Studio may experience negative performance impacts. McAfee has suggested the following remedy link:https://kc.mcafee.com/corporate/index?page=content&id=KB58727[options].
+--
+
+== Known Issues
+
+* For all users adopting new API Designer in Design Center, Studio 6.3+ Studio versions prior to 6.3 will not be able to import RAML project folders from new API Designer in Design Center. When attempting to import a zip folder downloaded from new API Designer in side Design Center, users will not see any error message, but import will fail.
+* Publishing assets to Exchange inside Studio 6.3 beta only works with Exchange 2.0. If a user configures the url to exchange under preference to Exchange 1.0 url, assets will still be published to Exchange 2.0.
+* Studio 6.3 does not support the following Mule 3.8 features:
+** RecordVars and record payload should be editable in a commit block.
+** Object Store support gaps around Idempotent Redelivery Policy, Aggregators and DevKit token manage
+* Create JSON metadata from example does not support Big Integers
+* When importing a zipped project related to the API Gateway's default domain (for example, proxies generated from API Platform), if the domain project does not exist in the workspace already, there is a chance that it will be generated incorrectly, resulting in an entry in the Package Explorer like "api-gateway_2_0_3 : ". The workaround is to delete the corrupt domain project and right click in the imported project -> Mule -> Associate with API Gateway domain, until the project is generated correctly displaying, for example, "api-gateway_2_0_3 : api-gateway".
+* When changing API Platform environments from production to another environment, Studio would try to update offline projects, showing connection error marker. The workaround is to use different workspaces for each environment so that there will no be problem with users authentication.
+* Folder decorators are not being shown correctly when users eliminate them. It shows them as modified and not as eliminated.
+* When creating a new project with an invalid raml zip, Studio does not copy those files to the workspace.
+* API Custom Policy Editing is a beta feature. We have a few known gaps.
+* When having some projects connected to the Platform and using an invalid On Premises URL, two error messages per project will be thrown. This issue will be fixed in 6.2.1 (STUDIO-8541)
+
+
+[[migration]]
+== Migration Guide
+
+Users running Studio 6.0 can update to this new version directly from the Studio link:/anypoint-studio/v/6/studio-update-sites[Update Site]. +
+If you are running an older version than Studio 6.0, you need to download a new full copy in order to update.
+
+When opening a previous Workspace with projects that were created with Studio 5.1.0 or older, and which has metadata stored in disk, Studio asks you to perform an update to all the projects so that the Metadata Manager can handle the types and to show the types in your project.
+
+[TIP]
+====
+You can easily import all of the external components that you had installed in your old version of Anypoint Studio through a single action. This includes connectors, runtimes, and any other type of extension added through the Anypoint Exchange or the ​*Help -> Install new software*​ menu, as long as there are no compatibility restrictions.
+
+Do this by selecting *File->Import* and then choose *Install->From existing installation*.
+
+image:import_extensions.png[import]
+
+Then specify the location of your old version of Anypoint Studio in your local drive.
+====
+
+== Eclipse Plugin
+
+If you are using Studio as an Eclipse plugin, you can get this version of Studio using the Eclipse update site `+http://studio.mulesoft.org/r5/plugin+`.
+
+This allows you to download Anypoint Studio core and third-party components version 6.x.x and with an embedded version of Mule Runtime v3.8.x along with other optional components. +
+For a detailed description of the update site's content visit the link:/anypoint-studio/v/6/studio-in-eclipse#available-software-in-the-update-site[Studio in Eclipse] section.
+
+== JIRA Ticket List for Anypoint Studio
+
+=== Bug Fixes
+
+* STUDIO-7679 - API Project import fails when importing several apis with domain
+* STUDIO-8968 - Cannot run maven projects with finalName/appName configured in mule plugins
+* STUDIO-9051 - Wrong validation error when adding global connector to MUnit test configuration
+* STUDIO-9052 - Validation issues in Anypoint Studio for oauth2 module
+* STUDIO-9060 - JSON schema relative reference for array items causes file not found
+* STUDIO-9063 - Empty .dwl file generated erroneously
+* STUDIO-9086 - Problem when doing multiple test connection with Derby JDBC
+* STUDIO-9087 - DB Stored Proc operation parameters get sorted breaking the stored procedure
+* STUDIO-9114 - Studio for Windows error when there is a literal unicode character in a DW script
+* STUDIO-9123 - [SE] SAP missing jar file error
+* STUDIO-9166 - Export Documents fails for large projects - Windows Studio
+* STUDIO-9200 - [SE] Studio showing confusing dialog title for API Sync
+* STUDIO-9201 - Update CXF library to 2.7.18 (same version from Mule 3.8+)
+* STUDIO-9216 - Generate Flows from WSDL is failing after upgrading the library
+* STUDIO-9217 - APIKit: Business groups is listing the users instead of the Organizations
+* STUDIO-9218 - [SE] Flow generation from WSDL fails when service name changes
+* STUDIO-9267 - Add empty fields validations in Publish to Exchange dialog
+* STUDIO-9268 - Add pop validation to alert users that the app will be deployed to Exchange
+* STUDIO-9271 - Add undefined default option when project does not have a classifier defined
+* STUDIO-9275 - Studio does not add TLS namespace when specifying a trust store for OAuth authorization
+* STUDIO-9295 - [SE] Maven variables in finalName prevent project deployment from Studio
+* STUDIO-9302 - APIKit does not work with Studio 6.3
+* STUDIO-9306 - Cannot deploy to Cloud from Studio using Mac
+* STUDIO-9384 - Problem with APIKit scaffold from zip file
+
+=== Enhancement Request
+
+* STUDIO-7267 - When mavenizing a project include in the pom src/main/api as source folder
+* STUDIO-8849 - Add Support to Import APIs from VCS from Exchange 2.0
+* STUDIO-8850 - Support version selection for RAML from VCS
+* STUDIO-8851 - API Sync modification for API Manager RAMLs
+* STUDIO-8852 - RAML Editor for APIs in VCS should be read only
+* STUDIO-8853 - Alter New Project wizard to select RAML from Exchange 2.0
+* STUDIO-8854 - Support publish Studio projects to Exchange 2.0
+* STUDIO-9129 - [Publish to Exchange 2.0] Create a dialog with artifact type, progress bar, information and cancellation button
+* STUDIO-9131 - [Publish to Exchange 2.0] Show an Exchange 2.0 link to the artifact after a successful publishing
+* STUDIO-9132 - [Publish to Exchange 2.0] Create reusable Login Widget
+* STUDIO-9141 - [VCS integration] Add support for "Import from VCS" *
+
+=== Tasks
+
+* STUDIO-9326 - Update Raml Java parser version 1.0.10 in Wizard and Raml editor (Studio 6.3)
+
+
+== Support
+
+* Refer to MuleSoft Documentation:
+** Crowd Release Notes
+** link:/anypoint-studio/v/6/import-api-def-dc[Import API RAML specs from Design Center].
+** link:/anpoint-studio/v/6/exchange-integration[Publish Mule projects into Exchange].
+// ** Configure Exchange url.
+* Access link:http://forums.mulesoft.com/[MuleSoft’s Forum] to pose questions and get help from Mule’s broad community of users.
+* To access MuleSoft’s expert support team link:https://www.mulesoft.com/support-and-services/mule-esb-support-license-subscription[subscribe to Mule ESB Enterprise] and log in to MuleSoft’s link:http://www.mulesoft.com/support-login[Customer Portal].

--- a/release-notes/v/latest/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes.adoc
+++ b/release-notes/v/latest/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes.adoc
@@ -97,33 +97,6 @@ If you are running McAfee VirusScan on your Windows OS, Eclipse-based Anypoint S
 * API Custom Policy Editing is a beta feature. We have a few known gaps.
 * When having some projects connected to the Platform and using an invalid On Premises URL, two error messages per project will be thrown. This issue will be fixed in 6.2.1 (STUDIO-8541)
 
-
-[[migration]]
-== Migration Guide
-
-Users running Studio 6.0 can update to this new version directly from the Studio link:/anypoint-studio/v/6/studio-update-sites[Update Site]. +
-If you are running an older version than Studio 6.0, you need to download a new full copy in order to update.
-
-When opening a previous Workspace with projects that were created with Studio 5.1.0 or older, and which has metadata stored in disk, Studio asks you to perform an update to all the projects so that the Metadata Manager can handle the types and to show the types in your project.
-
-[TIP]
-====
-You can easily import all of the external components that you had installed in your old version of Anypoint Studio through a single action. This includes connectors, runtimes, and any other type of extension added through the Anypoint Exchange or the ​*Help -> Install new software*​ menu, as long as there are no compatibility restrictions.
-
-Do this by selecting *File->Import* and then choose *Install->From existing installation*.
-
-image:import_extensions.png[import]
-
-Then specify the location of your old version of Anypoint Studio in your local drive.
-====
-
-== Eclipse Plugin
-
-If you are using Studio as an Eclipse plugin, you can get this version of Studio using the Eclipse update site `+http://studio.mulesoft.org/r5/plugin+`.
-
-This allows you to download Anypoint Studio core and third-party components version 6.x.x and with an embedded version of Mule Runtime v3.8.x along with other optional components. +
-For a detailed description of the update site's content visit the link:/anypoint-studio/v/6/studio-in-eclipse#available-software-in-the-update-site[Studio in Eclipse] section.
-
 == JIRA Ticket List for Anypoint Studio
 
 === Bug Fixes
@@ -176,7 +149,7 @@ For a detailed description of the update site's content visit the link:/anypoint
 
 * Refer to MuleSoft Documentation:
 ** Crowd Release Notes
-** link:/anypoint-studio/v/6/import-api-def-dc[Import API RAML specs from Design Center].
+** link:/anypoint-studio/v/6.3/import-api-def-dc[Import API RAML specs from Design Center].
 ** link:/anpoint-studio/v/6/exchange-integration[Publish Mule projects into Exchange].
 // ** Configure Exchange url.
 * Access link:http://forums.mulesoft.com/[MuleSoft’s Forum] to pose questions and get help from Mule’s broad community of users.

--- a/release-notes/v/latest/index.adoc
+++ b/release-notes/v/latest/index.adoc
@@ -12,7 +12,7 @@
 |link:/release-notes/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes[Anypoint Studio 6.3 Beta with Mule Runtime 3.8.4 Release]
 
 | A development environment that accelerates productivity for cloud and on-premises integration and API development.
-*Documentation*: link:/anypoint-studio/v/6/[Anypoint Studio 6.3.0 Beta]
+*Documentation*: link:/anypoint-studio/v/6.3/[Anypoint Studio 6.3.0 Beta]
 
 |link:/release-notes/mule-4.0-beta-release-notes[Mule 4.0 Beta Release Notes]
 |The latest Enterprise and Community release of Mule

--- a/release-notes/v/latest/index.adoc
+++ b/release-notes/v/latest/index.adoc
@@ -9,6 +9,11 @@
 
 *Documentation*: link:/design-center[Design Center]
 
+|link:/release-notes/anypoint-studio-6.3-beta-with-3.8.4-runtime-release-notes[Anypoint Studio 6.3 Beta with Mule Runtime 3.8.4 Release]
+
+| A development environment that accelerates productivity for cloud and on-premises integration and API development.
+*Documentation*: link:/anypoint-studio/v/6/[Anypoint Studio 6.3.0 Beta]
+
 |link:/release-notes/mule-4.0-beta-release-notes[Mule 4.0 Beta Release Notes]
 |The latest Enterprise and Community release of Mule
 
@@ -21,5 +26,5 @@
 
 |link:/release-notes/rest-connect-release-notes[REST Connect Beta Release Notes]
 
-*Documentation*: link:/anypoint-exchange/ex2-rest-connect-faq[FAQ: Rest Connect Beta]
+|*Documentation*: link:/anypoint-exchange/ex2-rest-connect-faq[FAQ: Rest Connect Beta]
 |===


### PR DESCRIPTION
This PR adds Studio 6.3 as a standalone product in the closed beta site. 
It also adds Studio 6.3 release notes and tasks for Exchange and Design Center integration.