### PR TITLE
add missing types keyvalues and rateLimits

### DIFF
--- a/api-manager/v/latest/custom-policy-reference.adoc
+++ b/api-manager/v/latest/custom-policy-reference.adoc
@@ -92,7 +92,7 @@ The `configuration` parameter lists a set of properties. Each can contain the fo
 |`propertyName` |string - Property name for internal reference
 |`name` |string - Property name to display in configuration window
 |`description` |string - Property description to display in configuration window
-|`type` |string - Data type: `string`, `boolean`, `int`, `ipaddress`, `expression` (in MEL)
+|`type` |string - Data type: `string`, `boolean`, `int`, `ipaddress`, `expression` (in MEL), `keyvalues`, `rateLimits`
 |`optional` |boolean - True if assigning a value for it is optional.
 |`sensitive` |boolean - True if the information contained by this field is sensitive (typically used for passwords and tokens). When policy information is requested from the server, these sensitive fields are filtered out.
 |`allowMultiple` |boolean - True if multiple values can be assigned. Only valid if `type` is `ipaddress`.

--- a/api-manager/v/latest/custom-policy-reference.adoc
+++ b/api-manager/v/latest/custom-policy-reference.adoc
@@ -108,6 +108,7 @@ The following snippets show how to use define  propertyName parameters of the fo
 * Integer
 * Boolean
 * String
+* Map
 
 ==== Integer
 
@@ -152,6 +153,20 @@ configuration:
    optional: true
    sensitive: false
    allowMultiple: false
+----
+
+==== Map
+
+[source,yaml,linenums]
+----
+configuration:
+ - propertyName: amap
+   name: Test Key/Value Map
+   description: Some Description
+   type: keyvalue
+   optional: true
+   sensitive: false
+   allowMultiple: true
 ----
 
 ==== ramlSnippet and ramlV1Snippet Parameters


### PR DESCRIPTION
keyvalues was seen in a custom policy example. rateLimits is also shown as a choice in Studio when editing the YAML.