### PR TITLE
Design Center is not compatible with API Sync

### DIFF
--- a/anypoint-studio/v/6/api-sync-reference.adoc
+++ b/anypoint-studio/v/6/api-sync-reference.adoc
@@ -2,7 +2,7 @@
 :keywords: api, anypoint platform, sync, api sync
 
 
-In API Sync View, you pull, push, and compare your API definition in Anypoint Studio and link:/api-manager/designing-your-api[API Designer] or link:/design-center/v/1.0/designing-api-about[Design Center], depending on which link:/getting-started/api-lifecycle-overview#which-version[version of API Lifecycle tools] you can use. 
+In API Sync View, you pull, push, and compare your API definition in Anypoint Studio and link:/api-manager/designing-your-api[API Designer]. 
 
 == How to Show It
 


### PR DESCRIPTION
Removed reference to Design Center, as API sync does not currently work with Design Center.