### PR TITLE
Update netsuite-connector.adoc

### DIFF
--- a/mule-user-guide/v/3.7/netsuite-connector.adoc
+++ b/mule-user-guide/v/3.7/netsuite-connector.adoc
@@ -831,7 +831,7 @@ Regarding the new *search* configuration, the connector is the same apart from a
 
 ==== ItemSearchAdvanced and returnSearchColumns
 
-When using `search` the connector will output a list of maps representing the Record objects returned by your `search` operation. If using an advanced search and the `returnSearchColumns` flag is set to true, NetSuite will return a `SearchRowList` containing the search results. The connector would then be responsible for mapping `SearchRows` into the corresponding `Record` type object in order to facilitate usability.
+When using `search` the connector will output a list of maps representing the Record objects returned by your `search` operation. If using an advanced search and the `returnSearchColumns` flag is set to true, NetSuite will return a `SearchRowList` containing the search results.
 
 However, in the case of `ItemSearchAdvanced` the connector will not do this mapping and will simply provide the user with the SearchRows. This is the case due to the fact that ITEMs in NetSuite can be of various types and we cannot assume the item type from an `ItemSearchRow`. This issue would also occur with any other record type that behaves similar to `ITEM`, but we are currently not aware of others.
 


### PR DESCRIPTION
removed "The connector would then be responsible for mapping SearchRows into the corresponding Record type object in order to facilitate usability"

this caused an issue today with one of our customers and after validating with engineering the connector will always return a map and not a Record type object. We should fix this in all versions of netsuite documentation