### PR TITLE
Update anypoint-mq-connector-reference.adoc

### DIFF
--- a/mule-user-guide/v/3.8/anypoint-mq-connector-reference.adoc
+++ b/mule-user-guide/v/3.8/anypoint-mq-connector-reference.adoc
@@ -439,7 +439,7 @@ Lets you set the number of messages to receive at once when asking for messages.
 
 When you subscribe a flow to an Anypoint MQ queue, the flow pool regularly polls the queue looking for messages. This operation can be very time consuming. In order to avoid delays, prefetch was introduced. This is a component placed between the flow and the Anypoint MQ queue that polls the queue regularly, but without processing the pooled messages. You can change these values depending on your site's performance and use case needs.
 
-Currently you can only use the global prefetch configuration and it's not possible to use it within the connector's configurations (anypoint-mq:config).
+*Note:* Only the global prefetch configuration is supported; however Prefetch within a connector's configuration (anypoint-mq:config) is not supported.
 
 The Prefetch tab fields are:
 

--- a/mule-user-guide/v/3.8/anypoint-mq-connector-reference.adoc
+++ b/mule-user-guide/v/3.8/anypoint-mq-connector-reference.adoc
@@ -439,6 +439,8 @@ Lets you set the number of messages to receive at once when asking for messages.
 
 When you subscribe a flow to an Anypoint MQ queue, the flow pool regularly polls the queue looking for messages. This operation can be very time consuming. In order to avoid delays, prefetch was introduced. This is a component placed between the flow and the Anypoint MQ queue that polls the queue regularly, but without processing the pooled messages. You can change these values depending on your site's performance and use case needs.
 
+Currently you can only use the global prefetch configuration and it's not possible to use it within the connector's configurations (anypoint-mq:config).
+
 The Prefetch tab fields are:
 
 [%header,cols="25s,75a"]


### PR DESCRIPTION
After discussion with engineering team, as per JIRA SE-5917 we won't fix this issue, Thus currently you can only use the global prefetch configuration and it's not possible to use it within the connector's configurations (anypoint-mq:config).
I didn't add it to notes as I think it's important to know at first look/read.
Applicaple to both to 3.8.x and 3.9.x