### PR TITLE
Update dataweave-selectors.adoc

### DIFF
--- a/mule-user-guide/v/4.0/dataweave-selectors.adoc
+++ b/mule-user-guide/v/4.0/dataweave-selectors.adoc
@@ -10,20 +10,21 @@ A selector always operates within a given context, which can be a reference to a
 |Selector Type |Syntax |Return Type
 
 |Single Value selector | .<key-name> |Value of a key:value pair
-|Multi Value selector | .*<key-name> |Array with values of a key:value pairs
-|Descendants Selector | ..<key-name> | Array with values of a key:value pairs
-|Key-Value Pair selector|.$<key-name>| Object with key:value pairs
+|Multi Value selector | .*<key-name> |Array with values of key:value pairs
+|Descendants Selector | ..<key-name> | Array with values of key:value pairs
+|Key-Value Pair selector|.&<key-name>| Object with key:value pairs
 |Indexed Selector|[<index>]|Value at selected array index
 |Range Selector|[<index> to <index>]| Array with values from selected indexes
 |XML Attribute Selector|.@<key-name>|Value for selected attribute
 |All XML Attributes|.@|Object with attributes as key:value pairs
+|Namespace Selector|.#|String of the namespace used at the current key|
 |===
 
 
 Applying the *Single level Explicit Selector*, the *Descendants Selector*, or the *Indexed Selector* returns the value of the key:value pair that matches the expression.
 
 [NOTE]
-Each of these selector expressions supports having a '?' appended at the end of the chain. This changes the expression into a query that checks upon the existence of the key. The return type in this case is a boolean true or false.
+Each of these selector expressions supports having a '?' appended at the end of the chain. This changes the expression into a query that checks upon the existence of the key. The return type in this case is Boolean with the values true or false.
 
 
 == Single Value selector
@@ -141,7 +142,7 @@ payload.people.person.address.street
   ]
 }
 ----
-<1> As 'people' is an array, this sets the context for searching across both 'person' instances. The result from this is always an array.
+<1> As 'people' is an array, this sets the context for searching across both 'person' elements. The result from this selection is always an array.
 
 .Output
 [source, json,linenums]
@@ -158,7 +159,7 @@ payload.people.person.address.street
 ]
 ----
 
-<1> As the context is an array, the output is always an array. An array is returned even if there's a single matching value.
+<1> The output is always an array. An array is returned even if there's a single matching value.
 
 
 
@@ -270,9 +271,10 @@ output application/json
 
 
 
+== Key-Value Pair Selector
 
 
-=== Selecting all the Descendant Key Value Pairs
+This selector retrieves both the keys and the values of all matching keys pairs in the current context. These are returned as an object, containing these retrieved keys and values.
 
 
 
@@ -283,12 +285,105 @@ output application/json
 output application/xml
 ---
 {
-  names: payload.people..name as Object<1>
+  users: payload.users.&user
 }
 ----
-<1> The *as Object* makes the expression return an object rather than an array (which would be returned by default). This implies that each value has a key. Without this conversion, in XML the returned array would be a single long string of characters comprised of all three names merged into one.
 
 
+.Input
+[source, xml, linenums]
+----
+<?xml version='1.0' encoding='US-ASCII'?>
+<users>
+  <user>Mariano</user>
+  <user>Martin</user>
+  <user>Leandro</user>
+  <admin>Admin</admin>
+  <admin>org_owner</admin>
+</users>
+----
+
+.Output
+[source, xml, linenums]
+----
+<?xml version='1.0' encoding='US-ASCII'?>
+<users>
+  <user>Mariano</user>
+  <user>Martin</user>
+  <user>Leandro</user>
+</users>
+----
+
+Note that unlike the multi-value selector, the output of this selector is an object, where the original keys for each value are also extracted.
+
+=== Selecting all the Descendant Key Value Pairs
+
+
+.Transform
+[source,DataWeave, linenums]
+----
+%dw 2.0
+output application/json
+---
+{
+  names: payload.people..&name
+}
+----
+
+.Input
+[source, json,linenums]
+----
+{
+  "people": {
+    "person": {
+      "name": "Nial",
+      "address": {
+        "street": {
+          "name": "Italia",
+          "number": 2164
+        },
+        "area": {
+          "zone": "San Isidro",
+          "name": "Martinez"
+        }
+      }
+    }
+  }
+}
+----
+
+.Output
+----
+{
+  names: [
+    {
+      name: "Nial"
+    },
+    {
+      name: "Italia"
+    },
+    {
+      name: "Martinez"
+    }
+  ]
+}
+----
+
+==== Converting the array of objects into an object of objects
+
+.Transform
+[source,DataWeave, linenums]
+----
+%dw 2.0
+output application/xml
+---
+{
+  names: (payload.people..&name) reduce (value, aggregator) -> aggregator ++ value
+  //Alternative methods
+  //names: payload.people..&name reduce ($$ ++ $)
+  //names: {(payload.people..&name)}
+}
+----
 
 .Input
 [source, json,linenums]
