### PR TITLE
Updated AES Max Size

### DIFF
--- a/mule-user-guide/v/3.9/mule-message-encryption-processor.adoc
+++ b/mule-user-guide/v/3.9/mule-message-encryption-processor.adoc
@@ -289,7 +289,7 @@ Additionally, you can add an Xpath expression attribute to the XML decrypter to 
 |===
 |Algorithms Available in JCE |Minimum Key Size |Maximum +
 Key Size
-|AES |16 |16
+|AES |16 |32
 |Blowfish |1 |Unlimited
 |DES |8 |8
 |DESede |16 |24


### PR DESCRIPTION
There is a minSize for AES which seems to be 16 byte. So it means by default you are required min 128 bit key. But it can handle 192 and 256 key sizes as per the AES standard, adapting based on key size. It might even accept larger values, so I'd recommend to double check with engineering. But 16 is definitely not the maximum.
<https://mulesoft.slack.com/archives/C02GKLLQ1/p1434138870000857>