### PR TITLE
Update salesforce-connector.adoc

### DIFF
--- a/mule-user-guide/v/3.9/salesforce-connector.adoc
+++ b/mule-user-guide/v/3.9/salesforce-connector.adoc
@@ -79,15 +79,6 @@ See the link:/release-notes/salesforce-connector-release-notes[Salesforce Connec
 *Notes:*
 
 * Starting with v.7.0.0, the Salesforce connector is licensed commercially with Anypoint Platform as are other link:/mule-user-guide/v/3.8/anypoint-connectors#connector-categories[_Select_] connectors.  Prior versions will remain freely available to the community.
-* Following the release of Mule 3.8.5, the SFTP Connector can connect via a proxy. The SFTP Connector supports connections through a proxy from Mule Runtime 3.8.5 and higher. For older versions of the product, a patch may be requested to achieve this configuration.
-
-The following properties can be set in the Environment to support a proxy configuration:
-
-* mule.sftp.proxy.host 
-* mule.sftp.proxy.port 
-* mule.sftp.proxy.protocol (can be: HTTP, SOCKS4 or SOCKS5) 
-* mule.sftp.proxy.username (if required) 
-* mule.sftp.proxy.password (if required)
 
 === Configuring Maven Dependencies
 


### PR DESCRIPTION
Not sure how SFTP configuration information is relevant to the Salesforce Connector.  If it truly is relevant, then the documentation should be updated to make such a relevancy more apparent to the reader; otherwise such SFTP documentation should be discarded from the Salesforce documentation altogether, as I have done here.