### PR TITLE
Update cloudhub-runtimes-release-notes.adoc

### DIFF
--- a/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
+++ b/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
@@ -14,7 +14,16 @@ These are the release notes for patches which are made to the Mule runtimes on C
 
 * Cross-site scripting (reflected) [SE-7930]
 
-== April 3, 2018
+== March 30, 2018
+
+3.8.5 Runtime Update comes with the following fixes:
+
+* Automatic retry on remote Closed exception does not respect RFC 7320 [SE-7116]
+* SFTP Reconnect throws "Already in lifecycle phase" as a error message [SE-6658]
+* Cross-site scripting (reflected) [SE-7930]
+* Warning logs are emitted when using secured properities [SE-7445]
+
+== March 29, 2018
 
 3.8.6 Runtime Update comes with the following fixes:
 
@@ -22,15 +31,7 @@ These are the release notes for patches which are made to the Mule runtimes on C
 * API created with auto discovery from RAML 1.0 spec with includes doesn't attach includes [SE-5486]
 * Cross-site scripting (reflected) [SE-7930]
 
-== April 2, 2018
-
-3.8.5 Runtime Update comes with the following fixes:
-
-* Automatic retry on remote Closed exception does not respect RFC 7320 [SE-7116]
-* SFTP Reconnect throws "Already in lifecycle phase" as a error message [SE-6658]
-* Cross-site scripting (reflected) [SE-7930]
-
-== March 29, 2018
+== March 28, 2018
 
 3.9.0 Runtime Update comes with the following fixes:
 
@@ -40,6 +41,13 @@ These are the release notes for patches which are made to the Mule runtimes on C
 * API created with auto discovery from RAML 1.0 spec with includes doesn't attach includes [SE-5486]
 * DataWeave transformation throws BufferUnderflowException [SE-7263]
 * Cross-site scripting (reflected) [SE-7930]
+* Warning logs are emitted when using secured properities [SE-7445]
+
+== March 26, 2018
+
+3.8.6 Runtime Update comes with the following fix:
+
+* Warning logs are emitted when using secured properities [SE-7445]
 
 == March 22, 2018
 
@@ -48,6 +56,12 @@ These are the release notes for patches which are made to the Mule runtimes on C
 * Fixes an issue where logs are filled up with "skip invalid notification" message when insight is enabled [SE-7552]
 * Fixes an issue where dates weren't being validate [SE-7622]
 * Fixes NPE thrown by the raml java parser [RP-253]
+
+== March 21, 2018
+
+3.8.6, 3.8.5, 3.8.4, and 3.8.1 Runtime Updates come with the following enhancement:
+
+* Adds more properties in batch notifications when using Insights
 
 == February 26, 2018
 


### PR DESCRIPTION
* Updated March 29 2018-> March 28 2018.
* Updated April 2 2018 -> March 30 2018.
* Updated April 3 2018 -> March 29 2018.
* Added fixes for 3.8.x for batch improvements.
* Added warning log fix to 3.8.x runtimes.