### PR TITLE
number of nodes limit a cluster

### DIFF
--- a/mule-user-guide/v/3.9/mule-high-availability-ha-clusters.adoc
+++ b/mule-user-guide/v/3.9/mule-high-availability-ha-clusters.adoc
@@ -53,7 +53,7 @@ The following problems may exist when you have a server group composed of multip
 
 == About Clustering
 
-With out of the box configurations, it is recommended that you scale a cluster to no more than eight Mule runtimes. All the Mule runtimes in a cluster group together to form a single unit. Thus, you can deploy, monitor, or stop all the Mule runtimes in a cluster as if they were a single Mule runtime. If you need more nodes than eight, contact link:https://www.mulesoft.com/support-and-services/mule-esb-support-license-subscription[MuleSoft Support].
+All the Mule runtimes in a cluster group together to form a single unit. Thus, you can deploy, monitor, or stop all the Mule runtimes in a cluster as if they were a single Mule runtime. 
 
 All the Mule runtimes in a cluster share memory, as illustrated below:
 
@@ -64,6 +64,10 @@ Mule uses an *active-active* model to cluster Mule runtimes, rather than an *act
 In an *active-passive* model, one node in a cluster acts as the *primary*, or active node, while the others are *secondary*, or passive nodes. The application in such a model runs on the primary node, and only ever runs on the secondary node if the first one fails. In this model, the processing power of the secondary node(s) is mostly wasted in passive waiting for the primary node to fail.
 
 In an *active-active* model, no one node in the cluster acts as the primary node; all nodes in the cluster support the application. This application in this model runs on all the nodes, even splitting apart message processing between nodes to expedite processing across nodes.
+
+[NOTE]
+If you plan to use many nodes in your cluster, or you plan to store large message payloads, it is recommended that you research Hazelcast cluster scaling in the link:https://hazelcast.org/documentation/[Hazelcast documentation], or to contact link:http://support.muleosft.com[MuleSoft Suport]
+
 
 == About Queues
 
@@ -140,7 +144,7 @@ There are also many hardware load balancers that can route both TCP and HTTP(S) 
 == Clustering for High Performance
 
 [NOTE]
-Note that high performance is implemented differently on link:/runtime-manager[CloudHub] and link:/runtime-manager/deploying-to-pcf[Pivotal Cloud Foundry], so this section applies only for link:/runtime-manager/deploying-to-your-own-servers[on-premises deployments].
+High performance is implemented differently on link:/runtime-manager[CloudHub] and link:/runtime-manager/deploying-to-pcf[Pivotal Cloud Foundry], so this section applies only for link:/runtime-manager/deploying-to-your-own-servers[on-premises deployments].
 
 If high performance is your primary goal (rather than reliability), you can configure a Mule cluster or an individual application for maximum performance using a *performance profile*. By implementing the performance profile for specific applications within a cluster, you can maximize the scalability of your deployments while deploying applications with different performance and reliability requirements in the same cluster. By implementing the performance profile at the container level, you apply it to all applications within that container. Application-level configuration overrides container-level configuration.
 

--- a/mule-user-guide/v/3.9/mule-high-availability-ha-clusters.adoc
+++ b/mule-user-guide/v/3.9/mule-high-availability-ha-clusters.adoc
@@ -65,9 +65,6 @@ In an *active-passive* model, one node in a cluster acts as the *primary*, or ac
 
 In an *active-active* model, no one node in the cluster acts as the primary node; all nodes in the cluster support the application. This application in this model runs on all the nodes, even splitting apart message processing between nodes to expedite processing across nodes.
 
-[NOTE]
-If you plan to use many nodes in your cluster, or you plan to store large message payloads, it is recommended that you research Hazelcast cluster scaling in the link:https://hazelcast.org/documentation/[Hazelcast documentation], or to contact link:http://support.muleosft.com[MuleSoft Suport]
-
 
 == About Queues
 
@@ -211,7 +208,8 @@ There are a number of recommended practices related to clustering. These include
 
 == Prerequisites and Limitations
 
-* With out of box configurations it is recommended that you scale a cluster to no more than eight Mule nodes.
+* To date, MuleSoft has only tested eight node clusters. If you plan to scale beyond eight nodes.
+If you plan to use many nodes in your cluster, or you plan to store large message payloads, it is recommended that you research Hazelcast cluster scaling in the link:https://hazelcast.org/documentation/[Hazelcast documentation], or to contact link:http://support.mulesoft.com[MuleSoft Suport]
 // COMBAK: Comenting this out per JIRA SE-6162.
 // If you need more nodes than eight, contact link:https://www.mulesoft.com/support-and-services/mule-esb-support-license-subscription[MuleSoft Support].
 * You must have at least two Mule runtimes in a cluster, each of which should run on different physical (or virtual) machines.


### PR DESCRIPTION
This needs to be changed in all previous version, and in Mule 4. The recommendation to use less then 8 nodes in a Hazelcast cluster was based on the number of nodes that had been tested by QA. There is not real evidence for this limit. Any limitation is a by-product of Hazelcast itself and the message size. It is not dependent on MuleSoft's implementation or use of Hazelcast.