### PR TITLE
Fixed the POM in the runtime agent extension tutorial

### DIFF
--- a/runtime-manager/v/latest/extending-the-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/extending-the-runtime-manager-agent.adoc
@@ -26,19 +26,30 @@ A Runtime Manager Agent custom component should comply with the following struct
 * `/lib` contains component dependencies
 * `/classes` contain compiled classes
 
+A custom component should also be compiled with Java 1.7, components compiled with higher versions will not be loaded by the agent.
+
 For this example, in order to acquire the libraries necessary to extend the agent, add the following dependencies to your `pom.xml`:
 
 [source,xml, linenums]
 ----
+<properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <mule.agent.version>1.6.4-mule-3.x</mule.agent.version>
+    <jersey.core.version>2.11</jersey.core.version>
+</properties>
+
 <dependencies>
         <dependency>
             <groupId>com.mulesoft.agent</groupId>
             <artifactId>mule-agent-api</artifactId>
+            <version>${mule.agent.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
+            <version>${jersey.core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -47,6 +58,35 @@ For this example, in order to acquire the libraries necessary to extend the agen
             <scope>provided</scope>
         </dependency>
 </dependencies>
+
+<repositories>
+    <repository>
+        <id>mulesoft-ci-releases</id>
+        <name>ci releases</name>
+        <url>https://repository-master.mulesoft.org/nexus/content/repositories/ci-releases</url>
+    </repository>
+</repositories>
+
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
 ----
 
 The corresponding jar should be added under the `lib` folder within the mule-agent plugin, which is contained in the `plugins` folder of the Mule instance. For example, `$MULE_HOME/plugins/mule-agent/lib/<component name>.jar`.


### PR DESCRIPTION
Added a POM that will allow someone to extend the runtime agent correctly. Also added a call out that java 1.7 must be used to compile the extension or it will not be loaded