### PR TITLE
Update migration-connectors.adoc

### DIFF
--- a/mule-user-guide/v/4.1/migration-connectors.adoc
+++ b/mule-user-guide/v/4.1/migration-connectors.adoc
@@ -29,7 +29,7 @@ Mule 3.x Module| Mule 4.0 Replacement
 |Jetty	| Use new HTTP module.
 |OGNL	| Replaced DataWeave expression language, or MEL in compatibility module.
 |Patterns|Removed. Use flows instead.
-|Quartz	| Use <poll>
+|Quartz	| Use new Scheduler component.
 |RSS	| Use HTTP + DataWeave
 |SXC	| Use DataWeave.
 |Tomcat 	| New embedded mode in development.


### PR DESCRIPTION
Poll scope was removed.  Suggesting to use a Mule 4.x Scheduler component as a replacement for the Mule 3.x Quartz component.