### PR TITLE
Remove jira from Mule Maven Plugin 3.1.0 release notes

### DIFF
--- a/release-notes/v/latest/mule-maven-plugin-3.1.0-release-notes.adoc
+++ b/release-notes/v/latest/mule-maven-plugin-3.1.0-release-notes.adoc
@@ -66,7 +66,6 @@ Finally we’ve added a number of extra validations to ensure that we stop any p
 * MMP-289 - Some tests fail in Windows due to test set up errors.
 * MMP-275 - Project dependencies is not really necessary.
 * MMP-90 - Change user-agent of jersey client.
-* MMP-260 - Check that application uploaded to cloudhub is started.
 * MMP-309 - Validate plugin compatibility between apps and domains.
 * MMP-330 - Update default values on CH deployer since new changes on last release.
 * MMP-310 - Remove httpClient exclusion.


### PR DESCRIPTION
This jira is for a feature that isn't fully completed at the moment  and we need to remove it from the release notes to prevent users for asking about it.