### PR TITLE
Update managing-schedules.adoc

### DIFF
--- a/runtime-manager/v/latest/managing-schedules.adoc
+++ b/runtime-manager/v/latest/managing-schedules.adoc
@@ -86,7 +86,7 @@ image:CHSetPollFreq.png[CHSetPollFreq]
 image:CHAdvModeWithQkRef.png[CHAdvModeWithQkRef]
 +
 [NOTE]
-Note that all schedules are based in UTC timezone, regardless of what region your CloudHub workers are on.
+Note that all schedules are based in UTC timezone, regardless of what region your CloudHub workers are on. Also the timezone configuration is ignored.
 
 . To see the schedule tab in action, select one or more of the scheduled jobs and click *Run Now*. "The schedules have been queued to run" message appears.
 +


### PR DESCRIPTION
cloudhub poll ignores the timezone setting and uses UTC. the current doc only says:

"
Note that all schedules are based in UTC timezone, regardless of what region your CloudHub workers are on.
"

it does NOT clearly mention that the timezone configuration in code is ignored.