### PR TITLE
 Update vm-transport-reference.adoc

### DIFF
--- a/mule-user-guide/v/3.6/vm-transport-reference.adoc
+++ b/mule-user-guide/v/3.6/vm-transport-reference.adoc
@@ -402,15 +402,10 @@ The In Memory Transport can be included with the following dependency:
 
 [source, xml, linenums]
 ----
-<vm:connector name="persistentVmConnector" queueTimeout="1000"> ❶
-   <queue-profile maxOutstandingMessages="100" persistent="true"/>
-</vm:connector>
- 
-<flow>
-    <vm:inbound-endpoint path="in" exchange-pattern="request-response"/> ❷
-    <component class="org.mule.ComponentClass"/>
-    <vm:outbound-endpoint exchange-pattern="one-way" path="out" connector-ref="persistentVmConnector" /> ❸
-</flow>
+<dependency>
+   <groupId>org.mule.transports</groupId>
+   <artifactId>mule-transport-vm</artifactId>
+</dependency>
 ----
 
 == Best Practices

--- a/mule-user-guide/v/3.7/vm-transport-reference.adoc
+++ b/mule-user-guide/v/3.7/vm-transport-reference.adoc
@@ -343,19 +343,11 @@ The In-Memory Transport can be included with the following dependency:
 
 [source, xml, linenums]
 ----
-<vm:connector name="persistentVmConnector" queueTimeout="1000"> //<1>
-   <queue-profile maxOutstandingMessages="100" persistent="true"/>
-</vm:connector>
- 
-<flow>
-    <vm:inbound-endpoint path="in" exchange-pattern="request-response"/> //<2>
-    <component class="org.mule.ComponentClass"/>
-    <vm:outbound-endpoint exchange-pattern="one-way" path="out" connector-ref="persistentVmConnector" /> //<3>
-</flow>
+<dependency>
+   <groupId>org.mule.transports</groupId>
+   <artifactId>mule-transport-vm</artifactId>
+</dependency>
 ----
-<1> Customized connector configuration with a queue profile and queueTimeout.
-<2> The first VM endpoint (inbound) uses a _request-response_ exchange pattern and the default connector configuration, thus no connector definition is needed.
-<3> The second VM endpoint (outbound) uses a _one-way_ exchange pattern and the customized connector configuration in #1.
 
 == Best Practices
 

--- a/mule-user-guide/v/3.8/vm-transport-reference.adoc
+++ b/mule-user-guide/v/3.8/vm-transport-reference.adoc
@@ -350,19 +350,11 @@ The In-Memory Transport can be included with the following dependency:
 
 [source, xml, linenums]
 ----
-<vm:connector name="persistentVmConnector" queueTimeout="1000"> //<1>
-   <queue-profile maxOutstandingMessages="100" persistent="true"/>
-</vm:connector>
- 
-<flow>
-    <vm:inbound-endpoint path="in" exchange-pattern="request-response"/> //<2>
-    <component class="org.mule.ComponentClass"/>
-    <vm:outbound-endpoint exchange-pattern="one-way" path="out" connector-ref="persistentVmConnector" /> //<3>
-</flow>
+<dependency>
+   <groupId>org.mule.transports</groupId>
+   <artifactId>mule-transport-vm</artifactId>
+</dependency>
 ----
-<1> Customized connector configuration <1> with a queue profile and queueTimeout.
-<2> The first VM endpoint (inbound) uses a _request-response_ exchange pattern and the default connector configuration, thus no connector definition is needed.
-<3> The second VM endpoint (outbound) uses a _one-way_ exchange pattern with #1.
 
 == Best Practices
 

--- a/mule-user-guide/v/3.9/vm-transport-reference.adoc
+++ b/mule-user-guide/v/3.9/vm-transport-reference.adoc
@@ -350,19 +350,11 @@ The In-Memory Transport can be included with the following dependency:
 
 [source, xml, linenums]
 ----
-<vm:connector name="persistentVmConnector" queueTimeout="1000"> //<1>
-   <queue-profile maxOutstandingMessages="100" persistent="true"/>
-</vm:connector>
- 
-<flow>
-    <vm:inbound-endpoint path="in" exchange-pattern="request-response"/> //<2>
-    <component class="org.mule.ComponentClass"/>
-    <vm:outbound-endpoint exchange-pattern="one-way" path="out" connector-ref="persistentVmConnector" /> //<3>
-</flow>
+<dependency>
+  <groupId>org.mule.transports</groupId>
+  <artifactId>mule-transport-vm</artifactId>
+</dependency>
 ----
-<1> Customized connector configuration <1> with a queue profile and queueTimeout.
-<2> The first VM endpoint (inbound) uses a _request-response_ exchange pattern and the default connector configuration, thus no connector definition is needed.
-<3> The second VM endpoint (outbound) uses a _one-way_ exchange pattern with #1.
 
 == Best Practices
 


### PR DESCRIPTION
The "Maven" section is incorrect. It seems to just be a copy and paste error as it's a duplicate of a section further up in the doc titled "Example Usage of VM Endpoints".  I had to go back to document version 3.5 to get what the section should say.