### PR TITLE
replace "it's" with "its"

### DIFF
--- a/anypoint-b2b/v/latest/as2-connector.adoc
+++ b/anypoint-b2b/v/latest/as2-connector.adoc
@@ -59,7 +59,7 @@ If you wish to use the AS2 Connector in conjunction with Maven, please follow th
 * Pick unique AS2 IDs per connector instance, it will help you track your messages
 * Test your trading partner ports and your own are open and reachable
 * It is recommended to use port 80 and 443 when possible (avoids mapping firewall rules for each partner)
-* When creating certificates, include it’s expiration date and your AS2 ID in the filename.
+* When creating certificates, include its expiration date and your AS2 ID in the filename.
 
 === Adding to a Flow
 


### PR DESCRIPTION
The correct possessive for "it" should be "its".  "It's" is a contraction for "it is".