### PR TITLE
Fixing typo in the flat file schema doc

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-flat-file-schemas.adoc
+++ b/mule-user-guide/v/3.8/dataweave-flat-file-schemas.adoc
@@ -375,7 +375,7 @@ A structure definition can contain the following attributes:
 |===
 
 [NOTE]
-The *tagStart* parameter is required when using flat file structures. Using it, along with tagLength, is the only way for the parser to distinguish different segments. The the only supported value for tagStart now is 0.
+The *tagStart* parameter is required when using flat file structures. Using it, along with tagLength, is the only way for the parser to distinguish different segments. The only supported value for tagStart now is 0.
 
 Each item in a segment list is either a segment reference (or inline definition) or a group definition (always inline).
 


### PR DESCRIPTION
Remove double "the" in the note section