### PR TITLE
[SE-7022] - Updated log4j2 example for mule agent logs redirection.

### DIFF
--- a/mule-user-guide/v/3.8/logging-in-mule.adoc
+++ b/mule-user-guide/v/3.8/logging-in-mule.adoc
@@ -146,20 +146,33 @@ Your `log4j2.xml` file should include something like the following snippet to en
 
 [source, xml, linenums]
 ----
-<Appenders>
+<Configuration>
+    <Appenders>
 
-  (...)
+      (...)
 
-    <RollingFile name="mule-agent-appender" fileName="./logs/custom_mule_agent.log" filePattern="./logs/custom_mule_agent.log-%d{MM-dd-yyyy}.log.gz">
-        <PatternLayout>
-            <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
-        </PatternLayout>
-        <Policies>
-            <TimeBasedTriggeringPolicy />
-            <SizeBasedTriggeringPolicy size="250 MB"/>
-        </Policies>
-    </RollingFile>
-</Appenders>
+        <RollingFile name="mule-agent-appender" fileName="${env:MULE_HOME}/logs/custom_mule_agent.log" filePattern="${env:MULE_HOME}/logs/custom_mule_agent.log-%d{MM-dd-yyyy}.log.gz">
+            <PatternLayout>
+                <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="250 MB"/>
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+
+        (...)
+
+        <AsyncRoot level="INFO">
+
+            (...)
+
+            <AppenderRef ref="mule-agent-appender"/>
+        </AsyncRoot>
+</Configuration>
 ----
 
 The above example makes the Runtime Manager agent log its state to a rolling log file in '$MULE_HOME/logs/custom_mule_agent.log', which rolls on a per day basis and until the file reaches a 250MB size.

--- a/mule-user-guide/v/3.9/logging-in-mule.adoc
+++ b/mule-user-guide/v/3.9/logging-in-mule.adoc
@@ -147,20 +147,33 @@ Your `log4j2.xml` file should include something like the following snippet to en
 
 [source, xml, linenums]
 ----
-<Appenders>
+<Configuration>
+    <Appenders>
 
-  (...)
+      (...)
 
-    <RollingFile name="mule-agent-appender" fileName="./logs/custom_mule_agent.log" filePattern="./logs/custom_mule_agent.log-%d{MM-dd-yyyy}.log.gz">
-        <PatternLayout>
-            <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
-        </PatternLayout>
-        <Policies>
-            <TimeBasedTriggeringPolicy />
-            <SizeBasedTriggeringPolicy size="250 MB"/>
-        </Policies>
-    </RollingFile>
-</Appenders>
+        <RollingFile name="mule-agent-appender" fileName="${env:MULE_HOME}/logs/custom_mule_agent.log" filePattern="${env:MULE_HOME}/logs/custom_mule_agent.log-%d{MM-dd-yyyy}.log.gz">
+            <PatternLayout>
+                <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="250 MB"/>
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+
+        (...)
+
+        <AsyncRoot level="INFO">
+
+            (...)
+
+            <AppenderRef ref="mule-agent-appender"/>
+        </AsyncRoot>
+</Configuration>
 ----
 
 The above example makes the Runtime Manager agent log its state to a rolling log file in '$MULE_HOME/logs/custom_mule_agent.log', which rolls on a per day basis and until the file reaches a 250MB size.


### PR DESCRIPTION
The log4j2.xml example in these pages was not working for Support nor customers:
- File location was not absolute (so depending on how you start the Mule, the location may change)
- Appender-ref was missing for the new appender.