### PR TITLE
Fixed a wrong URL to spring beans schemas

### DIFF
--- a/mule-user-guide/v/3.7/sftp-transport-reference.adoc
+++ b/mule-user-guide/v/3.7/sftp-transport-reference.adoc
@@ -6,7 +6,7 @@ The Secure Shell (SSH) File Transfer Protocol (SFTP) transport allows files to b
 *Notes*:
 
 * Mule 3.7 and newer supports SFTP retries. 
-* In code examples in this guide, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see  http://www.springframework.org/schema/beans/ -- Mule 3.7 and newer supports Spring 4.1.6.
+* In code examples in this guide, `spring-beans-current.xsd` is a placeholder. To locate the correct version, see  http://www.springframework.org/schema/beans/  -- Mule 3.7 and newer supports Spring 4.1.6.
 
 [%header%autowidth.spread]
 |===


### PR DESCRIPTION
The previous markup made it so that adoc was parsed in such a way that it created a wrong URL for spring beans schemas. Just adding an extra space between the url and the trailing plain text, solved the issue.