### PR TITLE
Explain how Scheduler works in the debugger now.

### DIFF
--- a/mule-user-guide/v/4.0/scheduler-concept.adoc
+++ b/mule-user-guide/v/4.0/scheduler-concept.adoc
@@ -40,6 +40,9 @@ Here are a few sample Cron expressions:
 
 Note that there are a number of free online tools that can help you build cron expressions by filling in a form, without needing to learn the syntax.
 
+== Debugging Flows with Schedulers
+When you debug a flow with a Scheduler, the scheduling frequency will be ignored. Instead a green arrow icon will be added to the bottom of the the Scheduler component's icon. The Scheduler will only trigger each time you click on this icon. This prevents events from piling up while you are stepping through the flow. 
+
 == See Also
 
 * link:/mule-user-guide/v/4.0/scheduler-xml-reference[Scheduler XML Reference]


### PR DESCRIPTION
It's different from the Polling scope in Mule 3.