@@ -324,57 +419,9 @@ output application/xml
 ----
 
 
-== Key-Value Pair Selector
-
-
-This selector retrieves both the keys and the values of all matching keys pairs in the current context. These are returned as an object, containing these retrieved keys and values.
-
-
-
-.Transform
-[source,DataWeave, linenums]
-----
-%dw 2.0
-output application/xml
----
-{
-  users: payload.users.&user
-}
-----
-
-
-
-.Input
-[source, xml, linenums]
-----
-<?xml version='1.0' encoding='US-ASCII'?>
-<users>
-  <user>Mariano</user>
-  <user>Martin</user>
-  <user>Leandro</user>
-  <admin>Admin</admin>
-  <admin>org_owner</admin>
-</users>
-----
-
-.Output
-[source, xml, linenums]
-----
-<?xml version='1.0' encoding='US-ASCII'?>
-<users>
-  <user>Mariano</user>
-  <user>Martin</user>
-  <user>Leandro</user>
-</users>
-----
-
-Note that unlike the multi-value selector, the output of this selector is an object, where the original keys for each value are also extracted.
-
-
-
 == Indexed Selector
 
-The index selector returns the element at the specified position, it can be applied over an `:array`, an  `:object` or a `:string`
+The index selector returns the element at the specified position, it can be applied over an `:array`, an `:object` or a `:string`
 
 === Over :array
 
@@ -393,19 +440,18 @@ payload.people[1]
 ----
 
 
-
 .Input
 [source, json,linenums]
 ----
 {
   "people": [
         {
-          "name": "Nial",
-          "address": "Martinez"
+          "nameFirst": "Nial",
+          "nameLast": "Martinez"
         },
         {
-          "name": "Coty",
-          "address": "Belgrano"
+          "nameFirst": "Coty",
+          "nameLast": "Belgrano"
         }
     ]
 }
@@ -415,8 +461,8 @@ payload.people[1]
 [source, json,linenums]
 ----
 {
-  "name": "Coty",
-  "address": "Belgrano"
+  "nameFirst": "Coty",
+  "nameLast": "Belgrano"
 }
 ----
 
@@ -468,9 +514,34 @@ output application/json
 }
 --------------------------------------------------------
 
-== Over :object
+=== Over :object
 
-The selector returns the value of the key : value pair at the specified position.
+The selector returns the value of the key:value pair at the specified position.
+
+.Transform
+[source,DataWeave, linenums]
+----
+%dw 2.0
+output application/json
+---
+payload[1]
+----
+
+.Input
+[source, json,linenums]
+----
+{
+  "nameFirst": "Mark",
+  "nameLast": "Nguyen"
+}
+----
+
+.Output
+[source, json,linenums]
+----
+"Nguyen"
+----
+
 
 == Range selector
 
@@ -535,7 +606,7 @@ output application/json
 
 == XML Attribute Selector
 
-In order to query for the attributes on an XML element, the syntax *.@<key-name>* is used. If you just use *.@* (without <key-name>) it returns an object containing each key:value pair in it.
+In order to query for the attributes on an XML element, the syntax *.@<key-name>* is used. If you just use *.@* (without <key-name>) it returns an object containing all attributes as key:value pairs.
 
 
 .Transform
