### PR TITLE
preferred authentication valid values incorrect

### DIFF
--- a/connectors/v/latest/sftp-documentation.adoc
+++ b/connectors/v/latest/sftp-documentation.adoc
@@ -50,7 +50,7 @@ An FileSystemProvider which provides instances of SftpFileSystem from instances 
 ** GSSAPI_WITH_MIC
 ** PUBLIC_KEY
 ** KEYBOARD_INTERACTIVE
-** PASSWORD |  +++Set of authentication methods used by the SFTP client. Valid values are: gssapi-with-mic, publickey, keyboard-interactive and password.+++ |  | {nbsp}
+** PASSWORD |  +++Set of authentication methods used by the SFTP client. Valid values are: SSAPI_WITH_MIC, PUBLIC_KEY, KEYBOARD_INTERACTIVE and PASSWORD.+++ |  | {nbsp}
 | Known Hosts File a| String |  +++If provided, the client will validate the server's key against the one in the referenced file. If the server key doesn't match the one in the file, the connection will be aborted.+++ |  | {nbsp}
 | Sftp Proxy Config a| <<SftpProxyConfig>> |  +++If provided, a proxy will be used for the connection.+++ |  | {nbsp}
 | Connection Timeout a| Number |  +++A scalar value representing the amount of time to wait before a connection attempt times out. This attribute works in tandem with #connectionTimeoutUnit. <p> Defaults to 10+++ |  +++10+++ | {nbsp}


### PR DESCRIPTION
The preferred authentication valid values must be entered in uppercase, otherwise the application throws and error and will be unable to connect. Also raised a bug report on this as incorrect values are displaying in studio also