### PR TITLE
say "flow elements", not "building blocks"

### DIFF
--- a/mule-user-guide/v/3.8/elements-in-a-mule-flow.adoc
+++ b/mule-user-guide/v/3.8/elements-in-a-mule-flow.adoc
@@ -3,11 +3,11 @@
 
 Building upon the information presented in link:/mule-user-guide/v/3.8/mule-concepts[Key Concepts], this section offers more detailed descriptions of the different types of elements in a flow. Find out which elements are message sources and which are message processors, and what they do within a Mule flow.
 
-The following are the categories of building blocks you can use. You can access them from the Anypoint Studio palette.
+The following are the categories of the flow elements you can use. You can access these categories from the Anypoint Studio palette.
 
 image:palette-categories.png[palette-categories]
 
-These block categories allow you to do almost anything: connect to SaaS services, transform data, connect to various protocols, filter data, and much more. Each building block has an icon in the Anypoint Studio Palette that you can drag from the palette to your flows on the canvas, and then configure the attributes of that particular instance.
+These categories allow you to do almost anything: connect to SaaS services, transform data, connect to various protocols, filter data, and much more. Each flow element has an icon in the Anypoint Studio Palette that you can drag from the palette to your flows on the canvas, and then configure the attributes of that particular instance.
 
 image:palette.png[palette]
 


### PR DESCRIPTION
Seems like we are moving away from "building block" to just say "flow elements" to include message processors and message sources together.