### PR TITLE
fixing example code for munit matchers

### DIFF
--- a/munit/v/2.1/munit-matchers.adoc
+++ b/munit/v/2.1/munit-matchers.adoc
@@ -28,39 +28,39 @@ These matchers are:
 
 | <<core-matchers-reference.adoc#nullvalue,nullValue()>>
 |  Checks that the expression is null.
-|  * `#[MunitTools::nullValue()`
+|  * `#[MunitTools::nullValue()]`
 
 | <<core-matchers-reference.adoc#notnullvalue,notNullValue()>>
 | Checks that the expression is not null.
-| * `#[MunitTools::notNullValue()`
+| * `#[MunitTools::notNullValue()]`
 
 | <<core-matchers-reference.adoc#withmediatype-string,withMediaType(String)>>
 | Checks that the expression’s media type is the one specified.
-| *  `#[MunitTools::withMediaType(‘text/xml’)`
+| *  `#[MunitTools::withMediaType('text/xml')]`
 
 | <<core-matchers-reference.adoc#withencoding-string,withEncoding(String)>>
 | Checks that the expression’s encoding is the one specified.
-| *  `#[MunitTools::withEncoding(‘UTF-8’)`
+| *  `#[MunitTools::withEncoding('UTF-8')]`
 
 | <<core-matchers-reference.adoc#both-matcher-matcher,both(Matcher, Matcher)>>
 | Checks that both provided matchers are successful.
-| *  `#[MunitTools::both(MunitTools::notNullValue(),MunitTools::equalTo(‘example’))`
+| *  `#[MunitTools::both(MunitTools::notNullValue(),MunitTools::equalTo('example'))]`
 
 | <<core-matchers-reference.adoc#either-matcher-matcher,either(Matcher,Matcher)>>
 | Checks that at least one of the matchers is successful.
-| *  `#[MunitTools::either(MunitTools::nullValue(),MunitTools::equalTo(0))`
+| *  `#[MunitTools::either(MunitTools::nullValue(),MunitTools::equalTo(0))]`
 
 | <<core-matchers-reference.adoc#not-matcher,not(Matcher)>>
 | Checks if the provided matcher is not successful.
-| *  `#[MunitTools::not(MunitTools::equalTo(0))`
+| *  `#[MunitTools::not(MunitTools::equalTo(0))]`
 
 | <<core-matchers-reference.adoc#anyof-matchers,anyOf(Matchers[])>>
 | Checks if any of the matchers are successful.
-| *  `#[MunitTools::anyOf(MunitTools::notNullValue(),MunitTools::withMediaType(‘text/xml’),MunitTools::isEmptyString())`
+| *  `#[MunitTools::anyOf(MunitTools::notNullValue(),MunitTools::withMediaType('text/xml'),MunitTools::isEmptyString())]`
 
 | <<core-matchers-reference.adoc#allof-matchers,allOf(Matchers[])>>
 | Checks if all of the matchers are successful.
-| *  `#[MunitTools::allOf(MunitTools::notNullValue(),MunitTools::withMediaType(‘text/xml’),MunitTools::isEmptyString())`
+| *  `#[MunitTools::allOf(MunitTools::notNullValue(),MunitTools::withMediaType('text/xml'),MunitTools::isEmptyString())]`
 |===
 
 
@@ -82,15 +82,15 @@ These matchers are:
 
 | <<string-matchers-reference.adoc#containsstring-string,containsString(String)>>
 | Checks that the expression contains the specified String.
-| *  `#[MunitTools::containsString(‘example’)]`
+| *  `#[MunitTools::containsString('example')]`
 
 | <<string-matchers-reference.adoc#startswith-string,startsWith(String)>>
 | Checks that the expression starts with the specified String.
-| * `#[MunitTools::startsWith(‘exam’)]`
+| * `#[MunitTools::startsWith('exam')]`
 
 | <<string-matchers-reference.adoc#endswith-string,endsWith(String)>>
 | Checks that the expression ends with the specified String.
-| * `#[MunitTools::endsWith(‘ple’)]`
+| * `#[MunitTools::endsWith('ple')]`
 
 
 | <<string-matchers-reference.adoc#isemptystring,isEmptyString()>>
