### PR TITLE
Update cloudhub-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/cloudhub-release-notes.adoc
+++ b/release-notes/v/latest/cloudhub-release-notes.adoc
@@ -6,12 +6,7 @@ In addition to these release notes, see the complete link:/runtime-manager/clou
 
 == 1.58.0 - July 15, 2017
 
-After rollout of three new regions in June, this release continues to strengthen capability and usability of CloudHub platform’s regional coverage:
-
-* You can self-serve select default regions for your organizations.
-* Persistent queues are available in the newly added regions (UK, Canada and Brazil).
-
-This release also includes reliability and scalability improvements, including built-in DNS failover, as response to the recent Amazon Web Services Route 53 outage incident this year.
+This release enables users to select default regions for their organizations, as well as a series of reliability and scalability enhancements.
 
 
 == 1.57.0 - June 17, 2017


### PR DESCRIPTION
Persistent queues and R53 did not go out