### PR TITLE
Correct color error in Basic Studio Tutorial

### DIFF
--- a/anypoint-studio/v/6/basic-studio-tutorial.adoc
+++ b/anypoint-studio/v/6/basic-studio-tutorial.adoc
@@ -56,7 +56,7 @@ The Studio UI, which has the following main sections, appears:
 
 image:blank+canvas.png[blank+canvas]
 
-The blue area in the center is the canvas where you build a visual representation of your Mule program by dragging building blocks from the palette outlined in green to the canvas.
+The orange area in the center is the canvas where you build a visual representation of your Mule program by dragging building blocks from the palette outlined in green to the canvas.
 For more information about how to use the visual editor, see this link:/anypoint-studio/v/6/[quick overview].
 
 At the bottom of the canvas are Message Flow and Configuration XML tabs for alternating between visual and XML editing of the application.


### PR DESCRIPTION
The color used to outline the visual representation area is orange in the current blank+canvas.png.  The color in the current documentation says that it is blue, but that outlines the Mule properties section.

![color error](https://user-images.githubusercontent.com/6707168/37867809-7bbfe532-2f6b-11e8-9bb8-35a2a3ee803c.PNG)
