### PR TITLE
fixed link to "Create an API key"

### DIFF
--- a/anypoint-b2b/v/latest/as2-and-edi-x12-purchase-order-walkthrough.adoc
+++ b/anypoint-b2b/v/latest/as2-and-edi-x12-purchase-order-walkthrough.adoc
@@ -209,7 +209,7 @@ If your organization has not created an API Key, you can use APM to create one.
 
 WARNING: The API Key is used by every Mule application across your entire Master link:/access-management/organization[Organization] that communicates with Anypoint Partner Manager. Therefore, before you create a new API Key, coordinate with your organization's MuleSoft administrator to ensure that none of your organization's processes are using an existing API Key because, if they are, creating a new API Key will cause them to cease functioning. In that case, instead of creating a new API Key, use the existing API Key.
 
-To obtain a key, see link:/anypoint-b2b/administration#create-a-new-api-key[Create a New API Key].
+To obtain a key, see link:/anypoint-b2b/security#create-a-new-api-key[Create a New API Key].
 
 
 You can determine your environment ID on the same page that you create a new API key.


### PR DESCRIPTION
It looks like the page this relative link points to has been reorganized from /administration to /security. Fixed link to point to the correct place.