### PR TITLE
Custom policies support DataWeave since 3.8.5

### DIFF
--- a/api-manager/v/latest/custom-policy-reference.adoc
+++ b/api-manager/v/latest/custom-policy-reference.adoc
@@ -299,7 +299,7 @@ In addition to the `<before></before>` and `<after></after>` tags, you can also
 
 The "Pointcuts Reference" section of this document covers enabling resource level policies. 
 
-The DataWeave component is not supported for use within your Custom Policies.
+The DataWeave component is supported for use within Custom Policies on mule runtime 3.8.5 and newer versions.
 
 
 == See Also

--- a/api-manager/v/latest/custom-policy-reference.adoc
+++ b/api-manager/v/latest/custom-policy-reference.adoc
@@ -299,7 +299,7 @@ In addition to the `<before></before>` and `<after></after>` tags, you can also
 
 The "Pointcuts Reference" section of this document covers enabling resource level policies. 
 
-The DataWeave component is supported for use within Custom Policies on mule runtime 3.8.5 and newer versions.
+The DataWeave component is supported for use within Custom Policies on Mule Runtime 3.8.5 and later.
 
 
 == See Also


### PR DESCRIPTION
Per SE-6431, custom policies support DataWeave on mule runtime 3.8.5 and newer versions.