### PR TITLE
Update promote-api-task.adoc

### DIFF
--- a/api-manager/v/2.x/promote-api-task.adoc
+++ b/api-manager/v/2.x/promote-api-task.adoc
@@ -11,6 +11,13 @@ A tight integration of Anypoint Platform components extends the use of environme
 . Select or deselect things to include in the promotion: Policies, SLAs, Alerts, API Configuration
 . Click Promote.
 
+[NOTE]
+====
+It will only promote the API Definition not the existing deployed applications subscribed to this API. After promoting an API, API Name will remain the same but API Version will change.
+For existing applications that needs to subscribe to promoted API user need to make following changes:
+. User needs to update their API Version. 
+. As each environment has different Client ID and Secret, user need to update application's client id and secret. 
+====
 
 == See Also
 

--- a/api-manager/v/2.x/promote-api-task.adoc
+++ b/api-manager/v/2.x/promote-api-task.adoc
@@ -11,13 +11,14 @@ A tight integration of Anypoint Platform components extends the use of environme
 . Select or deselect things to include in the promotion: Policies, SLAs, Alerts, API Configuration
 . Click Promote.
 
-[NOTE]
-====
-It will only promote the API Definition not the existing deployed applications subscribed to this API. After promoting an API, API Name will remain the same but API Version will change.
-For existing applications that needs to subscribe to promoted API user need to make following changes:
-. User needs to update their API Version. 
-. As each environment has different Client ID and Secret, user need to update application's client id and secret. 
-====
+
+*Note*: Promoting an API affects only the API definition, not the existing deployed applications subscribed to the API. After promoting an API, the API Name remains the same, but the API Version changes.
+
+For existing applications that need to subscribe to a promoted API, you need to make following changes:
+
+. Update the API Version. 
+. As each environment has different client id and secret, update the application's client id and secret. 
+
 
 == See Also
 


### PR DESCRIPTION
It is not clear but It will only promote the API Definition not the existing deployed applications subscribed to this API. 
Also after promoting an API, API Name will remain the same but API Version will change and customer has to update client id and secret as well.