### PR TITLE
Add an example on how to use "to" for substring and "${}" for system property

### DIFF
--- a/mule-user-guide/v/3.8/dataweave-operators.adoc
+++ b/mule-user-guide/v/3.8/dataweave-operators.adoc
@@ -2183,7 +2183,7 @@ Removes any excess spaces at the start and end of a string.
 ----
 
 
-== Substring
+== Substring using *..* or *to*
 .(':string') => ':string'
 
 Extracts a set of characters out of a string, based on the position that the first and last character of the desired substring occupy in the character array. If you use negative numbers, you can also inverse the order in which characters are set.
@@ -2196,7 +2196,10 @@ Extracts a set of characters out of a string, based on the position that the fir
 ---
 {
   "a": "abcdefg"[0..4],
-  "b": "abcdefg"[-1..-4]
+  "b": "abcdefg"[-1..-4],
+  "d": "abcdefg"[0 to 4],
+  "e": "abcdefg"[-1 to -4]
+
 }
 ----
 
@@ -2204,8 +2207,11 @@ Extracts a set of characters out of a string, based on the position that the fir
 [source,json,linenums]
 ----
 {
-  "a": "abcde"
-  "b": "gfed"
+  "a": "abcde",
+  "b": "gfed",
+  "d": "abcde",
+  "e": "gfed"
+
 }
 ----
 

--- a/mule-user-guide/v/3.8/dataweave-selectors.adoc
+++ b/mule-user-guide/v/3.8/dataweave-selectors.adoc
@@ -1020,7 +1020,7 @@ You can optionally also define the flow variable as a constant directive in the 
 
 === Accessing System and Spring Properties
 
-You can reference any *Property* (System or Spring) that exists in the server while DataWeave is processing your transformation, to do so use the *p('prop_name')* function.
+You can reference any *Property* (System or Spring) that exists in the server while DataWeave is processing your transformation, to do so use the *p('prop_name')* function or *'${prop_name}'*.
 
 [source,DataWeave,linenums]
 ---------------------------------------------------------------------
@@ -1028,7 +1028,8 @@ You can reference any *Property* (System or Spring) that exists in the server wh
 %output application/xml
 ---
 {
-  a: p('userName')
+  a: p('userName'),
+  b: '${userName}'
 }
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
- For DataWeave User Guide v3.8 file **dataweave-operators**: I have added an example for Substring using **"to"** instead of **".."** dot dot
- For DataWeave User Guide v3.8 file **dataweave-operators**: Fixed the example output by adding a missing comma on the first data.
**FROM:**
```json
{
  "a": "abcde"
  "b": "gfed"
}
```
**TO:**
```json
{
  "a": "abcde",
  "b": "gfed"
}
```

- For DataWeave User Guide v3.8 file **dataweave-selectors**: I have added a **${prop_name}** as an example to access property key in additional of **p()** function