### PR TITLE
Updating supported runtime versions

### DIFF
--- a/release-notes/v/latest/anypoint-private-cloud-1.6.0-release-notes.adoc
+++ b/release-notes/v/latest/anypoint-private-cloud-1.6.0-release-notes.adoc
@@ -47,7 +47,7 @@ The procedures for performing a backup and restore have changed in this release.
 [%header,cols="2*a"]
 |===
 | Compatible with |Version
-| Mule runtime | 3.7.x - 3.8.x
+| Mule runtime | 3.7.x - 3.8.4
 | API Gateway Runtime | 2.1.x - 2.2.x
 | Runtime Manager Agent | 1.5.2 - 1.5.3
 | Infrastructure providers |


### PR DESCRIPTION
PCE 1.6.0 supports Mule runtime up to 3.8.4.  PCE 1.6.1 is needed for 3.8.5 support

Per Ramiro Rinaudo (https://mulesoft.slack.com/archives/C0D9XL7J6/p1505317789000601)