### PR TITLE
Remove legacy ciphers

### DIFF
--- a/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
+++ b/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
@@ -155,15 +155,12 @@ DHE-RSA-AES256-SHA256
 DHE-RSA-AES128-SHA256
 DHE-RSA-AES256-SHA
 DHE-RSA-AES128-SHA
-ECDHE-RSA-DES-CBC3-SHA
-EDH-RSA-DES-CBC3-SHA
 AES256-GCM-SHA384
 AES128-GCM-SHA256
 AES256-SHA256
 AES128-SHA256
 AES256-SHA
 AES128-SHA
-DES-CBC3-SHA
 ----
 
 ClourHub's dedicated load balancer supports TLSv1.1 and TLSv1.2. Additionally, you can configure TLS v1.0, but bear in mind that such protocol is no longer accepted by PCi compliance due to its significant vulnerabilities.


### PR DESCRIPTION
Removed 3DES-based ciphers, corresponding to the 1.1.4 release.