### PR TITLE
MULE-15211 : Clarify how the default object store behaves (Connector)

### DIFF
--- a/connectors/v/latest/object-store-connector-reference.adoc
+++ b/connectors/v/latest/object-store-connector-reference.adoc
@@ -1,5 +1,5 @@
 :toc:               left
-:toc-title:         ObjectStore Connector
+:toc-title:         Object Store Connector
 :toclevels:         2
 :last-update-label!:
 :docinfo:
@@ -7,10 +7,10 @@
 :icons: font
 
 
-= ObjectStore Connector Documentation Reference
+= Object Store Connector Documentation Reference
 
 +++
-Connector that provides functionality to access and create ObjectStore instances.
+Connector that provides functionality to access and create object store instances.
 +++
 
 
@@ -64,7 +64,7 @@ Removes all the contents in the store.
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |======================
 | Name | Type | Description | Default Value | Required
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
 |======================
 
 
@@ -87,7 +87,7 @@ Checks if there is any value associated to the given key. If no value exist for 
 |======================
 | Name | Type | Description | Default Value | Required
 | Key a| String |  +++the key of the object to be removed+++ |  | *x*{nbsp}
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab. +++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
 |======================
@@ -118,7 +118,7 @@ Removes the value associated to the given key. If no value exist for the key, th
 |======================
 | Name | Type | Description | Default Value | Required
 | Key a| String |  +++the key of the object to be removed+++ |  | *x*{nbsp}
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab+++ |  | {nbsp}
 |======================
 
 
@@ -144,7 +144,7 @@ Retrieves the value stored for the given key. <p> If no value exists for the key
 | Name | Type | Description | Default Value | Required
 | Key a| String |  +++the key of the value to be retrieved+++ |  | *x*{nbsp}
 | Default Value a| Any |  +++value to be returned if the key doesn't exist in the store+++ |  | {nbsp}
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
 |======================
@@ -175,7 +175,7 @@ Retrieves all the key value pairs in the object store
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |======================
 | Name | Type | Description | Default Value | Required
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab+++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
 |======================
@@ -197,14 +197,14 @@ Retrieves all the key value pairs in the object store
 `<os:retrieve-all-keys>`
 
 +++
-Returns a List containing all keys that the objectStore currently holds values for.
+Returns a List containing all keys that the object store currently holds values for.
 +++
 
 ==== Parameters
 [cols=".^20%,.^20%,.^35%,.^20%,^.^5%", options="header"]
 |======================
 | Name | Type | Description | Default Value | Required
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab +++ |  | {nbsp}
 | Target Variable a| String |  +++The name of a variable on which the operation's output will be placed+++ |  | {nbsp}
 | Target Value a| String |  +++An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable+++ |  +++#[payload]+++ | {nbsp}
 |======================
@@ -237,7 +237,7 @@ Stores the given value using the given key. <p> This operation can be used eithe
 | Value a| Any |  +++the value to be stored. Should not be null if failOnNullValue is set to true+++ |  +++#[payload]+++ | {nbsp}
 | Fail If Present a| Boolean |  +++Whether to fail or update the pre existing value if the key already exists on the store+++ |  +++false+++ | {nbsp}
 | Fail On Null Value a| Boolean |  +++Whether to fail or skip the operation if the value is null+++ |  +++true+++ | {nbsp}
-| Object Store a| String |  +++A reference to the ObjectStore to be used. If not defined, the runtime's default partition will be used+++ |  | {nbsp}
+| objectStore a| String |  +++A reference to the object store to be used. If not defined, the runtime's default partition will be used. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab+++ |  | {nbsp}
 |======================
 
 


### PR DESCRIPTION
The parameter is actually `objectStore`. Using `Object Store` will fail. When deployed to CloudHub worker(s), the default persistent object store is used, and key/values appear in Runtime Manager in the Mule application's Application Data tab. Properties are case sensitive, so the docs should show the exact correct name.