### PR TITLE
fix broken syntax and refs

### DIFF
--- a/anypoint-b2b/v/latest/b2b-transaction-processing-framework.adoc
+++ b/anypoint-b2b/v/latest/b2b-transaction-processing-framework.adoc
@@ -232,7 +232,7 @@ xref:img-inbound-outbound[] depicts the relationships between these configuratio
 
 [[img-inbound-outbound]]
 image::inbound-outbound.png[img-inbound-outbound,title="B2B Directional Processing"]
-NOTE: In the interest of illustrating a range of usage scenarios, the architecture shown in xref:img-inbound-outbound depicts configuration details that may not appear in a specific scenario.
+NOTE: In the interest of illustrating a range of usage scenarios, the architecture shown in xref:img-inbound-outbound[] depicts configuration details that may not appear in a specific scenario.
 
 A common practice is to map each incoming document to a standard internal format, (often called the _canonical_ format). If the target system accepts this format, there is no need to apply a second map. That is, a map can be configured for the Source Channel to transform into the canonical format, and there is no map needed for the Target Channel. However, if there are multiple Target Channels for a given Source Channel, there may be a need to apply an additional map in one of the Target Channels; in that case two different maps would be applied.
 

--- a/anypoint-b2b/v/latest/certificate.adoc
+++ b/anypoint-b2b/v/latest/certificate.adoc
@@ -1,6 +1,6 @@
 = Certificate
 
-The <<img-as2-certificate>> enables you to upload an AS2 or RNIF certificate for the partner you selected on the <<partner-configuration.adoc#img-partner-configuration, Partner Configuration Page>>.
+The <<img-certificate>> enables you to upload an AS2 or RNIF certificate for the partner you selected on the <<partner-configuration.adoc#img-partner-configuration, Partner Configuration Page>>.
 
 include::/_sources/edit-settings.adoc[]
 

--- a/healthcare-toolkit/v/1.3/index.adoc
+++ b/healthcare-toolkit/v/1.3/index.adoc
@@ -17,7 +17,7 @@ The Mule Healthcare toolkit supports, and allows transformation between, the fol
 * HL7 XML: An XML representation of HL7 ER7 messages.
 * HAPI Message Objects: The native message format of the link:http://hl7api.sourceforge.net/[HAPI] (HL7 Application Programming Interface) message parser. HAPI is an open source object-oriented parser that works with HL7 XML (version 2.X) and ER7 formats.
 
-The Mule Healthcare toolkits allow you to send and receive HL7 message over MLLP (using the link:/healthcare-toolkit/v/1.3/hl7-global-connector[HL7 connector]) and other transport protocols (and corresponding connectors) supported by Mule, such as link:/mule-user-guide/v/3.5/http-connector[HTTP].
+The Mule Healthcare toolkits allow you to send and receive HL7 message over MLLP (using the link:/healthcare-toolkit/v/1.3/hl7-connector[HL7 connector]) and other transport protocols (and corresponding connectors) supported by Mule, such as link:/mule-user-guide/v/3.5/http-connector[HTTP].
 
 Other features:
 
@@ -34,7 +34,7 @@ The Mule Healthcare Toolkit includes the following elements.
 [%header%autowidth.spread]
 |===
 |Type |Tool |Input |Output |Use
-|Connector |link:/healthcare-toolkit/v/1.3/hl7-global-connector[HL7 Global Connector] |N/A |N/A |Use to configure a global connector which connectors in Mule can reference.
+|Connector |link:/healthcare-toolkit/v/1.3/hl7-connector[HL7 Global Connector] |N/A |N/A |Use to configure a global connector which connectors in Mule can reference.
 |Connector |link:/healthcare-toolkit/v/1.3/hl7-endpoint-reference[HL7 Endpoint Reference] |N/A |N/A |Use to receive or send HL7 messages over MLLP.
 .4+|Components |link:/healthcare-toolkit/v/1.3/hl7-message-component[HL7 Message Component] |N/A |HL7 ER7 |Use to generate an ER7-encoded HL7 message with user-defined parameters. Note that this component does not generate the HL7 _payload_ of a message, only the message structure. Use the Append Segment Component to add the payload.
 |link:/healthcare-toolkit/v/1.3/hl7-ack-component-reference[HL7 ACK Component Reference] |HL7 ER7 |HL7 ER7 |Use to return ACK (general acknowledge) message to confirm message receipt and validation, and NACK (negative general acknowledge) in case of message errors.

--- a/healthcare-toolkit/v/1.3/testing-with-hapi-testpanel.adoc
+++ b/healthcare-toolkit/v/1.3/testing-with-hapi-testpanel.adoc
@@ -74,7 +74,7 @@ To configure the HAPI TestPanel:
 
 . In the *Sending Connections* pane to the right of HAPI TestPanel's main window, click the displayed `localhost` connection (see the mouse cursor in the image below). The application displays the *Outgoing Message Sender* pane for configuring outgoing connections.
 +
