### PR TITLE
There is a redundant step in PCE installation

### DIFF
--- a/anypoint-private-cloud/v/1.6/install-auto-install.adoc
+++ b/anypoint-private-cloud/v/1.6/install-auto-install.adoc
@@ -81,15 +81,7 @@ Wait for the `./gravity install` and `./gravity join` commands to complete. This
 sudo gravity enter
 ----
 
-. Run the following command to create the Ops Center user:
-+
-----
-gravity user create --ops-url=https://gravity-site.kube-system.svc.cluster.local:3009 --insecure --email=username@mulesoft.com --password=Password1 --type=admin
-----
-+
-This command creates the default admin user and password. You can use these credentials to access Ops Center.
-
-. Create the Anypoint Platform user by running the following command in the gravity shell:
+. Create the Ops Center and the Anypoint Platform user by running the following command in the gravity shell:
 +
 ----
 curl -X POST http://bandwagon-mulesoft.default.svc/api/complete -H "Content-Type:application/json" -d '{"organization": "Test Org", "email": "username@mulesoft.com", "name": "username", "password": "Password1", "support": false}'


### PR DESCRIPTION
The Gravity User is created with the same step `curl -X POST http://bandwagon-mulesoft.default.svc/api/complete`