### PR TITLE
external identity not available at BU level

### DIFF
--- a/access-management/v/latest/sso-prerequisites-about.adoc
+++ b/access-management/v/latest/sso-prerequisites-about.adoc
@@ -25,5 +25,6 @@ If a user session times out, the user is redirected to the federated identity lo
 If a SAML user belongs to certain groups, Anypoint Platform does not automatically grant equivalent roles in the organization.
 +
 * Anypoint Platform does not generate the SAML assertion for the single sign on. Your IdP generates the Sign On URL that you configure.
+* External Identity configuration is only available at Organization level. Business Unit level external identity configuration is not currently supported.
 
 


### PR DESCRIPTION
customer's been asking about whether it's possible to configure external identity at BU level as different BUs might have different IDPS. this is not supported as of now(2018-02-15). It's better we document that.