### PR TITLE
encrypted YAML values must be Strings

### DIFF
--- a/mule-user-guide/v/4.1/secure-configuration-properties.adoc
+++ b/mule-user-guide/v/4.1/secure-configuration-properties.adoc
@@ -80,11 +80,14 @@ testPropertyA: "testValueA"
 testPropertyB: "testValueB"
 ----
 
+[Note]
+The encrypted value must be enclosed in quotes so that it is read as a String. 
+
 Here is the same configuration as above using a Spring-formatted properties file:
 
 .Example: file1.properties
 ----
-encrypted.key=![nHWo5JhNAYM+TzxqeHdRDXx15Q5R56YVGiQgXCoBJew=]
+encrypted.key="![nHWo5JhNAYM+TzxqeHdRDXx15Q5R56YVGiQgXCoBJew=]"
 
 testPropertyA=testValueA
 testPropertyB=testValueB


### PR DESCRIPTION
Also, need to tell readers the PASSWORD value, so they can test the examples.