### PR TITLE
Example yaml had typo for the type

### DIFF
--- a/api-manager/v/2.x/develop-custom-policies-reference.adoc
+++ b/api-manager/v/2.x/develop-custom-policies-reference.adoc
@@ -89,7 +89,7 @@ name: My Custom Policy
 supportedPoliciesVersions: '>=v1'
 description: The custom policy description
 category: Custom
-type: syscustomtem
+type: custom
 resourceLevelSupported: true
 standalone: true
 requiredCharacteristics: []


### PR DESCRIPTION
Example yaml had typo for the type