### PR TITLE
Removed reference to Description attribute

### DIFF
--- a/anypoint-exchange/v/latest/to-find-info.adoc
+++ b/anypoint-exchange/v/latest/to-find-info.adoc
@@ -26,9 +26,7 @@ the HTTP functions in the REST specification.
 == About Exchange Search
 
 Search lets you find Exchange assets that contain one or more terms 
-in an asset title, asset ID, or a tag in an asset. Assets
-that were migrated from Exchange 1 also include the description text
-in searches. You can also combine search terms with the filters listed in All Types.
+in an asset title, asset ID, or a tag in an asset. You can also combine search terms with the filters listed in All Types.
 Searches only apply to the Exchange you are viewing. 
 If you search in a private Exchange, the search only lists the
 private Exchange assets and not public Exchange assets.


### PR DESCRIPTION
Due to the noise that it produces, I've removed the reference to the description attribute for assets that came from Exchange 1