### PR TITLE
MUnit support version don't match release notes

### DIFF
--- a/munit/v/1.3/munit-1.3-migration-guide.adoc
+++ b/munit/v/1.3/munit-1.3-migration-guide.adoc
@@ -103,11 +103,11 @@ MUnit 1.3.5 requires the following properties in the `pom.xml` file:
 <mule.munit.support.version>3.7.5</mule.munit.support.version>
 ----
 
-Note that `${mule.munit.support.version}` should match the Mule ESB version:
+Note that `${mule.munit.support.version}` should match the Mule Runtime major and minor version numbers:
 
 * 3.6.5 for Mule 3.6.x
-* 3.7.5 for Mule 3.7.x
-* 3.8.2 for Mule 3.8.x
+* 3.7.8 for Mule 3.7.x
+* 3.8.5 for Mule 3.8.x
 
 == Mule ESB 3.7.x
 


### PR DESCRIPTION
https://docs.mulesoft.com/release-notes/munit-1.3.5-release-notes mentions 3.7.8 and 3.8.5. 3.6.x is missing.