### PR TITLE
Update cloudhub-architecture.adoc

### DIFF
--- a/runtime-manager/v/latest/cloudhub-architecture.adoc
+++ b/runtime-manager/v/latest/cloudhub-architecture.adoc
@@ -83,7 +83,7 @@ You can link:/runtime-manager/worker-monitoring[monitor your workers] and verify
 
 === Global Worker Clouds
 
-CloudHub offers different worker clouds in 11 different regions of the world: North America, South America, the European Union, and Asia-Pacific. This global distribution allows you to host your integration in a location that is closest to your services, thus reducing latency. It may also allow you to adhere with local laws, such as the EU Data Protection Directive. The management console and platform services are hosted in the United States.
+CloudHub offers worker clouds in 12 different regions of the world: North America, South America, the European Union, and Asia-Pacific. This global distribution allows you to host your integration in a location that is closest to your services, thus reducing latency. It may also allow you to adhere with local laws, such as the EU Data Protection Directive. The management console and platform services are hosted in the United States.
 
 The complete list of supported regions is:
 


### PR DESCRIPTION
Updated 11 to 12; removed a redundant 'different' in same sentence.