### PR TITLE
Deprecate populate_repo

### DIFF
--- a/mule-user-guide/v/3.7/configuring-maven-to-work-with-mule-esb.adoc
+++ b/mule-user-guide/v/3.7/configuring-maven-to-work-with-mule-esb.adoc
@@ -29,24 +29,6 @@ Before you can start using Maven to create new Mule projects from the command li
 
 . _Enterprise users only:_ Modify the `settings.xml` file to point to the Enterprise Customer repository and provide your credentials.
 
-== Checking Your Maven Installation
-
-By default, your local Maven installation stores configuration files in the directory `$HOME/.m2` ( `~/.m2` on Unix and Mac; `C:\Documents and Settings\<user>\.m2` on Windows). Keep in mind that in Linux or Mac `.m2` is a hidden folder.
-
-If you are building your project outside Studio, you need to manually add some required JARs which cannot be accessed publicly through Maven. In Mule Enterprise Edition, the command line tool `populate_m2_repo`, which is available in your `$MULE_HOME/bin` directory, can fetch all the associated files. Note: Avoid duplicating jars in your project which causes classloading errors.
-
-. Navigate to `%MULE_HOME%\bin`  directory (Windows), `$MULE_HOME/bin`  folder (Linux/Unix).
-
-. Execute one of the following commands:
-
-* `./populate_m2_repo <my-test-m2-repository>` (Linux/Unix)
-
-* `populate_m2_repo.cmd <my-test-m2-repository>` (Windows)
-
-(Note that `my-m2-test-repository` must not already exist in the current directory.)
-
-Note that you may encounter errors if your `MULE_HOME` is set to a path containing spaces. It is recommended that you select a `MULE_HOME` location that does not contain spaces.
-
 == Configuring Your Maven Installation for Mule
 
 === Enabling MuleSoft Plugins

--- a/mule-user-guide/v/3.8/configuring-maven-to-work-with-mule-esb.adoc
+++ b/mule-user-guide/v/3.8/configuring-maven-to-work-with-mule-esb.adoc
@@ -26,24 +26,6 @@ Click a connector asset and click Dependency Snippets to list the Maven pom.xml 
 
 . _Enterprise users only:_ Modify the `settings.xml` file to point to the Enterprise Customer repository and provide your credentials.
 
-== Checking Your Maven Installation
-
-By default, your local Maven installation stores configuration files in the directory `$HOME/.m2` ( `~/.m2` on Unix and Mac; `C:\Documents and Settings\<user>\.m2` on Windows). Keep in mind that in Linux or Mac `.m2` is a hidden folder.
-
-If you are building your project outside Studio, you need to manually add some required JARs which cannot be accessed publicly through Maven. In Mule Enterprise Edition, the command line tool `populate_m2_repo`, which is available in your `$MULE_HOME/bin` directory, can fetch all the associated files. Note: Avoid duplicating jars in your project which causes classloading errors.
-
-. Navigate to `%MULE_HOME%\bin`  directory (Windows), `$MULE_HOME/bin`  folder (Linux/Unix).
-
-. Execute one of the following commands:
-
-* `./populate_m2_repo <my-test-m2-repository>` (Linux/Unix)
-
-* `populate_m2_repo.cmd <my-test-m2-repository>` (Windows)
-
-(Note that `my-m2-test-repository` must not already exist in the current directory.)
-
-Note that you may encounter errors if your `MULE_HOME` is set to a path containing spaces. It is recommended that you select a `MULE_HOME` location that does not contain spaces.
-
 == Configuring Your Maven Installation for Mule
 
 === Enabling MuleSoft Plugins

--- a/mule-user-guide/v/3.9/configuring-maven-to-work-with-mule-esb.adoc
+++ b/mule-user-guide/v/3.9/configuring-maven-to-work-with-mule-esb.adoc
@@ -26,24 +26,6 @@ Click a connector asset and click Dependency Snippets to list the Maven pom.xml 
 
 . _Enterprise users only:_ Modify the `settings.xml` file to point to the Enterprise Customer repository and provide your credentials.
 
-== Checking Your Maven Installation
-
-By default, your local Maven installation stores configuration files in the directory `$HOME/.m2` ( `~/.m2` on Unix and Mac; `C:\Documents and Settings\<user>\.m2` on Windows). Keep in mind that in Linux or Mac `.m2` is a hidden folder.
-
-If you are building your project outside Studio, you need to manually add some required JARs which cannot be accessed publicly through Maven. In Mule Enterprise Edition, the command line tool `populate_m2_repo`, which is available in your `$MULE_HOME/bin` directory, can fetch all the associated files. Note: Avoid duplicating jars in your project which causes classloading errors.
-
-. Navigate to `%MULE_HOME%\bin`  directory (Windows), `$MULE_HOME/bin`  folder (Linux/Unix).
-
-. Execute one of the following commands:
-
-* `./populate_m2_repo <my-test-m2-repository>` (Linux/Unix)
-
-* `populate_m2_repo.cmd <my-test-m2-repository>` (Windows)
-
-(Note that `my-m2-test-repository` must not already exist in the current directory.)
-
-Note that you may encounter errors if your `MULE_HOME` is set to a path containing spaces. It is recommended that you select a `MULE_HOME` location that does not contain spaces.
-
 == Configuring Your Maven Installation for Mule
 
 === Enabling MuleSoft Plugins


### PR DESCRIPTION
It has been deprecated and it has been outdated for some time. Configuring the Maven repositories is the current recommended procedure. Remove it for 3.7 and 3.8 too.