### PR TITLE
Added Hostname for Exchange assets

### DIFF
--- a/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
@@ -843,6 +843,7 @@ These tables show you the ports or IPs/hostnames to add to your whitelists to al
 |*mule-manager.anypoint.mulesoft.com* | 443
 |*analytics-ingest.anypoint.mulesoft.com* |  443
 |*arm-auth-proxy.prod.cloudhub.io* |  443
+|*exchange2-asset-manager-kprod.s3.amazonaws.com* |   443
 |===
 
 *Static IPs*


### PR DESCRIPTION
Not sure if this is going to change but Exchange assets are stored in S3 and the hostname needs to be whitelisted in order for policies to be applied.