### PR TITLE
Add new action under Access Management - Users

### DIFF
--- a/access-management/v/latest/audit-logging.adoc
+++ b/access-management/v/latest/audit-logging.adoc
@@ -521,6 +521,13 @@ properties: none
 |Edit
 |subaction : password reset
 properties : none
+|Password changed
+|User
+|UserID
+|n/a
+|Edit
+|subaction : password changed
+properties : none
 |Delete user
 |User
 |UserID

--- a/access-management/v/latest/audit-logging.adoc
+++ b/access-management/v/latest/audit-logging.adoc
@@ -514,7 +514,7 @@ properties : organization ID
 |Create
 |subaction: none
 properties: none
-|Password reset
+|Password reset requested
 |User
 |UserID
 |n/a


### PR DESCRIPTION
Added a new action called `Password changed` which is executed when the user actually changes the password and is different from `Password reset` which is executed on just the click of the `Reset Password` link.