### PR TITLE
Correcting mis-spelling

### DIFF
--- a/mule-user-guide/v/3.9/mule-maven-plugin.adoc
+++ b/mule-user-guide/v/3.9/mule-maven-plugin.adoc
@@ -375,7 +375,7 @@ In this example, the plugin is configured for a standalone deployment, and perfo
 <6> Optional Groovy script to run just before deployment.
 <7> Use Enterprise Edition.
 <8> Use the `deploy` goal to download Mule, install it and deploy the domain and applications.
-<9> Use the `undeploy` goal to undeploy de applications and stop Mule server.
+<9> Use the `undeploy` goal to undeploy the applications and stop Mule server.
 
 For a list and description of the parameters employed, see <<Standalone>>.
 


### PR DESCRIPTION
Typo error corrected, changed "de" to "the".

Original said - "Use the undeploy goal to undeploy de applications and stop Mule server."