@@ -103,15 +103,15 @@ These matchers are:
 
 | <<string-matchers-reference.adoc#equaltoignoringcase-string,equalToIgnoringCase(String)>>
 | Checks that the expression is equal to the specified String, ignoring case.
-| * `#[MunitTools::equalToIgnoringCase(‘Example’)]`
+| * `#[MunitTools::equalToIgnoringCase('Example')]`
 
 | <<string-matchers-reference.adoc#equaltoignoringwhitespace-string,equalToIgnoringWhiteSpace(String)>>
 | Checks that the expression is equal to the string disregarding leading and trailing white spaces, and compression all inner white spaces to a single space.
-| * `#[MunitTools::equalToIgnoringWhiteSpace(‘An Example’)]`
+| * `#[MunitTools::equalToIgnoringWhiteSpace('An Example')]`
 
 | <<string-matchers-reference.adoc#stringcontainsinorder-array-string,stringContainsInOrder(>)>>
 | Checks that the expression contains all of the specified substrings, regardless of the order of their appearance.
-| * `#[MunitTools::stringContainsInOrder(‘an’, ‘example’)]`
+| * `#[MunitTools::stringContainsInOrder('an', 'example')]`
 
 |===
 
@@ -162,8 +162,8 @@ In other words, checks that the expression belongs to the range defined by the f
 | <<comparable-matchers-reference.adoc#equalto-object,equalTo(Object)>>
 | Checks that the expression is equal to a specific value. +
 This matcher also accepts Dataweave objects.
-| * `#[MunitTools::equalTo(‘example’)]`
-* `#[MunitTools::equalTo({example1: 1 , example2 :2}]`
+| * `#[MunitTools::equalTo('example')]`
+* `#[MunitTools::equalTo({example1: 1 , example2: 2}]`
 
 |===
 
@@ -199,7 +199,7 @@ This matcher only works for Arrays.
 --
 
 | *  `#[MunitTools::everyItem(MunitTools::notNullValue())]`
-* `#[MunitTools::everyItem(MunitTools::startsWith(‘a’))]`
+* `#[MunitTools::everyItem(MunitTools::startsWith('a'))]`
 
 
 | <<iterable-map-matchers-reference.adoc#hasitem-matcher,hasItem(Matcher)>>
@@ -211,12 +211,12 @@ This matcher only works for Arrays.
 --
 
 | *  `#[MunitTools::hasItem(MunitTools::notNullValue())]`
-* `#[MunitTools::hasItem(MunitTools::startsWith(‘a’))]`
+* `#[MunitTools::hasItem(MunitTools::startsWith('a'))]`
 
 | <<iterable-map-matchers-reference.adoc#hassize-matcher,hasSize(Matcher)>>
 | Checks that the size of the expression matches the specified matcher.
 | *  `#[MunitTools::hasSize(MunitTools::equalTo(5))]`
-* `#[MunitTools::hasSize(MunitTools::startsWith(‘a’))]`
+* `#[MunitTools::hasSize(MunitTools::startsWith('a'))]`
 
 | <<iterable-map-matchers-reference.adoc#isempty,isEmpty()>>
 | Checks that the expression is an empty collection.
@@ -231,8 +231,8 @@ This matcher only works for Arrays.
 This matcher only works for Maps.
 --
 
-| *  `#[MunitTools::hasKey(MunitTools::equalTo(‘myKey’))]`
-* `#[MunitTools::hasKey(MunitTools::startsWith(‘a’))]`
+| *  `#[MunitTools::hasKey(MunitTools::equalTo('myKey'))]`
+* `#[MunitTools::hasKey(MunitTools::startsWith('a'))]`
 
 | <<iterable-map-matchers-reference.adoc#hasvalue-matcher,hasValue(Matcher)>>
 | Checks that the expression has a value that matches the specified matcher.
@@ -242,8 +242,8 @@ This matcher only works for Maps.
 This matcher only works for Maps.
 --
 
-| *  `#[MunitTools::hasValue(MunitTools::equalTo(‘myValue’)]`
-* `#[MunitTools::hasValue(MunitTools::startsWith(‘a’))]`
+| *  `#[MunitTools::hasValue(MunitTools::equalTo('myValue')]`
+* `#[MunitTools::hasValue(MunitTools::startsWith('a'))]`
 
 |===
 


### PR DESCRIPTION
some were with strange quotes, others missing square bracket on end