### PR TITLE
Application logging information is incorrect

### DIFF
--- a/mule-user-guide/v/3.9/logging-in-mule.adoc
+++ b/mule-user-guide/v/3.9/logging-in-mule.adoc
@@ -90,8 +90,6 @@ If this deployment property isn't set, when an application is deployed, Mule loo
 * Look for a file called `log4j2.xml` in the application classpath
 * Look for a file called `log4j2-test.xml` in the domain classpath
 * Look for a file called `log4j2.xml` in the domain classpath
-* Look for a file called `log4j2-test.xml` in `MULE_HOME/conf`
-* Look for a file called `log4j2.xml` in `MULE_HOME/conf`
 * Apply default configuration.
 
 


### PR DESCRIPTION
Following lines removed:

* Look for a file called `log4j2-test.xml` in `MULE_HOME/conf`
* Look for a file called `log4j2.xml` in `MULE_HOME/conf`

As per: https://www.mulesoft.org/jira/browse/DOCS-1854 these should have already been removed. When an application starts and no log4j2.xml file is present for the app or the domain a default configuration is applied, application does not pick up logging configuration from the MULE_HOME/conf directory, this has been confirmed in testing. Please advise if current documentation should be correct and a bug needs to be raised instead of this documentation change.