### PR TITLE
Update mule-3.8.5 release notes.

### DIFF
--- a/release-notes/v/latest/mule-3.8.5-release-notes.adoc
+++ b/release-notes/v/latest/mule-3.8.5-release-notes.adoc
@@ -176,6 +176,7 @@ This version of Mule runtime is bundled with the Runtime Manager Agent plugin ve
 | MULE-12590 | Upgrade JRuby to 1.7.27 or newer 
 | MULE-12754 | Upgrade XStream to 1.4.10 
 | MULE-12755 | Upgrade Drools to 5.2.1.Final 
+| MULE-12755 | Downgrade EJC to 3.5.1
 |===
 
 == Issues Impacting Migration


### PR DESCRIPTION
It is necessary to add information about EJC downgrade in 3.8.5 release.