### PR TITLE
fixing typo "on-premise" to "on-premises"

### DIFF
--- a/anypoint-private-cloud/v/1.1.0/installing-anypoint-on-premises.adoc
+++ b/anypoint-private-cloud/v/1.1.0/installing-anypoint-on-premises.adoc
@@ -61,7 +61,7 @@ Follow the docker installation instructions that are appropriate for your system
 
 Depending on what you wish to install, download the following bundle of configuration files and scripts:
 
-* link:_attachments/anypoint-platform-1.1.1.zip[Anypoint Platform On Premise Edition]: For installing the entire functionality of the Anypoint Platform, including API administration tools.
+* link:_attachments/anypoint-platform-1.1.1.zip[Anypoint Platform On-Premises Edition]: For installing the entire functionality of the Anypoint Platform, including API administration tools.
 
 These .zip files contain all of the configuration and installation scripts needed to run Anypoint Platform.
 


### PR DESCRIPTION
A 'premise' is "an assumption that something is true", while 'premises' means "Premises are land and buildings together considered as a property." 

See [On-premises Software](https://en.wikipedia.org/wiki/On-premises_software) for more info.