-image:hapi-outconf.png[hapi-outconf]
+image:HAPIoutconf.png[hapi-outconf]
 +
 . At the *Outgoing Message Sender *pane, configure the following settings (highlighted above):
 ** *Host*: `localhost`
@@ -86,12 +86,12 @@ image:hapi-outconf.png[hapi-outconf]
 . Click  *Start*  near the top of the *Incoming Message Receiver* pane. HAPI TestPanel  starts listening for HL7 messages on the configured host and port.
 . Click the *Messages* pane to the right of the application window. The application displays a predefined sample HL7 message (see image below).
 +
-image:hapi-messages.png[hapi-messages]
+image:HAPImessages.png[hapi-messages]
 +
 . Click the *Send* button near the top of the pane. The application sends the sample message once to the specified host and port. Mule receives the HL7 message, then returns an ACK message to HAPI TestPanel.
 . Click the `localhost` connection in the *Receiving Connections* pane, then check the *Activity* log for the HL7 response from Mule. The image below displays the HL7 ACK messages sent by Mule.
 +
-image:hapi-incoming-ack.png[hapi-incoming-ack]
+image:HAPIincoming-ACK.png[hapi-incoming-ack]
 
 
 == See Also
@@ -104,7 +104,7 @@ Learn more about configuring the elements in the Toolkit:
 * link:/healthcare-toolkit/v/1.3/hl7-encoding-transformer[HL7 Encoding Transformer]
 * link:/healthcare-toolkit/v/1.3/hl7-endpoint-reference[HL7 Endpoint Reference]
 * link:/healthcare-toolkit/v/1.3/hl7-exception-strategy[HL7 Exception Strategy]
-* link:/healthcare-toolkit/v/1.3/hl7-global-connector[HL7 Global Connector]
+* link:/healthcare-toolkit/v/1.3/hl7-connector[HL7 Global Connector]
 * link:/healthcare-toolkit/v/1.3/hl7-message-component[HL7 Message Component]
 * link:/healthcare-toolkit/v/1.3/hl7-message-validation[HL7 Message Validation]
 * link:/healthcare-toolkit/v/1.3/hl7-mule-expression-language-support[HL7 Mule Expression Language Support]

--- a/healthcare-toolkit/v/2.0/index.adoc
+++ b/healthcare-toolkit/v/2.0/index.adoc
@@ -20,7 +20,7 @@ The Mule Healthcare toolkit supports, and allows transformation between, the fol
 * HL7 XML: An XML representation of HL7 ER7 messages
 * HAPI Message Objects: The native message format of the link:http://hl7api.sourceforge.net/[HAPI] (HL7 Application Programming Interface) message parser. HAPI is an open source object-oriented parser that works with HL7 XML (version 2.X) and ER7 formats.
 
-The Mule Healthcare toolkit allows you to send and receive HL7 messages over MLLP (using the link:/mule-healthcare-toolkit/v/2.0/hl7-endpoint-reference[HL7 connector]) and other transport protocols (and corresponding connectors) supported by Mule, such as link:/mule-user-guide/v/3.8/http-connector[HTTP].
+The Mule Healthcare toolkit allows you to send and receive HL7 messages over MLLP (using the link:/healthcare-toolkit/v/2.0/hl7-endpoint-reference[HL7 connector]) and other transport protocols (and corresponding connectors) supported by Mule, such as link:/mule-user-guide/v/3.8/http-connector[HTTP].
 
 Other features:
 

--- a/mule-user-guide/v/3.2/mule-studio.adoc
+++ b/mule-user-guide/v/3.2/mule-studio.adoc
@@ -1,6 +1,6 @@
 = Mule Studio User Guide
 
-Learn about link:link:/anypoint-studio/v/5/[Studio] at your own pace, in your own way, by exploring our tutorials and reference material.
+Learn about link:/anypoint-studio/v/5/[Studio] at your own pace, in your own way, by exploring our tutorials and reference material.
 
 === Studio Essentials
 

--- a/mule-user-guide/v/3.6/batch-processing.adoc
+++ b/mule-user-guide/v/3.6/batch-processing.adoc
@@ -67,7 +67,6 @@ Each batch step in a batch job contains message processors which act upon a reco
 == Unsuitable Message Processors
 
 The only element you cannot use in batch processing is a request-response inbound connector. Otherwise, you are free to leverage any and all Mule message processors to build your batch processing flow.
-====
 
 [source, xml, linenums]
 ----

--- a/release-notes/v/latest/ldap-connector-release-notes.adoc
+++ b/release-notes/v/latest/ldap-connector-release-notes.adoc
@@ -1,4 +1,4 @@
-≈= LDAP Connector Release Notes
+= LDAP Connector Release Notes
 :keywords: release notes, ldap, active directory, connector
 
 Lightweight Directory Access Protocol (LDAP) is an Internet protocol used to access information from a server. The LDAP connector allows Mule applications to interact with LDAP servers.


### PR DESCRIPTION
- fix broken header in ldap-connector-release-notes.adoc
- fix broken links and image references in healthcare toolkit
- fix unclosed xref in b2b-transaction-processing-framework.adoc