### PR TITLE
schema file locations cannot by dynamic

### DIFF
--- a/anypoint-b2b/v/latest/x12-module.adoc
+++ b/anypoint-b2b/v/latest/x12-module.adoc
@@ -235,7 +235,9 @@ After you set up a global element for your X12 module, configure the schemas, ac
 
 === Setting Your Schema Locations
 
-NOTE: Currently, you can only configure schema locations in the Anypoint Studio XML view.
+NOTE: 
+* Currently, you can only configure schema locations in the Anypoint Studio XML view.
+* The schema files are loaded when connector is initialized, thus runtime expressions(for example flow variables) are not supported.
 
 Using the schema locations determined above, switch to the XML view by clicking *Configuration XML* in Studio and modify your X12 module configuration to include a list of all the schemas you wish to include by adding an `edi:schema` element for each document type:
 


### PR DESCRIPTION
connector UI shows the schema locations can be 'From Expression', which misleads customers to use MEL with flow variables.

I checked with Dennis Sosnoski, the main contributor of X12 connector project, and confirmed that "it is expecting the values when initialized. There's substantial overhead in loading the schemas, so that's only done at initialization." as a result, MEL with flow variables won't work. In other words, dynamically loading different schema files at runtime is not currently supported.