### PR TITLE
Update cloudhub-runtimes-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
+++ b/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
@@ -5,6 +5,10 @@ These are the release notes for patches which are made to the Mule runtimes on C
 
 == January 15, 2018
 
+3.8.3 Runtime Update comes with the following fix:
+
+* kernel-level patch to the operating system to protect against the Speculative Execution vulnerability (CVE-2017-5754)
+
 3.9.0 Runtime Update comes with the following improvements:
 
 * Fixes an issue where the RAML java parser fails parsing a DataType that import a library [SE-7329]


### PR DESCRIPTION
Added "3.8.3 Runtime Update" for Jan 15th release