### PR TITLE
Remove bottom text

### DIFF
--- a/design-center/v/1.0/design-api-ui-reference.adoc
+++ b/design-center/v/1.0/design-api-ui-reference.adoc
@@ -46,7 +46,7 @@ After you turn on the mocking service, the mocking service base URI goes into ef
 
 image::baseuri-mocking.png[mocking uri,height=258,width=549]
 
-The mocking service URI works only in the Design Center environment, You cannot go to `+https://mocksvc.mulesoft.com/mocks/27e.../v1+` using a client, such as Postman or a browser.
+
 
 
 


### PR DESCRIPTION
Calling the mock url from postman works perfectly without any content-type header, calling from browser did not.
Rephrase / reinvestigate but remove this 'strange comment'. :)