### PR TITLE
[In Progress] Update cloudhub-fabric.adoc

### DIFF
--- a/runtime-manager/v/latest/cloudhub-fabric.adoc
+++ b/runtime-manager/v/latest/cloudhub-fabric.adoc
@@ -31,7 +31,7 @@ Use the drop-down menus next to *workers* to pick the amount and a size for the
 
 image:WorkerSizeQuantity.png[WorkerSizeQuantity]
 
-Each application can be deployed with up to 8 workers of any kind, totaling up to 16 vCores. However, you may be limited to fewer vCores than those you need, based on how many are available in your subscription. See link:/runtime-manager/deploying-to-cloudhub[Worker Sizing] for more information about deploying to multiple vCores.
+Each application can be deployed with up to 8 workers of any kind, totaling up to 128 vCores. However, you may be limited to fewer vCores than those you need, based on how many are available in your subscription. See link:/runtime-manager/deploying-to-cloudhub[Worker Sizing] for more information about deploying to multiple vCores.
 
 Worker scale out also adds additional reliability. MuleSoft automatically distributes multiple workers for the same application across two or more datacenters for maximum reliability. AWS Data Centers are at least 60 miles apart.
 

--- a/runtime-manager/v/latest/cloudhub-fabric.adoc
+++ b/runtime-manager/v/latest/cloudhub-fabric.adoc
@@ -33,7 +33,7 @@ image:WorkerSizeQuantity.png[WorkerSizeQuantity]
 
 Each application can be deployed with up to 8 workers of any kind, totaling up to 128 vCores. However, you may be limited to fewer vCores than those you need, based on how many are available in your subscription. See link:/runtime-manager/deploying-to-cloudhub[Worker Sizing] for more information about deploying to multiple vCores.
 
-Worker scale out also adds additional reliability. MuleSoft automatically distributes multiple workers for the same application across two or more datacenters for maximum reliability. AWS Data Centers are at least 60 miles apart.
+Worker scale out also adds additional reliability. MuleSoft automatically distributes multiple workers for the same application across two or more datacenters for maximum reliability.
 
 When deploying your application to two or more workers, you can distribute workloads across these instances of Mule. CloudHub provides two facilities to do this:
 

--- a/runtime-manager/v/latest/cloudhub-fabric.adoc
+++ b/runtime-manager/v/latest/cloudhub-fabric.adoc
@@ -31,9 +31,9 @@ Use the drop-down menus next to *workers* to pick the amount and a size for the
 
 image:WorkerSizeQuantity.png[WorkerSizeQuantity]
 
-Each application can be deployed with up to 4 workers of any kind, totaling up to 16 vCores. However, you may be limited to fewer vCores than those you need, based on how many are available in your subscription. See link:/runtime-manager/deploying-to-cloudhub[Worker Sizing] for more information about deploying to multiple vCores.
+Each application can be deployed with up to 8 workers of any kind, totaling up to 16 vCores. However, you may be limited to fewer vCores than those you need, based on how many are available in your subscription. See link:/runtime-manager/deploying-to-cloudhub[Worker Sizing] for more information about deploying to multiple vCores.
 
-Worker scale out also adds additional reliability. MuleSoft automatically distributes multiple workers for the same application across two or more datacenters for maximum reliability.
+Worker scale out also adds additional reliability. MuleSoft automatically distributes multiple workers for the same application across two or more datacenters for maximum reliability. AWS Data Centers are at least 60 miles apart.
 
 When deploying your application to two or more workers, you can distribute workloads across these instances of Mule. CloudHub provides two facilities to do this:
 


### PR DESCRIPTION
updated # of workers from 4 to 8
added note about AWS DCs being at least 60 miles apart.