### PR TITLE
Changed as :number to as :string

### DIFF
--- a/mule-user-guide/v/3.9/dataweave-examples.adoc
+++ b/mule-user-guide/v/3.9/dataweave-examples.adoc
@@ -994,13 +994,13 @@ invoice: {
             description: $.description,
             quantity: $.quantity,
             unit_price: $.unit_price,
-            discount: (discount * 100) as :number { format: "##" } ++ "%",
+            discount: (discount * 100) as :string { format: "##" } ++ "%",
             subtotal: $.unit_price * $.quantity * (1 - discount)
         }
     }) },
     totals: using (subtotal = payload.invoice.items reduce ((item, sum1 = 0) -> sum1 + (item.unit_price * item.quantity * (1 - discount)))) {
         subtotal: subtotal,
-        tax: (tax * 100) as :number { format: "##.#" } ++ "%",
+        tax: (tax * 100) as :string { format: "##.#" } ++ "%",
         total: subtotal * (1 + tax)
     }
 }


### PR DESCRIPTION
The transformation didn't work as it was expected in the documentation given that the String can be formatted, not the Number.