### PR TITLE
Line 351. Configuring was spelled without a "g"

### DIFF
--- a/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
+++ b/runtime-manager/v/latest/cloudhub-dedicated-load-balancer.adoc
@@ -348,7 +348,7 @@ The whitelist works for inbound connections at the load balancer level, not at t
 [TIP]
 In order to be able to create and configure a load balancer, your profile needs to be an administrator of the organization to which the load balancer is associated.
 
-There are three ways of creating and configurin a dedicated load balancer for your VPC:
+There are three ways of creating and configuring a dedicated load balancer for your VPC:
 
 . Using the link:/runtime-manager/anypoint-platform-cli#cloudhub-load-balancer-create[cloudhub load-balancer create] command from the *Anypoint Platform Command Line Interface*
 . Using the link:/runtime-manager/runtime-manager-api[Cloudhub API] through the endpoints `anypoint.mulesoft.com/cloudhub/api/organizations/{orgid}/loadbalancers` and `anypoint.mulesoft.com/cloudhub/api/organizations/{orgid}/vpcs`.


### PR DESCRIPTION
Line 351. Configuring was spelled without a "g" at the end.