### PR TITLE
Updated reference to correct screenshot

### DIFF
--- a/anypoint-b2b/v/latest/_sources/tutorial/supplier/identifier-x12-isa-supplier.adoc
+++ b/anypoint-b2b/v/latest/_sources/tutorial/supplier/identifier-x12-isa-supplier.adoc
@@ -45,11 +45,11 @@ A list of qualifiers appears.
 
 . Click *Save* to save the new identifier.
 +
-The <<img-identifiers-x12-added-aaz>> appears.
+The <<img-identifiers-x12-added-aaz2>> appears.
 
 
-[[img-identifiers-x12-added-aaz, Identifiers Page (Identifier Added)]]
+[[img-identifiers-x12-added-aaz2, Identifiers Page (Identifier Added)]]
 
-image::yc/identifiers-x12-added-aaz.png[img-identifiers-x12-added-aaz, title="Identifiers Page (X12-ISA Identifier Added)"]
+image::yc/identifiers-x12-added-aaz2.png[img-identifiers-x12-added-aaz2, title="Identifiers Page (X12-ISA Identifier Added)"]
 
 Note that the Identifier you added in the preceding steps (*X12-ISA*) now appears.


### PR DESCRIPTION
identifiers-x12-added-aaz referred to the wrong configuration (supplier instead of AZZ)