### PR TITLE
Updating list of external identity providers

### DIFF
--- a/access-management/v/latest/external-identity.adoc
+++ b/access-management/v/latest/external-identity.adoc
@@ -26,6 +26,7 @@ Before configuring OpenID Connect or SAML 2.0, select an identity management pro
 * Active Directory Federation Services (AD FS)
 * onelogin
 * CA Single Sign-On
+* SecureAuth
 
 Familiarize yourself with the documentation of your Idp. After you select an IdP, set up your Anypoint Platform organization as your audience in your IdP configuration. Configure identity management in the Anypoint Platform master organization. The IdP you select is effective for the entire organization and all business groups. Configure attribute names on the IdP and Anypoint Platform to match.
 


### PR DESCRIPTION
Adding SecureAuth to the list of external identity providers supported by MuleSoft.  I've got this working at a customer site and SecureAuth lists MuleSoft as a supported application, see https://www.secureauth.com/resources/apps/mulesoft-anypoint-platform.