### PR TITLE
Update link on File Connector Doc

### DIFF
--- a/connectors/v/latest/file-documentation.adoc
+++ b/connectors/v/latest/file-documentation.adoc
@@ -388,7 +388,7 @@ Polls a directory looking for files that have been created or updated. One messa
 [cols=".^50%,.^50%"]
 |======================
 | *Type* a| Binary
-| *Attributes Type* a| <<FileAttributes>>
+| *Attributes Type* a| <<LocalFileAttributes>>
 |======================
 
 ==== For Configurations.


### PR DESCRIPTION
There is a broken link for FileAttributes in the "On New or Updated File" operation.  This should point to LocalFileAttributes instead