### PR TITLE
typo

### DIFF
--- a/anypoint-studio/v/7.1/proxy-settings-task.adoc
+++ b/anypoint-studio/v/7.1/proxy-settings-task.adoc
@@ -17,8 +17,8 @@ If necessary, you can add bypasses to your proxy. This is a list of hosts that s
 Click Add Host... to add hostnames to your proxy bypass list. +
 Keep in mind that when setting a manual provider, you should not disable the default localhost and 127.0.0.1 bypasses. Otherwise the embedded Mule Runtime within Studio won't be able to reach your developing application.
 
-When applying changes to your proxy settings, Anypoint Studio restards the mule instance used to obtain metadata and test outbound connections.
-If this fails, you need to manually restart your instance by going to Preferences > Tooling, and clicking Restart Instance.
+When applying changes to your proxy settings, Anypoint Studio restarts the Mule instance used to obtain metadata and test outbound connections.
+If this fails, manually restart your instance by going to Preferences > Tooling, and clicking Restart Instance.
 
 == See Also
 


### PR DESCRIPTION
Minor typo noticed while inventorying. changed `restards` to `restarts` and capitalized Mule.
Tested locally.

![image](https://user-images.githubusercontent.com/39537186/41684975-f3828558-7493-11e8-975e-c914a0cc47a8.png)
