### PR TITLE
Update plugin version to 2.2.1

### DIFF
--- a/mule-user-guide/v/3.8/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.8/mule-maven-plugin.adoc
@@ -23,7 +23,7 @@ As an alternative to using the Maven Plugin for deploying applications to the Ru
 This document assumes that you are familiar with Maven, managing pom.xml files, and working with Maven plugins. (If you are just getting started with Maven, we suggest you follow Maven’s link:http://maven.apache.org/guides/getting-started/[Getting Started tutorial].) Additionally, this document assumes familiarity with developing Mule applications within Maven. For more information about Mule and Maven, see link:/mule-user-guide/v/3.8/using-maven-with-mule[Using Maven with Mule].
 
 [NOTE]
-We recommend that you update this plugin to its latest version, as its usability is greatly improved as of version 2.1.1
+We recommend that you update this plugin to its latest version, as its usability is greatly improved as of version 2.2.1
 
 == Adding the Plugin
 
@@ -36,7 +36,7 @@ Edit your `settings.xml` or project file to include the following:
 <plugin>
   <groupId>org.mule.tools.maven</groupId>
   <artifactId>mule-maven-plugin</artifactId>
-  <version>2.1.1</version>
+  <version>2.2.1</version>
 </plugin>
 ----
 
@@ -54,7 +54,7 @@ The repository for the plugin is at https://repository.mulesoft.org/nexus/conten
 </pluginRepositories>
 ----
 
-You can also find the plugin .jar and POM files manually at the link:https://repository.mulesoft.org/nexus/content/repositories/releases/org/mule/tools/mule-maven-plugin/2.0-RC1[online repository] for the plugin, or get if from the Maven Central Repository.
+You can also find the plugin .jar and POM files manually at the link:https://repository.mulesoft.org/nexus/content/repositories/releases/org/mule/tools/mule-maven-plugin/2.2.1[online repository] for the plugin, or get if from the Maven Central Repository.
 
 == A Simple Example
 
@@ -70,10 +70,10 @@ NOTE: For the following example to work, your `settings.xml` or `pom.xml` must i
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.0</version>
+    <version>2.2.1</version>
     <configuration>
         <deploymentType>standalone</deploymentType>
-        <muleVersion>3.8.0</muleVersion>
+        <muleVersion>3.8.5</muleVersion>
     </configuration>
     <executions>
         <execution>
@@ -111,7 +111,7 @@ TIP: For a list and description of the parameters used in the examples, see <<Fu
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
         <deploymentType>arm</deploymentType>
         <username>myUsername</username>
@@ -144,11 +144,11 @@ To deploy your application to CloudHub:
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
         <deploymentType>cloudhub</deploymentType>
          <!-- muleVersion is the runtime version as it appears on the CloudHub interface -->
-        <muleVersion>3.7.0</muleVersion>
+        <muleVersion>3.8.5</muleVersion>
         <username>myUsername</username>
         <password>myPassword</password>
         <redeploy>true</redeploy>
@@ -209,7 +209,7 @@ Instead of downloading and installing a new Mule server, you can configure the p
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
         <deploymentType>standalone</deploymentType>
         <muleHome>/path/to/mule/server</muleHome>
@@ -235,7 +235,7 @@ You can also configure the plugin to deploy to an existing Mule server using the
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
         <deploymentType>agent</deploymentType>
         <uri>http://localhost:9999/</uri>
@@ -270,7 +270,7 @@ To run integration tests, the basic steps are the following:
     <plugin>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-app-maven-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>2.2.1</version>
         <extensions>true</extensions>
     </plugin>
     <plugin>
@@ -279,7 +279,7 @@ To run integration tests, the basic steps are the following:
         <version>2.0</version>
         <configuration>
             <deploymentType>standalone</deploymentType>
-            <muleVersion>3.7.0</muleVersion>
+            <muleVersion>3.8.5</muleVersion>
         </configuration>
         <executions>
             <execution>
@@ -330,9 +330,9 @@ In this example, the plugin is configured for a standalone deployment, and perfo
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
-        <muleVersion>3.7.0</muleVersion>                 <1>
+        <muleVersion>3.8.5</muleVersion>                 <1>
         <deploymentType>standalone</deploymentType>
         <applications>
             <application>${app.location}</application>   <2>
@@ -388,9 +388,9 @@ TIP: For a list and description of the parameters used in the examples, see <<Fu
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
-        <muleVersion>3.7.0</muleVersion>
+        <muleVersion>3.8.5</muleVersion>
         <deploymentType>cluster</deploymentType>
         <size>2</size>                                      <1>
         <application>${app.1.location}</application>
@@ -441,9 +441,9 @@ To deploy more than one application, you need to configure one plugin execution 
 <plugin>
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.1</version>
     <configuration>
-        <muleVersion>3.8.0</muleVersion>
+        <muleVersion>3.8.5</muleVersion>
         <deploymentType>standalone</deploymentType>
     </configuration>
     <executions>
@@ -501,7 +501,7 @@ When true, `skip` causes plugin execution to be skipped. This property works wit
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-maven-plugin</artifactId>
     <configuration>
-        <muleVersion>3.7.0</muleVersion>
+        <muleVersion>3.8.5</muleVersion>
         <deploymentType>standalone</deploymentType>
         <skip>${skipTests}</skip>
     </configuration>


### PR DESCRIPTION
Version 2.2.1 has several bug fixes with respect to 2.1.1.
Updated examples to use the last Mule version available.