### PR TITLE
Update marketo-connector-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/marketo-connector-release-notes.adoc
+++ b/release-notes/v/latest/marketo-connector-release-notes.adoc
@@ -3,6 +3,29 @@
 
 *Guide:* link:/mule-user-guide/v/3.8/marketo-connector[Marketo Connector User Guide]
 
+== Version 2.0.2 - January 25, 2018
+
+=== Compatibility
+
+[%header%autowidth]
+|===
+|Software |Version
+|Mule Runtime |3.7.0
+|Marketo REST API |1.0
+|===
+
+=== Features
+
+* None.
+
+=== Fixed in this Release
+
+* Incorrect date parsing - Marketo changed the date format on many of their responses, making the connector fail when attempting to parse them. This no longer happens.
+* NullPointerException on processor call - The _Activities | Get Lead Changes_ processor would throw a `NullPointerException` if the lead didn't have the `rest` attribute. This was fixed.
+* value in LeadAttributes entity can be a list - Some calls to the _Activities | Get Lead Changes_ processor would fail due to a returned field being a list instead of a string. This no longer happens and the responses are parsed correctly.
+* Missing field in LeadActivities response - The connector's `LeadActivities` entity was missing the `campaignId` field. It was added and it is now returned when calling the _Activities | Get Lead Activities_ processor.
+* Parameter made optional - The `Status` parameter of the _Program | Browse Programs_ processor was marked as optional, in compliance with the API documentation.
+
 == Version 2.0.1 - May 19, 2017
 
 === Compatibility


### PR DESCRIPTION
Marketo 2.0.2 released
@george-hoffer : there are some italics in the doc to group some references ... 