@@ -568,12 +639,12 @@ output application/json
 [source, json,linenums]
 ----
 {
-  "item:" {
+  "item": {
     "type": "tv",
     "name": "Samsung",
-    "attributes": { # <1>
+    "attributes": { <1>
       "id": 1,
-      "type": tv
+      "type": "tv"
     }
   }
 }
@@ -637,8 +708,8 @@ user: payload.name as Object <1>
 [source, json,linenums]
 ----
 {
-  "name": "Mariano",
-  "lastName" : "Doe"
+  "nameFirst": "Mariano",
+  "nameLast" : "Doe"
 }
 ----
 
@@ -647,14 +718,40 @@ user: payload.name as Object <1>
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <user>
-  <name>Mariano</name>
+  <nameFirst>Mariano</nameFirst>
 </user>
 ----
 
 
+== Namespace Selector
 
+The Namespace selector returns the namespace of the current key that it is queried against.
 
+.Transform
+[source,DataWeave, linenums]
+----
+%dw 2.0
+output application/json
+---
+payload.order.#
+----
 
+.Input
+[source, xml,linenums]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<ns0:order xmlns:ns0=http://orders.company.com>
+  <name>Mark</name>
+  <items>42</items>
+  <orderdate>2017-01-04</orderdate>
+</ns0:order>
+----
+
+.Output
+[source,json,linenums]
+----
+"http://orders.company.com"
+----
 
 
 == Selectors modifiers

--- a/mule-user-guide/v/4.0/dataweave-selectors.adoc
+++ b/mule-user-guide/v/4.0/dataweave-selectors.adoc
@@ -29,9 +29,9 @@ Each of these selector expressions supports having a '?' appended at the end of 
 
 == Single Value selector
 
-Value selectors may be applied over an `:object` or an `:array`.
+Value selectors may be applied over an `Object` or an `Array`.
 
-=== Over :object
+=== Over Object
 
 This selector returns the first value whose key matches the expression, that is, *payload.name*, which returns the value whose key matches *name*.
 
@@ -89,9 +89,9 @@ output application/xml
 
 
 
-=== Over :array
+=== Over Array
 
-This selector is applied on each of the elements of the array that are of type `:object` and returns an array with all the selected values
+This selector is applied on each of the elements of the array that are of type `Object` and returns an array with all the selected values
 
 .Transform
 [source,DataWeave, linenums]
@@ -167,9 +167,9 @@ payload.people.person.address.street
 
 == Multi Value selector
 
-Multi value selector can either be applied over an `:object` or an `:array`.
+Multi value selector can either be applied over an `Object` or an `Array`.
 
-=== Over :object
+=== Over Object
 
 This selector returns an array with all the values whose key matches the expression.
 
@@ -210,9 +210,9 @@ output application/json
 
 
 
-=== Over :array
+=== Over Array
 
-The selector is applied on each of the elements of the array that are of type `:object` and returns an array with all the selected values.
+The selector is applied on each of the elements of the array that are of type `Object` and returns an array with all the selected values.
 
 
 == Descendants Selector
@@ -421,9 +421,9 @@ output application/xml
 
 == Indexed Selector
 
-The index selector returns the element at the specified position, it can be applied over an `:array`, an `:object` or a `:string`
+The index selector returns the element at the specified position, it can be applied over an `Array`, an `Object` or a `String`
 
-=== Over :array
+=== Over Array
 
 This selector can be applied to String literals, Arrays and Objects. In the case of Objects, the value of the key:value pair found at the index is returned. The index is zero based.
 
@@ -488,7 +488,7 @@ output application/json
 }
 --------------------------------------------------------
 
-=== Over :string
+=== Over String
 
 The selector picks the character at a given position, treating the string as an array of characters.
 
@@ -514,7 +514,7 @@ output application/json
 }
 --------------------------------------------------------
 
-=== Over :object
+=== Over Object
 
 The selector returns the value of the key:value pair at the specified position.
 
@@ -545,7 +545,7 @@ payload[1]
 
 == Range selector
 
-=== Over :array
+=== Over Array
 
 Range selectors limit the output to only the elements specified by the range on that specific order. This selector allows you to slice an array or even invert it.
 
@@ -577,7 +577,7 @@ output application/json
 }
 ----
 
-=== Over :string
+=== Over String
 
 The Range selector limits the output to only the elements specified by the range on that specific order, treating the string as an array of characters. This selector allows you to slice a string or even invert it.
 


### PR DESCRIPTION
1.  Added Namespace selector section
2. Fixed Descendant Key-Value section. Original code does not work.
3. Expanded `over :object` section underneath `indexed selector` section

Propose we refer all datatypes using DW 2.0 syntax:

* Array instead of :array
* Object instead of :object
* String instead of :string
* etc...