### PR TITLE
http-load-static-res-task.adoc - How to use relative paths

### DIFF
--- a/connectors/v/latest/http-load-static-res-task.adoc
+++ b/connectors/v/latest/http-load-static-res-task.adoc
@@ -11,7 +11,8 @@
 . From the Mule Palette, drag HTTP > Load Static Resource to the flow. 
 . Configure the load static resource operation:
 * Set the resource base path to the path and file name of the resource. For example, set the path to */Users/max/Sites/index.html*.
-* Set the default file to the name of a backup file in the same directory as the resource. 
+* Set the default file to the name of a backup file in the same directory as the resource.
+* If you need to use a relative path to the Mule project, use the variable ${app.home}. i.e. resourceBasePath="${app.home}/images/"
 +
 In the event of a failure, the app loads the backup file.
 +

--- a/connectors/v/latest/http-load-static-res-task.adoc
+++ b/connectors/v/latest/http-load-static-res-task.adoc
@@ -12,7 +12,7 @@
 . Configure the load static resource operation:
 * Set the resource base path to the path and file name of the resource. For example, set the path to */Users/max/Sites/index.html*.
 * Set the default file to the name of a backup file in the same directory as the resource.
-* If you need to use a relative path to the Mule project, use the variable ${app.home}. i.e. resourceBasePath="${app.home}/images/"
+* If you need to use a relative path to the Mule project, use the variable `${app.home}` (for example, `resourceBasePath="${app.home}/images/"`).
 +
 In the event of a failure, the app loads the backup file.
 +


### PR DESCRIPTION
Clarification to use relative paths. This is not clear and generated some support cases