### PR TITLE
add missing words "environment ID"

### DIFF
--- a/anypoint-b2b/v/latest/as2-and-edi-x12-purchase-order-walkthrough.adoc
+++ b/anypoint-b2b/v/latest/as2-and-edi-x12-purchase-order-walkthrough.adoc
@@ -201,7 +201,7 @@ Regarding the *Name* box, the xref:Note[note provided for the Send Endpoint] app
 
 === Identify or Create an API Key
 
-In order to create a Mule project, you must enter an link:/anypoint-b2b/glossary#secta[API Key] and an .
+In order to create a Mule project, you must enter an link:/anypoint-b2b/glossary#secta[API Key] and an environment ID.
 
 If you have an existing API Key, use it. If you do not know the API Key, consult your organization's MuleSoft administrator.
 


### PR DESCRIPTION
This sentence was missing some words. It seems clear, from context, that it should say:

> In order to create a Mule project, you must enter an API Key and an environment ID.