### PR TITLE
Update alerts-on-runtime-manager.adoc

### DIFF
--- a/runtime-manager/v/latest/alerts-on-runtime-manager.adoc
+++ b/runtime-manager/v/latest/alerts-on-runtime-manager.adoc
@@ -166,7 +166,7 @@ This alert is currently not available on the link:/runtime-manager/deployment-st
 
 * *Application Deployment success*
 * *Application Deployment failure*
-* *Application Deleted*
+* *Application undeployed*
 
 
 === Conditions on Mule Servers


### PR DESCRIPTION
"Application Deleted" Alert for Hybrid deployments is not available, instead "Application undeployed" exists