### PR TITLE
Update sap-connector-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/sap-connector-release-notes.adoc
+++ b/release-notes/v/latest/sap-connector-release-notes.adoc
@@ -5,6 +5,47 @@ The Mule Runtime supports SAP integration through our Anypoint Connector for SAP
 
 link:/mule-user-guide/v/3.8/sap-connector[SAP Connector User Guide]
 
+== Version 3.2.0 - October 3, 2017
+
+[%header%autowidth]
+|===
+|Software |Version
+|Mule Runtime|3.5.x
+|Anypoint Studio|6.3
+|Java|7, 8
+|SAP Solution| ECC 6.0 or higher
+|Supported modules|SAP CRM, SAP ERP, SAP SRM, SAP SCM, and any other modules compatible with the NetWeaver platform.
+|===
+
+=== Features
+
+None.
+
+=== Fixed in this Release
+
+* *Transaction ID (TID) not copied to the outbound scope* - This issue occurs when making outbound calls with the *Mule Runtime 3.8.x EE*, which introduced modifications in the transaction management implementation that affected the connector. The SAP transaction component would never initialize a transaction, resulting in a null TID when executing `#[message.outboundProperties.sapTid]`. The issue is now fixed and transactions are again working with Mule Runtime 3.5.x to 3.8.x. In addition to the present patch, a workaround is also available by wrapping the SAP component in a Transactional scope.
+
+* *NoSuchMethodError `getDefaultEncoding()`* - A regression bug introduced in SAP 3.1.1 as a result of fixing an encoding issue. This exception arises only in *Mule Runtime 3.5.x EE* because the method `getDefaultEncoding()` is not present in that version. It was introduced in 3.6.x.
+
+* *IDocs containing negative numbers fail to be parsed* - When sending an IDOC to SAP with a field of datatype NUMC, the conversion fails. A similar situation occurs if, for example, an unknown field is added to the IDoc. JCo can handle this content by configuring a series of parsing options but not the SAP connector. In the current version, these options are exposed through the System property `mule.sap.idoc.parserOptions`. Multiple options can be combined using a comma (",") separator, for example: `mule.sap.idoc.parserOptions=PARSE_WITH_FIELD_VALUE_CHECKING,PARSE_IGNORE_UNKNOWN_FIELDS`. Below is the ist of supported options:
+    ** PARSE_WITH_FIELD_VALUE_CHECKING
+    ** PARSE_IGNORE_UNKNOWN_FIELDS
+    ** PARSE_IGNORE_INVALID_CHAR_ERRORS
+    ** PARSE_WITHOUT_FIELD_DATATYPE_CHECKING
+    ** PARSE_REFUSE_UNKNOWN_XMLVERSION
+    ** PARSE_REFUSE_XMLVERSION_10
+    ** PARSE_REFUSE_XMLVERSION_11
+    ** PARSE_ACCEPT_ONLY_XMLVERSION_10
+    ** PARSE_ACCEPT_ONLY_XMLVERSION_11
+    ** PARSE_ACCEPT_ONLY_XMLVERSIONS_10_TO_11
+
+*Note:* option `PARSE_WITH_IGNORE_UNKNOWN_FIELDS` is deprecated.
+
+=== Known Issues
+
+* Destination Provider reference gets lost after hot redeploy of an application (i.e. modifying the `mule-config.xml`)
+
+
 
 == Version 3.1.1 - July 31, 2017
 


### PR DESCRIPTION
We've released SAP 3.2.0 on October and we forgot to update the Release Notes