### PR TITLE
increase specificity on SAML NameID field

### DIFF
--- a/access-management/v/latest/managing-users.adoc
+++ b/access-management/v/latest/managing-users.adoc
@@ -34,7 +34,7 @@ An arbitrary string value that identifies your Anypoint Platform organization. T
 +
 * Username Attribute
 +
-Field name in the SAML AttributeStatements that maps to username. By default, the 'NameID' attribute in the SAML assertion is used.
+Field name in the SAML AttributeStatements that maps to username. By default, the 'NameID' attribute of the SAML 'Subject' in the SAML assertion is used.
 +
 * First Name Attribute
 +


### PR DESCRIPTION
Specifically call out that the NameID field that is used by default for the value of the username is found in the 'Subject' part of the SAML document (as opposed to the AttributeStatements where the rest of the user's attributes are found).