### PR TITLE
Update index-migration.adoc

### DIFF
--- a/mule-user-guide/v/4.1/index-migration.adoc
+++ b/mule-user-guide/v/4.1/index-migration.adoc
@@ -12,7 +12,6 @@ This documentation describes the differences between Mule 3 and Mule 4, indicate
 * More in-depth migration details:
  ** link:migration-patterns[Migration Patterns]
  ** link:migration-core[Migrating Core Components]
- ** link:migration-patterns[Migration Patterns]
  ** link:migration-connectors[Migrating Connectors]
  ** link:migration-api-gateways[Migrating API Gateways]
  ** link:migration-mel[Migrating from MEL to DataWeave]


### PR DESCRIPTION
Removed redundant link to Migration Patterns.