### PR TITLE
Update install-auto-install.adoc

### DIFF
--- a/anypoint-private-cloud/v/1.6/install-auto-install.adoc
+++ b/anypoint-private-cloud/v/1.6/install-auto-install.adoc
@@ -84,7 +84,7 @@ sudo gravity enter
 . Create the Ops Center and the Anypoint Platform user by running the following command in the gravity shell:
 +
 ----
-curl -X POST http://bandwagon-mulesoft.default.svc/api/complete -H "Content-Type:application/json" -d '{"organization": "Test Org", "email": "username@mulesoft.com", "name": "username", "password": "Password1", "support": false}'
+curl -X POST http://bandwagon-mulesoft.default.svc.cluster.local/api/complete -H "Content-Type:application/json" -d '{"organization": "Test Org", "email": "username@mulesoft.com", "name": "username", "password": "Password1", "support": false}'
 ----
 
 == See Also


### PR DESCRIPTION
The complete DNS name of the bandwagon host is required for this curl request to succeed. If we leave the URL as it is now, an "Unknown host" error is generated.