### PR TITLE
Fixed DW for error Match condition

### DIFF
--- a/mule-user-guide/v/4.0/error-handling.adoc
+++ b/mule-user-guide/v/4.0/error-handling.adoc
@@ -66,7 +66,7 @@ You can also set up a path to be triggered by type *ANY*, referring to all error
 
 As an alternative to mapping a path to a set of error types, you can map it to a freely defined condition. For example, you can map a path to a condition by setting the When field to:
 
-`#[error.cause.message.contains("fatal")]`
+`#[ error.cause.message contains "fatal" ]`
 
 Each flow can contain only one error handler, however this error handler can contain as many On Error scopes as you see necessary.
 


### PR DESCRIPTION
`#[ error.cause.message.contains("fatal") ]` should be `#[ error.cause.message contains "fatal" ]`