### PR TITLE
Remove masterfile redeployment mention

### DIFF
--- a/mule-user-guide/v/3.8/mule-application-deployment-descriptor.adoc
+++ b/mule-user-guide/v/3.8/mule-application-deployment-descriptor.adoc
@@ -14,8 +14,8 @@ Here's the list of supported configuration properties in the deployment descript
 |===
 |Name |Description |Default
 |domain |Domain name for this application. Typically used to share common libraries and configuration between applications. See link:/mule-user-guide/v/3.8/shared-resources[Shared Resources] |"default"
-|config.resources |A comma separated list of configuration file names for this application. Typical use is to support split configurations declaratively. An alternative is to have a default `mule-config.xml` file import extra configuration pieces. Note that the first config piece is considered to be a 'master' and is monitored for redeployment, but not others. |`mule-config.xml` from the app root is used if nothing else is specified
-|redeployment.enabled |Allows explicitly disabling application hot-redeployment - configuration 'master' file will not be monitored for changes. Dropping a new version of the application archive in the `$MULE_HOME/apps` will still redeploy the application. Any values other than `true, yes, on` are treated as `false` and disable the config change monitor. |Enabled by default
+|config.resources |A comma separated list of configuration file names for this application. Typical use is to support split configurations declaratively. An alternative is to have a default `mule-config.xml` file import extra configuration pieces. All configuration files are monitored for redeployment. |`mule-config.xml` from the app root is used if nothing else is specified
+|redeployment.enabled |Allows explicitly disabling application hot-redeployment. Dropping a new version of the application archive in the `$MULE_HOME/apps` will still redeploy the application. Any values other than `true, yes, on` are treated as `false` and disable the config change monitor. |Enabled by default
 |encoding |Default encoding, used throughout the application if none specified explicitly on, for example,. a transformer |UTF-8
 |config.builder |Configuration builder to use for parsing the application config file. |AutoConfigurationBuilder
 |scan.packages (since Mule 3.1) |The application's classpath is no longer scanned for iBeans annotations (`@Call`, `@Template` and `@IBeanGroup`). The regular Mule annotations (for example, `@Transformer` still work). To reactivate classpath scanning, configure a comma-separated list of package names to scan for annotations at startup. |Empty by default
@@ -61,6 +61,6 @@ Just as in Applications, you can add a `mule-deploy.properties` in the `src/main
 [%header,cols="34,33,33"]
 |===
 |Name |Description |Default
-|redeployment.enabled |Allows explicitly disabling domain hot-redeployment - configuration 'master' file will not be monitored for changes. Dropping a new version of the domain archive in the `$MULE_HOME/apps` will still redeploy the domain. Any values other than `true, yes, on` are treated as `false` and disable the config change monitor. |Enabled by default
+|redeployment.enabled |Allows explicitly disabling domain hot-redeployment. Dropping a new version of the domain archive in the `$MULE_HOME/apps` will still redeploy the domain. Any values other than `true, yes, on` are treated as `false` and disable the config change monitor. |Enabled by default
 |loader.override |Overrides default class loading. The property value is specified as a comma-separated list of classes, packages, or both. Blocking can also be specified by preceding the classes or packages in the list with a - (dash/minus sign). If a class is specified in the blocking list, its lookup is performed within the domain or plugin only, and not in Mule. For further details, see link:/mule-user-guide/v/3.8/classloader-control-in-mule[Classloader Control in Mule]. |Empty by default
 |===


### PR DESCRIPTION
All XML configuration files mentioned in the deployment descriptor are monitored for changes and will trigger a redeployment when the setting is set to true.
Not sure when this was introduced but I tested this and this is the current behaviour for 3.8