### PR TITLE
Ambiguous preparedStatementCacheSize default Value

### DIFF
--- a/mule-user-guide/v/3.9/database-connector-reference.adoc
+++ b/mule-user-guide/v/3.9/database-connector-reference.adoc
@@ -630,7 +630,7 @@ Provides a way to configure database connection pooling.
 * *Required:* no
 * *Default:* none
 
-|preparedStatementCacheSize |Determines how many statements are cached per pooled connection. Defaults to 0, meaning statement caching is disabled.
+|preparedStatementCacheSize |Determines how many statements are cached per pooled connection. If changed to 0, statement caching is disabled.
 
 * *Type:* integer
 * *Required:* no


### PR DESCRIPTION
Updated preparedStatementCacheSize description. It's ambiguous on the default value.