### PR TITLE
Update about-sharing-assets.adoc

### DIFF
--- a/anypoint-exchange/v/latest/about-sharing-assets.adoc
+++ b/anypoint-exchange/v/latest/about-sharing-assets.adoc
@@ -2,6 +2,8 @@
 
 You can use Exchange private or Exchange portal to share Mule XML example code, templates, connectors, APIs, and custom information assets. Sharing assets helps your organization model and reuse code and APIs for ease of access and to provide a repository.
 
-Exchange private provides an editor to add descriptions, videos, and links to an asset, as well as an API Console to experiment with sending requests and receiving responses from REST API assets. The API Notebook built into Exchange also lets you share information about each REST API method so users can experiment interactively with the API by changing variables and running it in the notebook.
+Exchange private makes it easy to share share assets with internal developers by givin them viwer, contributor or admin access. Additionally, assets created within a Business Group are automatically shared with developers within that Business Group. 
+
+Exchange public enables Exchange admins to share assets externally with developers ourside of their own organization.
 
 Exchange also lets users review assets so that asset providers can get feedback.


### PR DESCRIPTION
"Sharing assets helps your organization model and reuse code and APIs for ease of access and to provide a repository." - this sentence is very confusing. 

Also not sure why we're talking about the API console and API notebooks here. I would remove this section and only talk about Exchange private - BGs and sharing functionality; Exchange public - on how assets could be shared with external developers.

I made a draft changes so feel free to add more meat/edit my suggestions.