### PR TITLE
customer need to know they can no longer revert back to the old versi…

### DIFF
--- a/runtime-manager/v/latest/managing-applications-on-cloudhub.adoc
+++ b/runtime-manager/v/latest/managing-applications-on-cloudhub.adoc
@@ -123,6 +123,8 @@ If you can see the application name, but the name is not a live link, your admin
 == Updating Your Application
 
 If you made changes to your applications and would like to upload a new version, click *Choose file* on the Deployment screen for that application. The new filename appears in italicized text. Click *Apply changes* to use the new file for deployment. Within a few seconds, your application successfully redeploys. While redeploying, the application status indicator changes to blue, and then turns green after the deployment completes. You can click *Logs* to see a live redeployment of your application.
+Please note after successfully starting new worker with the application's latest version, CloudHub will overwrite the previous version and you can no longer download the previous archive or revert back to the previous version of application.
+
 
 === Zero Downtime Updates with CloudHub
 


### PR DESCRIPTION
…on of application

customer needs to know they can no longer revert back to the old version of application after successful deployment of new version in new worker. also they will lose the old zip/archive.