### PR TITLE
Update documentation for OIDC

### DIFF
--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -1,4 +1,6 @@
-= To Configure OpenID Connect
+= To Configure OpenID Connect with Dynamic Client Registration
+
+Support for Okta and OpenAM Dynamic Client Registration has been verified with the Anypoint Platform.
 
 . Log into the master Organization in Anypoint Platform as Administrator.
 . In Anypoint Platform, click Access Management > External Identity.
@@ -6,23 +8,33 @@
 +
 The External Identity - Identity Management OpenID Connect form appears.
 +
-. Fill in the following required fields:
+. Fill in the following required fields after obtaining them from your identity provider’s configuration:
 +
-* Client Registration URL
+* *Client Registration URL*
+The URL to dynamically register Anypoint as a client application for your identity provider.
+** Okta: https://developer.okta.com/docs/api/resources/oauth-clients.html#register-new-client
+** OpenAM: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 +
-The Anypoint Platform URL where users must sign in.
+* *Authorize Header*
+This is an optional field under the Advanced Settings link. This header is required if the provider restricts registration requests to authorized clients.
+** Okta: This value will be `SSWS ${api_token}`, where `api_token` is created through this process: https://developer.okta.com/docs/api/getting_started/getting_a_token.html
+** OpenAM: This value will be `Bearer ${api_token}`, where `api_token` is created through this process: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 +
-* Authorize URL
+* *Authorize URL*
+The OpenID Connect URL where the user authenticates and grants Anypoint access to the user’s identity.
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#authentication-request
+** OpenAM: `/oauth2/authorize` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
 +
-The OpenID Connect URL where the user authenticates and grants the client app access to the user’s identity.
+* *Token URL*
+The URL that provides the user’s identity encoded in a secure JSON Web Token.
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#token-request
+** OpenAM: `/oauth2/access_token` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
 +
-* Token URL
+* **User Info URL**
+The URL that returns user profile information to Anypoint.
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#get-user-information
+** OpenAM: `/oauth2/userinfo` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
 +
-The URL that provides the user’s identity encoded in the secure JSON Web Token. 
-+
-* User Info URL
-+
-The URL that returns user profile information to the client app. Provided by the IdP. 
 . Save your configuration.
 +
-Sign out and navigate to the Authorize URL entered above, and sign in via your identity provider to test the configuration.
+. Sign out and navigate to your organization’s SSO URL, e.g. https://anypoint.mulesoft.com/accounts/login/{yourOrgDomain}, and sign in via your identity provider to test the configuration.

--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -18,48 +18,41 @@ The External Identity - Identity Management OpenID Connect form appears.
 +
 The URL to dynamically register Anypoint as a client application for your identity provider.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oauth-clients.html#register-new-client
