### PR TITLE
revised grammatical error in ftp-transport-ref

### DIFF
--- a/mule-user-guide/v/3.8/ftp-transport-reference.adoc
+++ b/mule-user-guide/v/3.8/ftp-transport-reference.adoc
@@ -78,7 +78,7 @@ Connector and endpoint syntax `<ftp:connector name="ftpConnector" passive="true"
 * Streaming for transferring large files
 * Support for link:/mule-user-guide/v/3.8/configuring-reconnection-strategies[reconnection strategies]
 
-Mule Enterprise includes several additional features that allow to to filter files to be processed by file age and moving and renaming files on the source FTP server after processing.
+Mule Enterprise includes several additional features that allow filtering of files to be processed by file age and moving and renaming files on the source FTP server after processing.
 
 == Usage
 


### PR DESCRIPTION
Two words "to to" we're incorrectly used in a sentence. I just noticed it reading the documentation and figured I'd sign up to contribute. Also, I'm using the documentation a lot now with clients.