### PR TITLE
Update configuring-properties.adoc

### DIFF
--- a/mule-user-guide/v/3.9/configuring-properties.adoc
+++ b/mule-user-guide/v/3.9/configuring-properties.adoc
@@ -66,6 +66,13 @@ To load multiple properties files, separate each with commas:
 
 These files must be located at `src/main/resources`, inside your Mule project.
 
+You can also pass HTTP URL's in the location attribute, as below, to refer the properties from a centralized location: 
+
+[source,xml]
+----
+<context:property-placeholder location="https://www.abccompany.com/property/http.properties"/>
+----
+
 Since properties from files, system properties and environment variables are referred to through the same syntax, you can add a `system-properties-mode` parameter to your property placeholder to ensure that overrides work in the way that you desire. The accepted values for this parameter are ENVIRONMENT, NEVER, FALLBACK, and OVERRIDE:
 
 [source,xml, linenums]


### PR DESCRIPTION
The reason for adding this change is because the HTTP URL's are allowed as a value in the location attribute, since the backing spring library supports URLs & URI's to pass. 

org.springframework.core.io.Resources class has a method getURL() which is called from org.springframework.core.io.support.PropertiesLoaderSupport. This PropertiesLoaderSupport is called by Property loader spring bean.