### PR TITLE
Update objectstore-connector-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/objectstore-connector-release-notes.adoc
+++ b/release-notes/v/latest/objectstore-connector-release-notes.adoc
@@ -23,6 +23,13 @@ The Object Store connector is compatible with:
 |Anypoint Studio|5.x or higher
 |===
 
+== Version 2.1.1 - March 2, 2018
+
+=== Fixed in this Release
+
+* *ClassCastException when target property is defined* - The retrieve method used to fail with a ClassCastException when a "target" property was defined and the payload sent to the connector was non-serializable. This is no longer the case.
+
+
 == Version 2.1.0 - February 3, 2017
 
 * New operation: *Dispose store*: Removes an object store partition. Before, the only way to remove an object store partition was by calling the `disposePartition` function of the `ObjectStoreManager` inside a Java custom component.


### PR DESCRIPTION
Release Notes for version 2.1.1. 
I've noticed that the compatibility Data is unique by all the Release Notes. IMHO, this makes sense when that info is valid for all the versions... But once that chance, we need to specify that info at least in the versions where it changes. (Is that the idea?)