### PR TITLE
Modified "fields" parameter default value

### DIFF
--- a/api-manager/v/latest/analytics-event-api.adoc
+++ b/api-manager/v/latest/analytics-event-api.adoc
@@ -141,8 +141,8 @@ To cover a duration of one week, specify `7d` as the duration. To cover half a m
 *Required:* no +
 *Example:* `duration=45m`
 |fields |Fields to include in the report. Required for CSV output and optional for JSON output. 
-If omitted for JSON output, the default is all fields. The list of fields can be comma- or 
-period-delimited. Use `%20` for spaces. You can use any value in <<Data Fields for Reports>>. 
+The list of fields can be comma- or period-delimited. Use `%20` for spaces. You can use any value
+in <<Data Fields for Reports>>. 
 Timestamp, API Name, API ID, API Version, API Version ID are always included. +
 
 *Type:* string +


### PR DESCRIPTION
Updated the "fields" parameter documentation since omitting the "fields" parameter doesn't default to all fields, but to some specific fields.