### PR TITLE
Update database-sync-bulk-insert-task.adoc

### DIFF
--- a/connectors/v/latest/database-sync-bulk-insert-task.adoc
+++ b/connectors/v/latest/database-sync-bulk-insert-task.adoc
@@ -46,4 +46,4 @@ INSERT INTO orders(orderNumber, orderDate, requiredDate, shippedDate,status,comm
 +
 *syncResult*
 +
-You use this variable in the ObjectStore - Store operation.
+The BULK INSERT operation returns a success message that overrides the Database payload. You set the target of the return message to a syncResult variable to prevent the override.


### PR DESCRIPTION
Fixed the reason why we need to use syncResult variable.