### PR TITLE
Corrected Mule service flow.

### DIFF
--- a/mule-user-guide/v/3.9/mule-wmq-transport-reference.adoc
+++ b/mule-user-guide/v/3.9/mule-wmq-transport-reference.adoc
@@ -98,17 +98,18 @@ Mule configuration:
 
 [source, xml, linenums]
 ----
-<mule xmlns="http://www.mulesoft.org/schema/mule/core"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:spring="http://www.springframework.org/schema/beans"
-      xmlns:test="http://www.mulesoft.org/schema/mule/test"
-      xmlns:http="http://www.mulesoft.org/schema/mule/http"
-      xmlns:wmq="http://www.mulesoft.org/schema/mule/ee/wmq"
-    xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
-        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
-        http://www.mulesoft.org/schema/mule/ee/wmq http://www.mulesoft.org/schema/mule/ee/wmq/current/mule-wmq-ee.xsd
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd">
+<mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns:metadata="http://www.mulesoft.org/schema/mule/metadata" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:wmq="http://www.mulesoft.org/schema/mule/ee/wmq"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/ee/wmq http://www.mulesoft.org/schema/mule/ee/wmq/current/mule-wmq-ee.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+        http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
  
     <wmq:connector name="wmqconnector"
                    hostName="localhost" port="1414"
@@ -131,10 +132,16 @@ Mule configuration:
         <wmq:message-info-mapping />
     </flow>
  
-    <flow name="service">
-        <wmq:inbound-endpoint queue="RESPONSE.QUEUE" connector-ref="wmqconnector"/>
-        <test:component appendString=" RESPONSE OK"/>
-    </flow>
+    <flow name="service">
+        <wmq:inbound-endpoint queue="REQUEST.QUEUE" connector-ref="wmqconnector" doc:name="WMQ"/>
+        <logger message="reached REQUEST QUEUE" level="INFO" doc:name="Logger"/>
+        <dw:transform-message doc:name="Transform Message">
+            <dw:set-payload><![CDATA[%dw 1.0
+%output application/java
+---
+"Response OK"]]></dw:set-payload>
+        </dw:transform-message>
+    </flow>
 </mule>
 ----
 


### PR DESCRIPTION
The example provided was incorrect as the service flow was listening on the wrong queue, causing the flow to wait indefinitely.