### PR TITLE
Update how-to-export-resources.adoc

### DIFF
--- a/mule4-user-guide/v/4.1/how-to-export-resources.adoc
+++ b/mule4-user-guide/v/4.1/how-to-export-resources.adoc
@@ -1,10 +1,10 @@
 = How to Export Resources
 
-Mule Applications, Mule Domains and Mule Policies contain a set of resources which may be properties files, dataweave transformation files, java classes, etc. By default all of these files are internal to the artifact in which they are defined and can't be accesible from other artifacts. For instance, a resource defined at the domain level, if it's not exported, it can't be accesed within the applications that belong to that domain. Another example are classes from an application that are meant to be used by the java module. If those clases are not exported then the java module won't be able to access them.
+Mule Applications, Mule Domains and Mule Policies contain a set of resources which may be properties files, DataWeave transformation files, Java classes, etc. By default, all of these files are internal to the artifact in which they are defined, and as a result, they are inaccessible from other artifacts. For instance, if a resource defined at the domain level is not explicitly exported, then it cannot be accessed from within any of the applications that belong to that shared domain. Another example is classes from an application that are meant to be used by the Java module. If those classes are not exported, then the Java module will not be able to access them.
 
-== How to export java classes
+== How to export Java classes
 
-To export java classes use the `exportedPackages` field of the `mule-artifact.json` file of your artifact. Have in mind that only complete packages can be exported and not individual classes.
+To export Java classes, use the `exportedPackages` field of the `mule-artifact.json` file of your artifact. Keep in mind that only complete packages can be exported and not individual classes.
 
 [source, json, linenums]
 ----
@@ -23,14 +23,14 @@ To export java classes use the `exportedPackages` field of the `mule-artifact.js
 }
 ----
 
-CAUTION: Export the minimum number of classes required for your application to work. This will diminish the likelyhood of conflicts with other artifacts like modules or connectors that you may be using within your application.
+CAUTION: Export the minimum number of classes required for your application to work. This will reduce the likelihood of conflicts with other artifacts, such as modules or connectors, that you may be using within your application.
 
-TIP: Try to use `.api.` within public packages and `.internal.` within your non public pacakges.
+TIP: Try to use `.api.` within public packages and `.internal.` within your non-public packages.
 
 
 == How to export resource files
 
-To export resources use the `exportedResources` filed of the `mule-artifact.json` file of you artifact.
+To export resources, use the `exportedResources` field of the `mule-artifact.json` file for your artifact.
 
 [source, json, linenums]
 ----
@@ -50,4 +50,4 @@ To export resources use the `exportedResources` filed of the `mule-artifact.json
 }
 ----
 
-IMPORTANT: This same mechanism applys to every artifact including extensions develop with the Mule SDK.
+IMPORTANT: This same mechanism applies to every artifact, including custom extensions developed with the Mule SDK.


### PR DESCRIPTION
Minor fixes to typographical, grammar, and spelling mistakes.  Added additional punctuation and changed some wording to improve comprehension.