### PR TITLE
Create Template instead of Transaction

### DIFF
--- a/anypoint-b2b/v/latest/_sources/tutorial/supplier/start-td-aaz.adoc
+++ b/anypoint-b2b/v/latest/_sources/tutorial/supplier/start-td-aaz.adoc
@@ -8,7 +8,7 @@ image::yc/td-aaz.png[img-td-aaz, title="Transaction Designer Page"]
 
 [start=2]
 
-. On the <<img-td-aaz>>, click *New*. 
+. On the <<img-td-aaz>>, click *Create Template*. 
 +
 The <<img-td-new-aaz>> appears.
 


### PR DESCRIPTION
Previous instruction made it impossible to reuse transaction as a buyer.