### PR TITLE
fix broken AsciiDoc

### DIFF
--- a/mule-user-guide/v/3.2/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.2/using-flows-for-service-orchestration.adoc
@@ -113,6 +113,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
-link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
-link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.3/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.3/using-flows-for-service-orchestration.adoc
@@ -114,6 +114,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.4/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.4/using-flows-for-service-orchestration.adoc
@@ -114,6 +114,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.5/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.5/using-flows-for-service-orchestration.adoc
@@ -108,6 +108,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.6/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.6/using-flows-for-service-orchestration.adoc
@@ -106,6 +106,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
- link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.7/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.7/using-flows-for-service-orchestration.adoc
@@ -107,6 +107,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
-* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
 * link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]

--- a/mule-user-guide/v/3.8/using-flows-for-service-orchestration.adoc
+++ b/mule-user-guide/v/3.8/using-flows-for-service-orchestration.adoc
@@ -107,6 +107,7 @@ A private Flow differs from the use of a "Processor Chain" in that a Flow has it
 
 == Further Reading
 
-You can read more about the reason we added Flow for Mule 3 in the following blog posts: +
-* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics] +
+You can read more about the reason we added Flow for Mule 3 in the following blog posts:
+
+* link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-1-back-to-basics/[Mule 3 Architecture, Part 1: Back to Basics]
 * link:https://blogs.mulesoft.com/dev/mule-dev/mule-3-architecture-part-2-introducing-the-message-processor/[Mule 3 Architecture, Part 2: Introducing the Message Processor]


### PR DESCRIPTION
- fix broken link syntax at bottom of using-flows-for-service-orchestration.adoc page