### PR TITLE
Update to-find-info.adoc

### DIFF
--- a/anypoint-exchange/v/latest/to-find-info.adoc
+++ b/anypoint-exchange/v/latest/to-find-info.adoc
@@ -2,11 +2,7 @@
 
 When you click an asset, the right detail panel lists the asset type, when the asset was created and by which organization, when the asset was last published, the version, and the asset's dependencies. 
 
-In a REST API, click a function and the right detail panel lets you send requests to the API and view the responses.
-
-In a Exchange portal that contains your organization's logo and content, you can click additional pages in the task bar across the top of the page. 
-
-In Exchange public and Exchange private, additional pages appear in the left navigation bar. 
+In a REST API, click a method and the right detail panel lets you send requests to the API and view the responses. Additional pages appear in the left navigation bar. 
 
 == Testing REST API Elements
 
@@ -19,7 +15,7 @@ image:ex2-rest-ftns.png[Screenshot - REST API function buttons in left nav bar]
 
 == Viewing and Trying an API with API Notebook
 
-. Click API Notebook in the left navigation bar if one is available for the API.
+. Click API Notebook inide the content page if one is available for the API.
 . After you read the description for usage information, you can experiment with the example in the code block to try different parameters and values, and see the results in real time.
 . Click Play to test the method in the code example and view the results.
 


### PR DESCRIPTION
I think the beginning that talks about Exchange private and portal is a little confusing. Removed it. Made some minor changes to the API notebook and also think that it would be great to show the screenshot of the notebook since it has a new UI and appears differently.

Also, after BGs scopes would be great to mention that assets could be shared with other developers from different BGs via sharing functionality. 