### PR TITLE
Update to-manage-data-types.adoc

### DIFF
--- a/design-center/v/1.0/to-manage-data-types.adoc
+++ b/design-center/v/1.0/to-manage-data-types.adoc
@@ -4,15 +4,14 @@
 
 The _type_ of your data refers to its *metadata*, this is the representation of the structure of data, regardless of its format.
 
-For example, the metadata of a message may define that the 'user' element has two child elements: 'name' and 'address'; it doesn't matter if the message is in JSON or XML format, the structure is beyond that.
+For example, the metadata of a message may define that the 'user' element has two child elements: 'name' and 'address'; it doesn't matter if the message is in JSON or XML format. The metadata does not adhere to any particular format.
 
-When this information is available to another card, it is interpreted as the expected input or output, depending on where each are placed relative to each other on the flow.
+When the metadata information is available to another component, it is interpreted as the expected input or output, depending on where each are placed relative to each other in a flow.
 
-Almost all cards include an *Input* and *Output* tab. These let you describe the types of the data that both enters and leaves the component, with specifics about each part of the Mule Event: the payload, its properties and variables. If the component has handled any real data, you can also view it here.
+Almost all components include an *Input* and *Output* tab. These tabs let you describe the types of data that enter and leave the component. The data includes specifics about the Mule Event: the payload, its properties and variables. If the component has processed any real data, it will be shown here.
 
 [TIP]
-Many elements you can use in your projects expose the types of their input and output data to the rest of the flow. In such cases, there's no need to provide this information manually. For example, when a connector is configured to carry out a specific operation, its output structure is known to Design Center.
-
+Many elements you use in your projects expose their metadata automatically. There's no need to provide this information manually. For example, when a connector is configured to carry out a specific operation, the output structure is already registered in flow designer.
 
 
 == Assign Existing Data Types
@@ -46,7 +45,7 @@ Some formats only allow you to provide a schema. To provide a Schema for a CSV o
 +
 image:handling-metadata-in-flow-designer-8e17e.png[]
 
-. When you've filled in every field and are happy with your new data type, click *Save*. Once defined, the type can be assigned anywhere in your project.
+. Click *Save*. The data type can be referenced anywhere in your project.
 
 
 
@@ -57,7 +56,7 @@ image:handling-metadata-in-flow-designer-8e17e.png[]
 As a shortcut, instead of manually defining a data type, you can automatically create it from live data that passes through your flow when triggered.
 
 
-. Create a basic flow that's capable of receiving or producing the data you need. For example, if the data arrives in an HTTP request, an HTTP listener is enough; if the data is in a database, you could use a Scheduler component as a trigger and then a database connector.
+. Create a basic flow that's capable of receiving or producing the data you need. For example, if the data arrives in a HTTP Request, a HTTP Listener is enough; if the data is in a database, you could use a Scheduler component as a trigger and then a database connector.
 . Configure all the required fields in these components.
 . Click Deploy in the top nav bar to run your project in a design environment.
 . If your flow starts with an HTTP connector, hit its URL to trigger it; if it starts with a Scheduler, wait for it to be triggered.
@@ -83,22 +82,22 @@ image:to-manage-data-types-f40c8.png[]
 
 == Set Data Types for the Transform Card
 
-To use the drag and drop UI of the link:/design-center/v/1.0/transform-message-component-concept-design-center[Transform Card], your flow must have metadata for both the Input and the Output of this component, that way it knows what's available and where it can be mapped to.
+To use the drag and drop UI of the link:/design-center/v/1.0/transform-message-component-concept-design-center[Transform Card], your flow must have metadata for both the Input and the Output of this component.
 
 There are several ways you can provide this required metadata:
 
-* Make sure that other elements in the flow are fully configured. For example, a connector can't expose its output structure until a given operation is chosen, as its output might differ depending on this.
-* You can manually assign a data type to the previous component in the flow via its Input and Output tabs. This information is propagated forward and transformed as it transitions through other components.
+* Make sure that other elements in the flow are fully configured. For example, a connector can't expose its output structure until a given operation is chosen, as its output might differ depending on the operation.
+* You can manually assign a data type to the previous component in the flow via its Input and Output tabs. This data is propagated forward and transformed as it transitions through other components.
 * You can manually define the input and output of the Transform component. For this you can either:
 ** Click the Set Data Type icon image:to-manage-data-types-69ae0.png[] below either the input pane or the output pane.
-** On the input pane, expand the element you want to define and click its Set data type link.
-** On the output pane, open the dropdown menu next to the Output label, and select Set Data Type.
+** Expand the element you want to define and click its Set data type link in the input pane.
+** Open the dropdown menu next to the Output label, and select Set Data Type in the output pane.
 
 
 
 
 
-Note that for the input, you can Set Data Types for all parts of the Mule event. For the output, on the other hand (as the transformation has one single output) you can only set one part. By default, this is the payload. If you want to output to a different part of the mule event:
+Note that for the input pane, you can Set Data Types for the main payload and attributes variable of the Mule event. For the output, you can only the main payload. If you want to output to a different part of the Mule event:
 
 * Click the dropdown menu next to the Output label
 * Select Add Transformation.
@@ -106,17 +105,19 @@ Note that for the input, you can Set Data Types for all parts of the Mule event.
 
 image:to-manage-data-types-25472.png[]
 
-
+////
 == Add an API Definition File
 
-The HTTP Request Connector doesn't expose any information by default, but you can provide the connector a link:https://raml.org/[RAML] API definition file, which includes information about required inputs and expected outputs.
+The HTTP Request Connector does not expose any information by default, but you can provide the connector a link:https://raml.org/[RAML] API definition file, which includes information about required inputs and expected outputs.
 
 [NOTE]
 Note that this feature is only available with HTTP Request Connectors, not with HTTP Listener Connectors (the kind that can serve as triggers to a flow) nor any other type of connector.
 
+
 To do so:
 
-. Add a new HTTP Request Connector and configure it.
+. Add a new HTTP Request Connector.
+. At the top nav bar, click the Set up link.
 +
 image:to-define-data-types-675b0.png[]
 
@@ -129,7 +130,7 @@ image:to-define-data-types-24906.png[]
 +
 [NOTE]
 Currently, you can only reference API definition files that are hosted on the web. Future releases will allow you to upload your own file.
-
+////
 
 
 ////

--- a/design-center/v/1.0/to-manage-data-types.adoc
+++ b/design-center/v/1.0/to-manage-data-types.adoc
@@ -97,11 +97,11 @@ There are several ways you can provide this required metadata:
 
 
 
-Note that for the input pane, you can Set Data Types for the main payload and attributes variable of the Mule event. For the output, you can only the main payload. If you want to output to a different part of the Mule event:
+Note that for the input pane, you can Set Data Types for the main payload, attributes, and variables of the Mule event. For the output, you can only set the main payload in the default view. If you want to output to a different part of the Mule event:
 
 * Click the dropdown menu next to the Output label
 * Select Add Transformation.
-* Pick an attribute or variable to output to.
+* Pick attribute or variable to output to.
 
 image:to-manage-data-types-25472.png[]
 


### PR DESCRIPTION
Edited the document. Currently, there is no API specification option in the HTTP Request configuration dialog. Commented out that section.