### PR TITLE
Fix typo in Dataweave Mule Config Example

### DIFF
--- a/mule-user-guide/v/3.7/dataweave-examples.adoc
+++ b/mule-user-guide/v/3.7/dataweave-examples.adoc
@@ -648,7 +648,7 @@ mule: {
 
   http#connector @(name:"HTTP_HTTPS",
                                   cookieSpec:"netscape",
-                                  alidateConnections:"true",
+                                  validateConnections:"true",
                                 sendBufferSize:"0",
                                 receiveBufferSize:"0",
                                 receiveBacklog:"0",
@@ -734,7 +734,7 @@ mule: {
 <mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:as2="http://www.mulesoft.org/schema/mule/as2"
       xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
       xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp">
-    <http:connector name="HTTP_HTTPS" cookieSpec="netscape" alidateConnections="true" sendBufferSize="0" receiveBufferSize="0" receiveBacklog="0" clientSoTimeout="10000" serverSoTimeout="10000" socketSoLinger="0" doc:name="HTTP-HTTPS"></http:connector>
+    <http:connector name="HTTP_HTTPS" cookieSpec="netscape" validateConnections="true" sendBufferSize="0" receiveBufferSize="0" receiveBacklog="0" clientSoTimeout="10000" serverSoTimeout="10000" socketSoLinger="0" doc:name="HTTP-HTTPS"></http:connector>
     <http:endpoint exchange-pattern="request-response" host="localhost" port="${http.port}" connector-ref="HTTP_HTTPS" method="POST" name="http-receive-endpoint" doc:name="HTTP"></http:endpoint>
     <http:endpoint exchange-pattern="request-response" host="btsci-dev.cloudapp.net" port="80" connector-ref="HTTP_HTTPS" method="POST" name="http-send-endpoint" doc:name="HTTP" path="as2tests/scenario1/BTSHTTPReceive.dll"></http:endpoint>
     <as2:config name="receive-as2-config" httpEndpointRef="http-receive-endpoint" doc:name="AS2"></as2:config>


### PR DESCRIPTION
"alidateConnections" -> "validateConnections"