### PR TITLE
Update http-about-http-connector.adoc

### DIFF
--- a/connectors/v/latest/http-about-http-connector.adoc
+++ b/connectors/v/latest/http-about-http-connector.adoc
@@ -5,18 +5,18 @@ Using the HTTP or HTTPS protocol, the HTTP connector performs one of the followi
 
 * Listener
 +
-Starts executing the Mule flow upon receiving a message from a source.
+Starts executing the Mule flow upon receiving an HTTP request.
 +
 * Request
 +
-Consumes a web service.
+Consumes an HTTP service.
 
 Mule preconfigures the first HTTP connector in an empty flow as a listener and trigger. When the app runs and the listener hears a request, the flow executes.
 
-By default, the listener configuration connects to CloudHub using HTTP and the request configuration connects to port 80 using HTTP and GET.  You can quickly configure an app to consume a web service using the two HTTP connector instances as follows:
+By default, the listener configuration connects to CloudHub using HTTP and the request configuration connects to port 80 using HTTP and GET.  You can quickly configure an app to consume an HTTP service using the two HTTP connector instances as follows:
 
 * Listener configuration: Path = */somepath*, for example
-* Request configuration: Path Or URL = the URL of the web service you want to consume
+* Request configuration: Path Or URL = the URL of the HTTP service you want to consume
 
 == See Also
 


### PR DESCRIPTION
The "consumes a web service" bit is weird since there's a connector named "Web Service Consumer". Changed to HTTP since it's more accurate.