### PR TITLE
Added FAQ

### DIFF
--- a/anypoint-mq/v/latest/mq-faq.adoc
+++ b/anypoint-mq/v/latest/mq-faq.adoc
@@ -197,6 +197,10 @@ image:mq-delete-exchange.png[mq-delete-exchange]
 +
 . Click *Delete Exchange*.
 
+== Why I see the message decrypted in the UI for my encrypted queues?
+
+When you have the queue encrypted the messages are stored encrypted but they are desencrypted when they are read. It's automatic and transparent for the final user. There's no option to disable the automatic desencrytion. If you need to encrypt the message in a way that payload remain encrypted, It's required to manually encrypt the content.
+
 == See Also
 
 * link:/anypoint-mq/[Anypoint MQ]


### PR DESCRIPTION
a question received by a customer: Why I see the message decripted in my encrypted queues?

@george Please check the `desencrytion` word. Not sure what's the correct english form