### PR TITLE
Fix typo "fo" to "for"

### DIFF
--- a/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
@@ -379,7 +379,7 @@ The registration command will have the same format `./amc_setup -H <token> _serv
 
 [NOTE]
 ====
-The help fo these additional parameters says they are optional, but you will need to supply all the correct values in order to properly register the Mule runtime with the on-prem Runtime Manager. All of these parameters are only used to append the `-H` parameter. They are not used with the `-I` nor with the `S` parameter to configure non Runtime Manager REST API connections.
+The help for these additional parameters says they are optional, but you will need to supply all the correct values in order to properly register the Mule runtime with the on-prem Runtime Manager. All of these parameters are only used to append the `-H` parameter. They are not used with the `-I` nor with the `S` parameter to configure non Runtime Manager REST API connections.
 ====
 
 ==== Specifying URLs of On-Premises Services


### PR DESCRIPTION
"The help fo these" should obviously read "The help for these"