### PR TITLE
Remove duplicated instructions

### DIFF
--- a/api-manager/v/2.x/classify-api-task.adoc
+++ b/api-manager/v/2.x/classify-api-task.adoc
@@ -3,7 +3,7 @@
 
 After you upgrade to API Manager 2.x your APIs are placed in an unclassified environment. You need to classify unclassified APIs to govern or otherwise manage the APIs.
 
-Even though API Manager supports tracking APIs with both organization and environment credentials, MuleSoft recommends using environment credentials since the permissions associated to them are more restrictive. You need to restart Mule Runtime after changing credentials. Restarting can cause downtime. 
+Even though API Manager supports tracking APIs with both organization and environment credentials, MuleSoft recommends using environment credentials since the permissions associated to them are more restrictive. You need to restart Mule Runtime after changing credentials. Restarting can cause downtime. See link:/api-manager/classify-api-task[Advanced Classification to Configure Mule Servers with Environment Credentials (Optional)] below for details on how to change them. After doing so, you may classify your API as normal into the environment that API Manager will suggest.
 
 Using credentials from one environment does not allow:
 
@@ -45,7 +45,6 @@ image::classify-instance.png[]
 
 ////
 Two-step classification is no longer necessary.
-////
 
 == Two-Step Classification Approach
 
@@ -143,6 +142,7 @@ Updating standalone Runtimes:
 === To Complete API Classification
 
 After updating the server, when the application is up and running again,
+////
 
 ////
 A classification suggestion appears in the API list. Click the suggestion and follow the instructions.
@@ -236,6 +236,7 @@ Updating standalone runtimes:
 ** anypoint.platform.client_secret
 +
 . Restart Mule Runtime.
+
 
 == See Also
 

--- a/api-manager/v/2.x/classify-api-task.adoc
+++ b/api-manager/v/2.x/classify-api-task.adoc
@@ -3,7 +3,7 @@
 
 After you upgrade to API Manager 2.x your APIs are placed in an unclassified environment. You need to classify unclassified APIs to govern or otherwise manage the APIs.
 
-Even though API Manager supports tracking APIs with both organization and environment credentials, MuleSoft recommends using environment credentials since the permissions associated to them are more restrictive. You need to restart Mule Runtime after changing credentials. Restarting can cause downtime. See link:/api-manager/classify-api-task[Advanced Classification to Configure Mule Servers with Environment Credentials (Optional)] below for details on how to change them. After doing so, you may classify your API as normal into the environment that API Manager will suggest.
+Even though API Manager supports tracking APIs with both organization and environment credentials, MuleSoft recommends using environment credentials since the permissions associated to them are more restrictive. You need to restart Mule Runtime after changing credentials. Restarting can cause downtime. See link:/api-manager/classify-api-task[Advanced Classification to Configure Mule Servers with Environment Credentials (Optional)] below for details on how to change them. After doing so, you may classify your API to an environment that API Manager will suggest.
 
 Using credentials from one environment does not allow:
 
@@ -236,7 +236,6 @@ Updating standalone runtimes:
 ** anypoint.platform.client_secret
 +
 . Restart Mule Runtime.
-
 
 == See Also
 


### PR DESCRIPTION
There were two sections explaining pretty much the same thing. So, I've:
- commented one of them out, and 
- added a small comment beforehand to point to it, and let the user know that they will still need to manually classify the API after the runtime has been configured with the environment credentials.