### PR TITLE
Fix link for Studio "hardware and software requirements"

### DIFF
--- a/anypoint-studio/v/6/setting-up-your-development-environment.adoc
+++ b/anypoint-studio/v/6/setting-up-your-development-environment.adoc
@@ -7,7 +7,7 @@ The following document outlines the steps to be taken before any significant use
 
 === Check Hardware and Software Requirements
 
-* Review the link:/mule-user-guide/v/3.8/hardware-and-software-requirements[Hardware and Software requirements] and make sure you meet the essentials.
+* Review the link:/anypoint-studio/v/6/hardware-and-software-requirements[Hardware and Software requirements] and make sure you meet the essentials.
 
 === Install Oracle JDK
 


### PR DESCRIPTION
Link should point to Studio requirements, not Mule runtime requirements. https://docs.mulesoft.com/anypoint-studio/v/6/hardware-and-software-requirements 

As it is, the Studio requirements page appears to be an orphan, with the current link instead pointing to the Runtime requirements.