### PR TITLE
DOCS-2300 : correct name of the plugin mentioned (Mule 3.9)

### DIFF
--- a/mule-user-guide/v/3.9/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.9/mule-maven-plugin.adoc
@@ -260,7 +260,7 @@ One of the most important uses for the plugin is to run integration tests on you
 
 To run integration tests, the basic steps are the following:
 
-* Configure the `maven-mule-plugin` to pack your project in the Mule app format
+* Configure the `mule-app-maven-plugin` to pack your project in the Mule app format
 * Configure `maven-failsafe-plugin` to run integration tests and report
 * Configure `mule-maven-plugin` to deploy the project's packaged application to a new Mule server downloaded from a Maven repository.
 


### PR DESCRIPTION
I am still new to Mule but this seems to be incorrect based on the pom file example that follows the text. 

On a side note, I am not clear when one would use maven-mule-plugin rather than mule-app-maven-plugin plugin?

thank you