### PR TITLE
Update http-about-http-request.adoc

### DIFF
--- a/connectors/v/latest/http-about-http-request.adoc
+++ b/connectors/v/latest/http-about-http-request.adoc
@@ -1,33 +1,28 @@
-= About Making an HTTP Request
+= About Receiving HTTP Requests
 :keywords: connectors, http, https
 
-The HTTP connector executes HTTP methods using HTTP or HTTPS protocol. The request body is passed to the next element of the flow as the message payload. Headers, status code, and reason phrase are returned in the `Message` as `HttpResponseAttributes`. You access the attributes using DataWeave.
+The HTTP connector's listener receives requests via HTTP or HTTPS protocol. The request body is passed to the next element of the flow as the `Message` payload while the method, headers, query parameters and so on are returned in the attributes as `HttpRequestAttributes` which you can access the attributes using DataWeave.
 
-== About HTTP Responses to Requests
+== About HTTP Requests and their Responses
 
-The response to a request can include the following information:
-
-* Query parameters
-* Headers
-* URI parameters
-* Status code
-* Reason phrase
-
-A response received by the connector configured as a listener generates a Mule Event. You can refer to parts of the response. The following diagram maps an example response to a Mule Event.
+A request received by listener generates a Mule Event and you can refer to parts of it. The following diagram explains how each request part is mapped to a Mule Event and how to access each.
 
 image:request-mule-msg-map.png[Map of HTTP Response to Mule Event]
 
-You can format the output of a request as follows:
+You can read the request body mapped to the payload with DataWeave.
 
-* A stream
-* Multipart/form data
-* X-form-urlencoded
+The response to a request can include the following information:
 
-Multipart/form data accommodates a message that contains attachments. Each attachment is converted to part of the HTTP request body. X-form-urlencoded data accommodates a map payload, converting map keys and values to parameter keys and values in a form. The ANY default output type for metadata converts the payload to a byte array.
+* Status code
+* Reason phrase
+* Body
+* Headers
 
-== Secure Requests
+You can configure these both for the successful and failing execution of the listener's flow. The former defaults will feature the payload as body and a 200 status code, while the latter defaults will feature the error description as body and a 500 status code.
 
-You can use the default Transport Layer Security (TLS) configuration for HTTPS requests based on the JVM settings for TLS. The JVM usually includes a trust store with certificates for major certifying authorities. Alternatively, you can configure a KeyStore or trust store, or both. 
+== Securing Requests and Responses
+
+You can use Transport Layer Security (TLS) and configure HTTPS by providing a key store with your certificate. You can also enable 2 way authentication by providing a trust store as well. 
 
 
 == See Also


### PR DESCRIPTION
This doc was mixing up the request and listener functionality. I've edit it to consider only the listener (mainly because of the featured image). We'll need a similar doc for the request component.