### PR TITLE
adjusting title to clarify it's about API management on Exchange

### DIFF
--- a/anypoint-exchange/v/latest/about-api-use.adoc
+++ b/anypoint-exchange/v/latest/about-api-use.adoc
@@ -1,6 +1,6 @@
-= About Exchange API Management
+= About Managing APIs on Exchange
 
-Anypoint Exchange provides significant features that enable API providers to easily publish and share APIs with developers inside and outside of an organization. Exchange enables API consumers with API console, API Notebooks, mocking service, and more to quickly start with an API. 
+Anypoint Exchange provides significant features that enable API providers to easily publish and share APIs with developers inside and outside of an organization. API pages on Exchange have an API console, API notebook, and mocking service capabilities.
 
 These topics help you manage APIs in Exchange:
 


### PR DESCRIPTION
not management of the "Exchange API" (disambiguation). For last sentence of intro, suggested an adjustment to specify the API features on any API page on Exchange for the developer trying to use an API in an app.