### PR TITLE
updating Jersey client link

### DIFF
--- a/runtime-manager/v/latest/cloudhub-api.adoc
+++ b/runtime-manager/v/latest/cloudhub-api.adoc
@@ -53,7 +53,7 @@ All resources or methods that return or accept a type use the JSON as the data f
 
 == Getting Started and Authenticating with the API
 
-To use the API, you can use any HTTP client. All APIs use JSON as the data format. If you use Java, we recommend you use the link:http://wikis.sun.com/display/Jersey/Main[Jersey client] or link:http://hc.apache.org/httpclient-3.x/index.html[HttpClient] with link:https://github.com/codehaus/jackson[Jackson] for JSON support.
+To use the API, you can use any HTTP client. All APIs use JSON as the data format. If you use Java, we recommend you use the link:https://jersey.github.io/[Jersey client] or link:http://hc.apache.org/httpclient-3.x/index.html[HttpClient] with link:https://github.com/codehaus/jackson[Jackson] for JSON support.
 
 // commented out per Kane Sun 2.28.2017 kris All APIs require HTTP basic authentication.
 


### PR DESCRIPTION
Old Jersey client link is dead, long live the new Jersey client link.

Alternatively, instead of linking to the main page, we could link to the (more likely to change) download page: https://jersey.github.io/download.html