### PR TITLE
Clarify try-scope and error-handling

### DIFF
--- a/mule-user-guide/v/4.0/try-scope-concept.adoc
+++ b/mule-user-guide/v/4.0/try-scope-concept.adoc
@@ -1,10 +1,10 @@
 = Try Scope
 
-The Try scope allows you to handle errors that may occur when attempting to execute its child components. It allows you to set a fine grained configuration to a specific part of your flow with a certain error-handling strategy. It also distinguishes different error types, and can apply different behaviors accordingly.
+The Try scope allows you to handle errors that may occur when attempting to execute any of the child components inside the Try scope. The Try scope has its own error handling that you configure in the same way you configure error handling for a flow. It allows you to set fine grained configuration for a specific part of your flow with a certain error handling, without having to extract those elements into a separate flow. Like all error handling, the Try scope can also distinguish between various error type conditions, and accordingly to then apply different behaviors to each error type condition.
 
 == Handling Transactions
 
-You configure a Try Scope so that it treats its child operations as an indivisible transaction. A transaction is a series of actions that should never be partially executed, errors should lead to either a rollback or a commit.
+You configure a Try scope so that it treats its child operations as an indivisible transaction. A transaction is a series of actions that should never be partially executed, errors should lead to either a rollback or a commit.
 
 The Try scope can be set to treat the components within it as a transaction. It can be configured in the following ways:
 


### PR DESCRIPTION
Needs a graphic showing the error-handler beneath the Try scope.