+** Okta: `https://example.okta.com/oauth2/v1/clients` (link:https://developer.okta.com/docs/api/resources/oauth-clients.html#register-new-client[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/connect/register`
+** OpenAM: `https://example.com/openam/oauth2/connect/register` (link:https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic[Docs])
 +
-Docs: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 * *Authorize Header*
 +
-This is an optional field under the Advanced Settings link. This header is required if the provider restricts registration requests to authorized clients.
+The authorization header for dynamic client registration request. This is an optional field under the Advanced Settings link. This header is required if the provider restricts registration requests to authorized clients.
 +
-** Okta: This value will be `SSWS ${api_token}`, where `api_token` is created through this process: https://developer.okta.com/docs/api/getting_started/getting_a_token.html
+** Okta: This value will be `SSWS ${api_token}`, where `api_token` is an API token link:https://developer.okta.com/docs/api/getting_started/getting_a_token.html[created through Okta].
 +
-** OpenAM: This value will be `Bearer ${api_token}`, where `api_token` is created through this process: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
+** OpenAM: This value will be `Bearer ${api_token}`, where `api_token` is an API token link:https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic[created through OpenAM].
 +
 * *Authorize URL*
 +
-The OpenID Connect URL where the user authenticates and grants Anypoint access to the user’s identity.
+The URL where the user authenticates and grants OpenID Connect client applications access to the user's identity.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#authentication-request
+** Okta: `https://example.okta.com/oauth2/v1/authorize` (link:https://developer.okta.com/docs/api/resources/oidc.html#authentication-request[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/authorize`
-+
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
+** OpenAM: `https://example.com/openam/oauth2/authorize` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints[Docs])
 +
 * *Token URL*
 +
 The URL that provides the user’s identity encoded in a secure JSON Web Token.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#token-request
+** Okta: `https://example.okta.com/oauth2/v1/token` (link:https://developer.okta.com/docs/api/resources/oidc.html#token-request[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/access_token`
-+
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
+** OpenAM: `https://example.com/openam/oauth2/access_token` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints[Docs])
 +
 * **User Info URL**
 +
 The URL that returns user profile information to Anypoint.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#get-user-information
+** Okta: `https://example.okta.com/oauth2/v1/userinfo` (link:https://developer.okta.com/docs/api/resources/oidc.html#get-user-information[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/userinfo`
-+
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
+** OpenAM: `https://example.com/openam/oauth2/userinfo` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization[Docs])
 +
 . Save your configuration.
 +
@@ -93,43 +86,33 @@ The password, or secret, for authenticating your Anypoint Platform client applic
 +
 * *Authorize URL*
 +
-The OpenID Connect URL where the user authenticates and grants Anypoint access to the user’s identity.
+The URL where the user authenticates and grants OpenID Connect client applications access to the user's identity.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#authentication-request
+** Okta: `https://example.okta.com/oauth2/v1/authorize` (link:https://developer.okta.com/docs/api/resources/oidc.html#authentication-request[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/authorize`
+** OpenAM: `https://example.com/openam/oauth2/authorize` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints[Docs])
 +
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
-+
-** PingFederate: `https://example.com:9031/as/authorization.oauth2`
-+
-Docs: https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#concept_authorizationEndpoint.html#concept_authorizationEndpoint
+** PingFederate: `https://example.com:9031/as/authorization.oauth2` (link:https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#concept_authorizationEndpoint.html#concept_authorizationEndpoint[Docs])
 +
 * *Token URL*
 +
 The URL that provides the user’s identity encoded in a secure JSON Web Token.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#token-request
+** Okta: `https://example.okta.com/oauth2/v1/token` (link:https://developer.okta.com/docs/api/resources/oidc.html#token-request[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/access_token`
+** OpenAM: `https://example.com/openam/oauth2/access_token` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints[Docs])
 +
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
-+
-** PingFederate: `https://example.com:9031/as/token.oauth2`
-+
-Docs: https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#adminGuide/concept/tokenEndpoint.html
+** PingFederate: `https://example.com:9031/as/token.oauth2` (link:https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#adminGuide/concept/tokenEndpoint.html[Docs])
 +
 * **User Info URL**
 +
 The URL that returns user profile information to Anypoint.
 +
-** Okta: https://developer.okta.com/docs/api/resources/oidc.html#get-user-information
+** Okta: `https://example.okta.com/oauth2/v1/userinfo` (link:https://developer.okta.com/docs/api/resources/oidc.html#get-user-information[Docs])
 +
-** OpenAM: `https://example.com/openam/oauth2/userinfo`
+** OpenAM: `https://example.com/openam/oauth2/userinfo` (link:https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization[Docs])
 +
-Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
-+
-** PingFederate: `https://example.com:9031/idp/userinfo.openid`
+** PingFederate: `https://example.com:9031/idp/userinfo.openid` (link:https://developer.pingidentity.com/en/resources/openid-connect-developers-guide.html#userinfo_endpoint[Docs])
 +
 . Save your configuration.
 +

--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -1,4 +1,8 @@
-= To Configure OpenID Connect with Dynamic Client Registration
+= To Configure OpenID Connect
+
+If you've already configured your Anypoint Platform as a client application in your identity provider, then follow the steps in link:#manual-client-registration[Manual Registration]. Otherwise, if your identity provider supports it, follow the steps in link:#dynamic-client-registration[Dynamic Client Registration].
+
+== Dynamic Client Registration
 
 Support for Okta and OpenAM Dynamic Client Registration has been verified with the Anypoint Platform.
 
@@ -61,7 +65,7 @@ Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid
 +
 . Sign out and navigate to your organization’s SSO URL, e.g. https://anypoint.mulesoft.com/accounts/login/{yourOrgDomain}, and sign in via your identity provider to test the configuration.
 
-= To Configure OpenID Connect with a Manually Created Client
+== Manual Client Registration
 
 Support for clients manually created in Okta, OpenAM, and PingFederate has been verified with the Anypoint Platform.
 
@@ -72,11 +76,11 @@ Support for clients manually created in Okta, OpenAM, and PingFederate has been 
 The External Identity - Identity Management OpenID Connect form appears.
 +
 . Click on the `Use manual registration` link under the Client Registration URL field.
-. Before proceeding further, create a client application for the Anypoint Platform inside your Identity Provider.
+. **Before proceeding further, create a client application for the Anypoint Platform inside your Identity Provider.**
 ** Your Identity Provider will require a redirect URI for redirecting authenticated users. Use the automatically generated redirect URI above the Client ID field for this.
 ** Inside your Identity Provider, ensure that your client's supported scopes include `openid`, `profile`, and `email`.
 ** Inside your Identity Provider, ensure that your client uses the `authorization_code` grant type.
-** Save your Client ID and Client Secret values in a secure place. You will need them for the next fields inside the Identity Management OpenID Connect form.
+** Store your Client ID and Client Secret values in a secure place. You will need them for the next fields inside the Identity Management OpenID Connect form.
 . Fill in the following required fields after obtaining them from your identity provider’s configuration:
 +
 * *Client ID*

--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -60,3 +60,73 @@ Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid
 . Save your configuration.
 +
 . Sign out and navigate to your organization’s SSO URL, e.g. https://anypoint.mulesoft.com/accounts/login/{yourOrgDomain}, and sign in via your identity provider to test the configuration.
+
+= To Configure OpenID Connect with a Manually Created Client
+
+Support for clients manually created in Okta, OpenAM, and PingFederate has been verified with the Anypoint Platform.
+
+. Log into the master Organization in Anypoint Platform as Administrator.
+. In Anypoint Platform, click Access Management > External Identity.
+. From Identity Management, select OpenId Connect.
++
+The External Identity - Identity Management OpenID Connect form appears.
++
+. Click on the `Use manual registration` link under the Client Registration URL field.
+. Before proceeding further, create a client application for the Anypoint Platform inside your Identity Provider.
+** Your Identity Provider will require a redirect URI for redirecting authenticated users. Use the automatically generated redirect URI above the Client ID field for this.
+** Inside your Identity Provider, ensure that your client's supported scopes include `openid`, `profile`, and `email`.
+** Inside your Identity Provider, ensure that your client uses the `authorization_code` grant type.
+** Save your Client ID and Client Secret values in a secure place. You will need them for the next fields inside the Identity Management OpenID Connect form.
+. Fill in the following required fields after obtaining them from your identity provider’s configuration:
++
+* *Client ID*
++
+The unique identifier that you provided for your manually created client application.
++
+* *Client Secret*
++
+The password, or secret, for authenticating your Anypoint Platform client application with your Identity Provider.
++
+* *Authorize URL*
++
+The OpenID Connect URL where the user authenticates and grants Anypoint access to the user’s identity.
++
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#authentication-request
++
+** OpenAM: `https://example.com/openam/oauth2/authorize`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
++
+** PingFederate: `https://example.com:9031/as/authorization.oauth2`
++
+Docs: https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#concept_authorizationEndpoint.html#concept_authorizationEndpoint
++
+* *Token URL*
++
+The URL that provides the user’s identity encoded in a secure JSON Web Token.
++
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#token-request
++
+** OpenAM: `https://example.com/openam/oauth2/access_token`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
++
+** PingFederate: `https://example.com:9031/as/token.oauth2`
++
+Docs: https://documentation.pingidentity.com/pingfederate/pf84/index.shtml#adminGuide/concept/tokenEndpoint.html
++
+* **User Info URL**
++
+The URL that returns user profile information to Anypoint.
++
+** Okta: https://developer.okta.com/docs/api/resources/oidc.html#get-user-information
++
+** OpenAM: `https://example.com/openam/oauth2/userinfo`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
++
+** PingFederate: `https://example.com:9031/idp/userinfo.openid`
++
+. Save your configuration.
++
+. Sign out and navigate to your organization’s SSO URL, e.g. https://anypoint.mulesoft.com/accounts/login/{yourOrgDomain}, and sign in via your identity provider to test the configuration.

--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -8,7 +8,7 @@ Support for Okta and OpenAM Dynamic Client Registration has been verified with t
 
 . Log into the master Organization in Anypoint Platform as Administrator.
 . In Anypoint Platform, click Access Management > External Identity.
-. From Identity Management, select OpenId Connect.
+. From Identity Management, select OpenID Connect.
 +
 The External Identity - Identity Management OpenID Connect form appears.
 +
@@ -71,7 +71,7 @@ Support for clients manually created in Okta, OpenAM, and PingFederate has been 
 
 . Log into the master Organization in Anypoint Platform as Administrator.
 . In Anypoint Platform, click Access Management > External Identity.
-. From Identity Management, select OpenId Connect.
+. From Identity Management, select OpenID Connect.
 +
 The External Identity - Identity Management OpenID Connect form appears.
 +

--- a/access-management/v/latest/conf-openid-connect-task.adoc
+++ b/access-management/v/latest/conf-openid-connect-task.adoc
@@ -11,29 +11,51 @@ The External Identity - Identity Management OpenID Connect form appears.
 . Fill in the following required fields after obtaining them from your identity provider’s configuration:
 +
 * *Client Registration URL*
-The URL to dynamically register Anypoint as a client application for your identity provider.
-** Okta: https://developer.okta.com/docs/api/resources/oauth-clients.html#register-new-client
-** OpenAM: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 +
+The URL to dynamically register Anypoint as a client application for your identity provider.
++
+** Okta: https://developer.okta.com/docs/api/resources/oauth-clients.html#register-new-client
++
+** OpenAM: `https://example.com/openam/oauth2/connect/register`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 * *Authorize Header*
++
 This is an optional field under the Advanced Settings link. This header is required if the provider restricts registration requests to authorized clients.
++
 ** Okta: This value will be `SSWS ${api_token}`, where `api_token` is created through this process: https://developer.okta.com/docs/api/getting_started/getting_a_token.html
++
 ** OpenAM: This value will be `Bearer ${api_token}`, where `api_token` is created through this process: https://backstage.forgerock.com/docs/openam/13.5/admin-guide#register-openid-connect-client-dynamic
 +
 * *Authorize URL*
++
 The OpenID Connect URL where the user authenticates and grants Anypoint access to the user’s identity.
++
 ** Okta: https://developer.okta.com/docs/api/resources/oidc.html#authentication-request
-** OpenAM: `/oauth2/authorize` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
++
+** OpenAM: `https://example.com/openam/oauth2/authorize`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
 +
 * *Token URL*
++
 The URL that provides the user’s identity encoded in a secure JSON Web Token.
++
 ** Okta: https://developer.okta.com/docs/api/resources/oidc.html#token-request
-** OpenAM: `/oauth2/access_token` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
++
+** OpenAM: `https://example.com/openam/oauth2/access_token`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-oauth2-client-endpoints
 +
 * **User Info URL**
++
 The URL that returns user profile information to Anypoint.
++
 ** Okta: https://developer.okta.com/docs/api/resources/oidc.html#get-user-information
-** OpenAM: `/oauth2/userinfo` in https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
++
+** OpenAM: `https://example.com/openam/oauth2/userinfo`
++
+Docs: https://backstage.forgerock.com/docs/openam/13.5/dev-guide#rest-api-openid-connect-authorization
 +
 . Save your configuration.
 +


### PR DESCRIPTION
This PR updates the documentation for OpenID Connect for Identity Management.

@samjonester and I added example OIDC endpoints and links to verified providers' documentation.

We also added in steps to configure OIDC with a manually registered client application.