### PR TITLE
Updated url to Platform REST api reference

### DIFF
--- a/runtime-manager/v/latest/anypoint-platform-cli.adoc
+++ b/runtime-manager/v/latest/anypoint-platform-cli.adoc
@@ -2066,7 +2066,7 @@ This command adds an SSL endpoint to the load balancer specified in <name>, usin
 |===
 
 [NOTE]
-Cloudhub does not implement the Online Certificate Status Protocol (OCSP). To keep your certification revocation list up to date, it's recommended to use the link:https://anypoint.mulesoft.com/apiplatform/sebastiankorol/#/portals/organizations/e853b9c5-6fb4-4590-8b25-0d29efeb8e98/apis/66762/versions/69421[REST API] to update your certificates programmatically.
+Cloudhub does not implement the Online Certificate Status Protocol (OCSP). To keep your certification revocation list up to date, it's recommended to use the link:https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/apis/8617/versions/2321502/pages/107964[REST API] to update your certificates programmatically.
 
 Besides the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this command also takes:
 


### PR DESCRIPTION
Updated url to Platform REST api reference because version was updated and referenced version of RAML seems broken