### PR TITLE
Change the private key format from ASC to PEM

### DIFF
--- a/runtime-manager/v/latest/anypoint-platform-cli.adoc
+++ b/runtime-manager/v/latest/anypoint-platform-cli.adoc
@@ -1982,8 +1982,8 @@ This command creates a load balancer using the specified values in the variables
 | name |Name for the load balancer. | newtestloadbalancer
 | Certificate |Absolute path to the `.pem` file of your certificate in your local hard drive. +
 *Your certificate files need to be pem encoded and not encrypted* | /Users/mule/Documents/cert.pem
-| privateKey |Absolute path to the `.asc` file of your private key in your local hard drive. +
-*Your private key file needs to be passphraseless* | /Users/mule/Documents/privateKey.asc
+| privateKey |Absolute path to the `.pem` file of your private key in your local hard drive. +
+*Your private key file needs to be passphraseless* | /Users/mule/Documents/privateKey.pem
 |===
 
 [CAUTION]
@@ -2058,8 +2058,8 @@ This command adds an SSL endpoint to the load balancer specified in <name>, usin
 | name |Name for the load balancer. | newtestloadbalancer
 | Certificate |Absolute path to the `.pem` file of your certificate in your local hard drive. +
 *Your certificate files need to be pem encoded and not encrypted* | /Users/mule/Documents/cert.pem
-| privateKey |Absolute path to the `.asc` file of your private key in your local hard drive. +
-*Your private key file needs to be passphraseless* | /Users/mule/Documents/privateKey.asc
+| privateKey |Absolute path to the `.pem` file of your private key in your local hard drive. +
+*Your private key file needs to be passphraseless* | /Users/mule/Documents/privateKey.pem
 |===
 
 [NOTE]


### PR DESCRIPTION
Changed the format for the private key in the `cloudhub load-balancer create` and the `cloudhub load-balancer ssl-endpoint add` to pem, since we don't do PGP-armoured ASCII.