### PR TITLE
Update configure-client-management-openid-task.adoc

### DIFF
--- a/access-management/v/latest/configure-client-management-openid-task.adoc
+++ b/access-management/v/latest/configure-client-management-openid-task.adoc
@@ -64,7 +64,10 @@ The URL that provides the user’s identity encoded in a secure JSON Web Token.
 +
 . Sign in through your identity provider to test the configuration.
 
-Now, you can apply the OpenID Connect OAuth Token Enforcement policy to your APIs.
+Once this has been successfully configured, you can apply the OpenID Connect OAuth Token Enforcement policy to your API Gateways through API Manager. Requesting API access through API portals, now, dynamically generates client applications in the configured IDP that acts as a token provider.
+
+*Note:* For Okta, the Okta admin needs to assign the dynamically generated clients to a user or a group of users in order for them to receive Access tokens by sending over the Client ID and Client Secret.
+
 
 == See Also
 


### PR DESCRIPTION
Added this to make it more clear on the next steps, as well as to specify an additional step with Okta

Once this has been successfully configured, you can apply the OpenID Connect OAuth Token Enforcement policy to your API Gateways through API Manager. Requesting API access through API portals, now, dynamically generates client applications in the configured IDP that acts as a token provider.

*Note:* For Okta, the Okta admin needs to assign the dynamically generated clients to a user or a group of users in order for them to receive Access tokens by sending over the Client ID and Client Secret.