### PR TITLE
CloudHub release v1.65.0

### DIFF
--- a/release-notes/v/latest/cloudhub-release-notes.adoc
+++ b/release-notes/v/latest/cloudhub-release-notes.adoc
@@ -3,6 +3,19 @@
 
 In addition to these release notes, see the complete link:/runtime-manager/cloudhub[CloudHub] documentation.
 
+== 1.65.0 - March 8, 2018
+
+This release enables users to:
+
+* Associate VPCs with second-level business groups.
+* Add additional firewall rules per VPC.
+
+In addition, this release also includes the following changes and improvements:
+
+* Additional shared load balancers across regions. link://docs.mulesoft.com/runtime-manager/cloudhub-architecture#global-worker-clouds[View changes in domains] used for new applications.
+* Infrastructure improvements powering mule applications.
+* A series of resiliency improvements and bug fixes.
+
 == 1.64.0 - January 13, 2018
 
 This release enables users to:

--- a/runtime-manager/v/latest/cloudhub-architecture.adoc
+++ b/runtime-manager/v/latest/cloudhub-architecture.adoc
@@ -104,7 +104,7 @@ The complete list of supported regions is:
 |Asia Pacific (Singapore)|au.cloudhub.io
 |===
 
-When your application is running in the EU, all HTTP services are also available over the eu.cloudhub.io domain. For example, if you create the application "myapp", then its domain is "myapp.eu.cloudhub.io." This load balancer is hosted in the EU, ensuring that your data is never transferred outside the EU when invoking HTTP services.
+The domain provided for your application is based on the region your application is deployed to. For example, if you deploy an application named "myapp" to Canada (Central), the domain used to access the application will be "myapp.ca-c1.cloudhub.io". The load balancer used to route requests reside in the same region as your application.
 
 For more information about deploying applications to different regions, refer to link:/runtime-manager/deploying-to-cloudhub[Deploying to CloudHub]. For more information about CloudHub's security and compliance, download the link:https://www.mulesoft.com/lp/whitepaper/saas/cloud-security[Anypoint Cloud Security & Compliance whitepaper].
 


### PR DESCRIPTION
- Added release notes.
- Simplified wording on how domains are associated with applications due to the regionality of shared load balancers.