### PR TITLE
Update to-describe-an-asset.adoc

### DIFF
--- a/anypoint-exchange/v/latest/to-describe-an-asset.adoc
+++ b/anypoint-exchange/v/latest/to-describe-an-asset.adoc
@@ -69,7 +69,7 @@ Tags can only be lowercase. If you enter uppercase, Exchange converts the letter
 . Click Save As Draft.
 . Publish.
 
-Users are then prompted to accept the terms and conditions before they can download the asset.
+Note: only available for APIs. Users are then prompted to accept the terms and conditions when requestion API access.
 
 == Versioning
 


### PR DESCRIPTION
1. There is no mention of uploading images. Today it's not very intuitive but we will fix it. Drag and drop image into WYSIWYG interface. 
2. Line 79 and 82 seem to have broken images
3. Terms and conditions appear in Request Access and are only available for APIs