### PR TITLE
GA support for COBOL copybook

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-formats.adoc
+++ b/mule-user-guide/v/3.8/dataweave-formats.adoc
@@ -743,10 +743,6 @@ See link:/anypoint-studio/v/6/input-output-structure-transformation-studio-task[
 
 Copybook types are technically considered a type of <<Flat File>> format, but when selecting this option the Transform Message component offers you settings that are better tailored to the needs of this format.
 
-
-[NOTE]
-This format is currently being supported as an early access feature.
-
 === Reader Properties
 
 When defining an input of type Copybook, there are a few optional parameters you can add in the XML definition of your Mule project to customize how the data is parsed.


### PR DESCRIPTION
Removing note for early access support since COBOL copybook support is GA, see Mule 3.8.3 release notes.