### PR TITLE
Update munit-short-tutorial.adoc

### DIFF
--- a/munit/v/1.1/munit-short-tutorial.adoc
+++ b/munit/v/1.1/munit-short-tutorial.adoc
@@ -237,7 +237,7 @@ http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/cor
     </munit:test>
 
     <munit:test name="doc-test-exampleFlow-functionalTest_2" description="Funtional Test case asserting scenario 2">
-        <munit:set payload="#['']" doc:name="Set Message url_key:payload_1">
+        <munit:set payload="#['']" doc:name="Set Message url_key:payload_2">
             <munit:inbound-properties>
                 <munit:inbound-property key="http.query.params" value="#[['url_key':'payload_2']]"/>
             </munit:inbound-properties>


### PR DESCRIPTION
Fixed XML definition of 'MUnit Test Suite file - doc-test.xml'. Changed display name of second functional test to 'Set Message url_key:payload_2' to more accurately reflect what the the payload is actually being set to.