### PR TITLE
update runtime-manager-agent doc

### DIFF
--- a/runtime-manager/v/latest/runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/runtime-manager-agent.adoc
@@ -55,7 +55,7 @@ See link:/runtime-manager/deployment-strategies[Deployment Strategies] for infor
 Additionally, MuleSoft provides several open source Runtime Manager Agent modules, to allow monitoring outside of Runtime Manager. These are provided as is, and receive no support from MuleSoft. To access these modules, check the GitHub repositories:
 
 * link:https://github.com/mulesoft/mule-agent-modules[Agent modules (general)]
-* link:https://github.com/mulesoft/mule-agent-modules/tree/master/mule-agent-monitoring-publishers[JMX publisher modules]
+* link:https://github.com/mulesoft/mule-agent-modules/tree/develop-mule-3.x/mule-agent-monitoring-publishers[JMX publisher modules]
 
 
 == Assumptions


### PR DESCRIPTION
Link to JMX publisher modules on GitHub is currently broken. Updating it.