### PR TITLE
Added a link to the quartz library for cron schedulers

### DIFF
--- a/runtime-manager/v/latest/hybrid-schedule-mgmt-config.adoc
+++ b/runtime-manager/v/latest/hybrid-schedule-mgmt-config.adoc
@@ -25,3 +25,4 @@ Before performing the following procedure, ensure that you have deployed an appl
 == See Also
 
 * link:/runtime-manager/hybrid-schedule-mgmt[About Schedule Management (Hybrid)]
+* [Quartz Library - Used for Cron-type schedulers](http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html)


### PR DESCRIPTION
We started doing backend and UI validations before accepting new values when configuring a cron scheduler so I added a link specifying which Cron library/type we're using to avoid misunderstandings as something like this `* * * * *` is technically valid in some cron implementations but not accepted by runtime-manager. 

Please feel free to edit/comment/rearrange the information to make it more presentable. 

Thanks!. 