### PR TITLE
define generated APIKit flows as skeletons

### DIFF
--- a/apikit/v/latest/index.adoc
+++ b/apikit/v/latest/index.adoc
@@ -1,7 +1,12 @@
 = APIkit Introduction
 :keywords: api, apikit, raml
+ 
 
-APIkit and APIkit for SOAP are toolkits that facilitate REST or SOAP API development: handling error conditions and setting status codes, and generating flows for RESTful calls or SOAP API requests. For RAML-based API simulation, APIkit also sets up the APIkit Console simulator. You develop APIs based on one of the following modeling languages:
+APIkit and APIkit for SOAP are toolkits that facilitate REST or SOAP API development: handling error conditions and setting status codes, and generating flows in a Mule project for RESTful calls or SOAP API requests. 
+
+The APIKit converts standard web service specification documents into these new flows in the Mule project. These auto-generated flows are called *skeleton* flows, because they are the bare minimum implementation to meet the communication operations required by the web service contract. 
+
+For RAML-based API simulation, APIkit also sets up the APIkit Console simulator. You develop APIs based on one of the following modeling languages:
 
 * RESTful API Modeling Language 
 * Web Service Description Language

--- a/apikit/v/latest/index.adoc
+++ b/apikit/v/latest/index.adoc
@@ -4,7 +4,7 @@
 
 APIkit and APIkit for SOAP are toolkits that facilitate REST or SOAP API development: handling error conditions and setting status codes, and generating flows in a Mule project for RESTful calls or SOAP API requests. 
 
-The APIKit converts standard web service specification documents into these new flows in the Mule project. These auto-generated flows are called *skeleton* flows, because they are the bare minimum implementation to meet the communication operations required by the web service contract. 
+APIKit converts standard web service specification documents into these new flows in the Mule project. These auto-generated flows are called _skeleton_ flows because they are the bare minimum implementation to meet the communication operations required by the web service contract. 
 
 For RAML-based API simulation, APIkit also sets up the APIkit Console simulator. You develop APIs based on one of the following modeling languages:
 


### PR DESCRIPTION
The term skeleton is the term usually used for these types of auto-generated implementations from a web service definition spec.