### PR TITLE
Removed reference to undocumented Node connector uploader application

### DIFF
--- a/anypoint-exchange/v/latest/to-create-an-asset.adoc
+++ b/anypoint-exchange/v/latest/to-create-an-asset.adoc
@@ -9,7 +9,7 @@ How you create an asset depends on its type.
 * For OAS 2.0, HTTP, WSDL, and Custom assets, create the asset directly using the Exchange *New* menu.
 * For a RAML specification, first use Design Center, and publish the API to Exchange. You can also publish RAMLs programatically using the Exchange Experience API. 
 * For an example or template, create each using the Mavenize feature in Anypoint Studio, and publish each to Exchange.
-* For a connector, use the source JAR, POM, and Studio Plugin zip for the connector with the Node.js Connector Uploader application to publish to Exchange.
+* For a connector, use the source JAR, POM, and Studio Plugin zip for the connector with the link:/anypoint-exchange/to-publish-assets-maven[Maven facade]
 
 Each asset in Exchange is versioned. You can manage which versions are visible by deprecating a version to hide it, and you can delete versions if needed. 
 

--- a/anypoint-exchange/v/latest/to-create-an-asset.adoc
+++ b/anypoint-exchange/v/latest/to-create-an-asset.adoc
@@ -9,7 +9,7 @@ How you create an asset depends on its type.
 * For OAS 2.0, HTTP, WSDL, and Custom assets, create the asset directly using the Exchange *New* menu.
 * For a RAML specification, first use Design Center, and publish the API to Exchange. You can also publish RAMLs programatically using the Exchange Experience API. 
 * For an example or template, create each using the Mavenize feature in Anypoint Studio, and publish each to Exchange.
-* For a connector, use the source JAR, POM, and Studio Plugin zip for the connector with the link:/anypoint-exchange/to-publish-assets-maven[Connector uploader application].
+* For a connector, see link:/anypoint-exchange/to-publish-assets-maven[To Publish and Deploy Exchange Assets Using Maven].
 
 Each asset in Exchange is versioned. You can manage which versions are visible by deprecating a version to hide it, and you can delete versions if needed. 
 

--- a/anypoint-exchange/v/latest/to-create-an-asset.adoc
+++ b/anypoint-exchange/v/latest/to-create-an-asset.adoc
@@ -9,7 +9,7 @@ How you create an asset depends on its type.
 * For OAS 2.0, HTTP, WSDL, and Custom assets, create the asset directly using the Exchange *New* menu.
 * For a RAML specification, first use Design Center, and publish the API to Exchange. You can also publish RAMLs programatically using the Exchange Experience API. 
 * For an example or template, create each using the Mavenize feature in Anypoint Studio, and publish each to Exchange.
-* For a connector, use the source JAR, POM, and Studio Plugin zip for the connector with the link:/anypoint-exchange/to-publish-assets-maven[Maven facade]
+* For a connector, use the source JAR, POM, and Studio Plugin zip for the connector with the link:/anypoint-exchange/to-publish-assets-maven[Connector uploader application].
 
 Each asset in Exchange is versioned. You can manage which versions are visible by deprecating a version to hide it, and you can delete versions if needed. 
 


### PR DESCRIPTION
Currently the Maven facade is the recommended way to publish connectors to Exchange in Mule 3 and 4.  We should not have documentation pointing at a different tool until it is released and documented.