### PR TITLE
Portal customization - Banner height specification

### DIFF
--- a/anypoint-exchange/v/latest/to-customize-portal.adoc
+++ b/anypoint-exchange/v/latest/to-customize-portal.adoc
@@ -41,7 +41,7 @@ Specify the hexadecimal red-green-blue color for the top bar text when the text 
 Choose an image for the banner for the public portal. The hero image file format can be .png, .jpg, or .gif. 
 The maximum file size for the banner image is 2 MB. The banner image can also be an animated GIF file.
 
-The image you specify is stretched to fit the window size as determined by the browser's window size.
+The image you specify is stretched to fit the window size as determined by the browser's window size. The height is fixed to 220px.
 
 === Banner Text Color
 


### PR DESCRIPTION
The Exchange Portal banner is going to be fixed to 220px. Exchange team confirmed this information. I wanted to add this to the documentation as it was important for one customer.