### PR TITLE
Update packager-concept.adoc

### DIFF
--- a/mule4-user-guide/v/4.1/packager-concept.adoc
+++ b/mule4-user-guide/v/4.1/packager-concept.adoc
@@ -13,7 +13,7 @@ The application package declares its dependencies so that the other components o
 
 Every Mule application has two descriptors. These descriptors tell the packager tool how to handle your Mule application's dependencies.
 
-* A mule-application.json file. +
+* A mule-artifact.json file. +
 This file describes how your application is composed. +
 
 * A pom.xml file. +


### PR DESCRIPTION
Corrected the filename for the artifact JSON configuration file.  

By the way, I think these docs still need additional content to document these "heavy" and "lightweight" package types.  What is significant about these two different package types, and how may we direct the creation of one package type over the other?