### PR TITLE
Add reference to API Manager's post-upgrade APIs

### DIFF
--- a/release-notes/v/latest/upgrade.adoc
+++ b/release-notes/v/latest/upgrade.adoc
@@ -145,7 +145,7 @@ What’s new:
 === APIs in API Manager Changes After the Upgrade
 
 * APIs utilizing an autodiscovery element now use API Manager instead.
-* API Manager API can be used with APIs in the unclassified environment with some restrictions (see below).
+* The pre-upgrade API Manager API can be used with APIs in the unclassified environment with some restrictions (see below). There are also new environment-aware APIs, which also support the unclassified environment, that you may start using (see the link:https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/api-manager-api/1.0.2/console/summary/[new API Manager portal] and the link:https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/proxies-xapi/1.0.1/[Proxies xAPI portal]).
 * Because the upgrading to the latest software is moving all portals and RAMLs cannot be used to modify, create, or delete them after the upgrade. After the upgrade, the API Manager API v2.x changes its behavior in the following way:
 ** The following resources for managing RAMLs return 400. Use Design Center APIs instead.
 +
@@ -222,11 +222,11 @@ See the https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/[Mu
 The CloudHub Public API enables you to access application management services for applications deployed to CloudHub.
 |API Platform / API Manager |https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/api-platform-api/[API Platform API] |https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/api-manager-api/[API Manager v1]
 
-The API Manager API enables you to manage an API by applying policies, setting SLAs, configuring alerts for your API instances, and promoting API instances.
+The API Manager API enables you to manage an API, unclassified or in any environment, by applying policies, setting SLAs, configuring alerts for your API instances, and promoting API instances.
 
 https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/api-platform-api/[API Platform v2]
 
-The API Platform API exposes the management capabilities of the Anypoint Platform for APIs, enabling them to be used by external sites.
+The API Platform API offers backwards compatibility with the pre-upgrade API to some extent (see section <<APIs in API Manager Changes After the Upgrade>> for more information on what is no longer supported after the upgrade).
 |Anypoint Runtime Manager (ARM) |https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/ae639f94-da46-42bc-9d51-180ec25cf994/apis/38784/versions/127446/pages/182845[ARM APIs] |https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services/[ARM Rest Services]
 |Exchange |https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/apis/11181/versions/78579/pages/114971[Anypoint Exchange - 1.6.1] |https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/exchange-experience-api/[Exchange Experience API] 
 
@@ -241,8 +241,8 @@ https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-31
 The Exchange Maven Facade API lets you interact with Exchange using the Maven client to publish and consume Exchange assets as Maven dependencies.
 
 You can use the Exchange Maven Facade API for Mule applications, templates, examples, connectors or policies. RAML API specifications are not supported, use the Design Center xAPI to publish those assets.
-|Proxies |N/A |The Proxies XAPI allows you to download or deploy proxies into Runtime Manager.
-https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/proxies-xapi/[Proxies API v1]
+|Proxies |N/A |The Proxies xAPI allows you to download or deploy proxies into Runtime Manager.
+https://anypoint.mulesoft.com/exchange/portals/anypoint-platform-eng/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/proxies-xapi/[Proxies xAPI v1]
 |===
 
 == See Also


### PR DESCRIPTION
This adds a reference to the new API Manager API's, and other minor fixes.