### PR TITLE
Update to-create-an-asset.adoc

### DIFF
--- a/anypoint-exchange/v/latest/to-create-an-asset.adoc
+++ b/anypoint-exchange/v/latest/to-create-an-asset.adoc
@@ -6,7 +6,7 @@ you first create an asset corresponding to the asset type.
 How you create an asset depends on its type.
 
 * For an OAS, HTTP, WSDL API, and a Custom asset, you can create the asset in Exchange.
-* For a RAML REST API, you first use Design Center and publish the API to Exchange.
+* For a RAML REST API, you first use Design Center and publish the API to Exchange. You can also publish RAMLs programatically via Exchagne API.
 * For an example or template, you create each using Anypoint Studio by using the Mavenize feature of Studio, which works with you to publish each to Exchange.
 * For a connector, you get the source JAR, POM, and Studio Plugin zip for the connector and use the Node.js Connector Uploader application to publish to Exchange.
 
@@ -25,7 +25,7 @@ An API asset specifies what an interface consists of including its functions, de
 Each asset type depends on the following:
 +
 * API Spec - OAS: Provide an OAS/Swagger API specification file.
-* API Spec - WSDL: Provide a WSDL (SOAP API) specification file.
+* API Spec - SOAP: Provide a WSDL specification file.
 +
 The HTTP API does not require a file, this type of asset provides an API endpoint 
 that is defined by API Manager. 


### PR DESCRIPTION
Made minor changes. Also the diagram is a little off using the terms. There is no OAS, RAML or WSDL API - those are specification formats. APIs are REST, SOAP and HTTP. I would change the APIs to specs that point to Exchange and remove APIM from the picture.

If you want to keep the APIM there, only keep the top container and next to the arrow from Exchange to APIM say "Automatic indexing of API endpoints"