### PR TITLE
Update external-oauth-2.0-token-validation-policy.adoc

### DIFF
--- a/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
+++ b/api-manager/v/latest/external-oauth-2.0-token-validation-policy.adoc
@@ -11,6 +11,8 @@ Alternatively, you can use the OAuth 2.0 Access Token Enforcement Using External
 
 To use the OAuth 2.0 Access Token Enforcement Using External Provider policy, you need a Mule link:/api-manager/aes-oauth-faq[OAuth 2.0 provider] to provide an access token. You restrict access to your API service on Anypoint Platform by applying the OAuth 2.0 Access Token Enforcement Using External Provider policy. Like other API Manager-enforced policies, the API needs to be registered in API Manager to apply this policy.
 
+IMPORTANT: OAuth 2.0 Access Token Enforcement Using External Provider policy is mean to used with *Mule OAuth 2.0 provider only*. This means that you can't use this policy to secure your APIs against any other kind of OAuth 2.0 provider, like Facebook, Google or Azure. For those use cases refer to link:https://docs.mulesoft.com/access-management/managing-api-clients[Federated Client Management] 
+
 == Applying the OAuth 2.0 Token Validation Policy
 
 To apply the OAuth 2.0 Access Token Enforcement Using External Provider policy to an API, use the general procedure for applying policies. Configure the optional scopes and required token validation endpoint URL as follows:


### PR DESCRIPTION
There has been plenty of confusion around what this policy what can do based on its name, so a clear warning seems in place.
For reference: https://mulesoft.slack.com/archives/C02HGAD2E/p1493152384227923