### PR TITLE
missed these typos

### DIFF
--- a/mule-sdk/v/1.1/xml-sdk.adoc
+++ b/mule-sdk/v/1.1/xml-sdk.adoc
@@ -309,7 +309,7 @@ Note that incorrect credentials return this error response from GitHub:
 | Hides the value of the property value in the UI when typing it (using `\****`).
 
 | `summary`
-| `optional
+| optional
 | NA
 | Adds a small tooltip to the `<property>`.
 
@@ -321,7 +321,7 @@ Note that incorrect credentials return this error response from GitHub:
 | `displayName`
 | `optional`
 | NA
-| Provides a nicer label to the UI, by leaving this attribute empty, the default value will be the `name` attribute hypenized.
+| Provides a nicer label in the UI. By leaving this attribute empty, the default value is a hyphenated version of the `name` attribute.
 
 | `displayName`
 | optional
@@ -371,7 +371,7 @@ The `<module>` element is the root of an XML SDK module. It contains all propert
 | `namespace`
 | optional
 | NA
-| Namespace to use for the module during schema generation. Otherwise, the default is +`http://www.mulesoft.org/schema/mule/<prefix>`+ where `<prefix>` is the `prefix` attribute value.
+| Namespace to use for the module during schema generation. Otherwise, the default is `+http://www.mulesoft.org/schema/mule/<prefix>+` where `<prefix>` is the `prefix` attribute value.
 
 | `doc:description`
 | optional
@@ -397,7 +397,7 @@ You import an XML SDK schema into a Mule app by using the `namespace` attribute.
 
 The generated schema location:
 
-+`http://www.mulesoft.org/schema/a/different/path/mule/hello/current/mule-hello-prefix.xsd`+
+`+http://www.mulesoft.org/schema/a/different/path/mule/hello/current/mule-hello-prefix.xsd+`
 
 .<module> provides `name` and `prefix`
 |===
@@ -413,7 +413,7 @@ The generated schema location:
 | `namespace=http://www.mulesoft.org/schema/mule/hello-prefix`
 |===
 
-Generated schema location: +`http://www.mulesoft.org/schema/mule/hello-prefix/current/mule-hello-prefix.xsd`+
+Generated schema location: `+http://www.mulesoft.org/schema/mule/hello-prefix/current/mule-hello-prefix.xsd+`
 
 .<module> provides just `name`
 |===
@@ -429,9 +429,9 @@ Generated schema location: +`http://www.mulesoft.org/schema/mule/hello-prefix/cu
 | `namespace=http://www.mulesoft.org/schema/mule/hello-with-spaces`
 |===
 
-Generated schema location is `http://www.mulesoft.org/schema/mule/hello-with-spaces/current/mule-hello-with-spaces.xsd`
+Generated schema location is `+http://www.mulesoft.org/schema/mule/hello-with-spaces/current/mule-hello-with-spaces.xsd+`
 
-The following module only has a `name` attribute `name="hello with spaces"`. This means that its `prefix` is dynamically generated as `hello-with-spaces`, and its `namespace` is dynamically generated as +`http://www.mulesoft.org/schema/mule/hello-with-spaces/current/mule-hello-with-spaces.xsd`+. It also means that the Mule app must have a schema location (`schemaLocation`) that points to a reference that matches that value.
+The following module only has a `name` attribute `name="hello with spaces"`. This means that its `prefix` is dynamically generated as `hello-with-spaces`, and its `namespace` is dynamically generated as `+http://www.mulesoft.org/schema/mule/hello-with-spaces/current/mule-hello-with-spaces.xsd+`. It also means that the Mule app must have a schema location (`schemaLocation`) that points to a reference that matches that value.
 
 [source,xml,linenums]
 ----
@@ -582,7 +582,7 @@ For example, for an XML SDK module to use the HTTP connector and the OAuth modul
 ----
 
 == Reusing Operations
-In some cases, operations will have repeated message processors, to which we could rely if they were encapsulated in an new operation and call it from other places.
+In some cases, operations have repeated message processors, on which we can rely if they are encapsulated in a new operation and called from other places.
 
 Each `<operation>` defined in a `<module>` can be reused in the _same_ `<module>` if the operation does not have cyclic dependencies.
 
@@ -714,13 +714,13 @@ Note that the value must map the target namespace of the current module.
 </module>
 ----
 
-Note that the `config-ref` is not included because this is a reference to the _same_ module, which implies all global instances will be shared among operations.
+Note that the `config-ref` is not included because this is a reference to the _same_ module, which implies all global instances are shared among operations.
 
 == Providing a Test Connection
 
 At design time, it is helpful to provide feedback when the attributes of a global element are fed with wrong values, such as wrong username or password, bad URLs, and so on. To provide such feedback, your module needs to incorporate a global element that supports connection testing.
 
-For example, the XML SDK module `<module name="module-using-file">` might use the connection testing functionality from the File connector by incorporating the `file:connection` element into the module. By default, the module will pick up and support the connection testing feature from the File configuration.
+For example, the XML SDK module `<module name="module-using-file">` might use the connection testing functionality from the File connector by incorporating the `file:connection` element into the module. By default, the module picks up and supports the connection testing feature from the File configuration.
 
 [source,xml,linenums]
 ----
@@ -741,7 +741,7 @@ For example, the XML SDK module `<module name="module-using-file">` might use th
 
 From the UI, connection testing is delegated to the global element encapsulated by `fileConfig`.
 
-If a module contains two or more global elements that provide a test connection, an error will occur when you build the module unless you mark the global element that you want to use with the `xmlns:connection="true"` attribute, for example:
+If a module contains two or more global elements that provide a test connection, an error occurs when you build the module unless you mark the global element that you want to use with the `xmlns:connection="true"` attribute, for example:
 
 [source,xml,linenums]
 ----
@@ -791,7 +791,7 @@ This example performs error mapping in an operation that divides two numbers:
 </module>
 ----
 
-If the divisor `numberB` is zero, the `div` operation will result in the `MULE:EXPRESSION` runtime error, which does not describe the error specifically enough.
+If the divisor `numberB` is zero, the `div` operation results in the `MULE:EXPRESSION` runtime error, which does not describe the error specifically enough.
 
 To create a more specific error, you can use error mapping to make the `div` operation produce the `MATH-XML-SDK:DIVISION_BY_ZERO` error, for example:
 
@@ -986,7 +986,7 @@ To use the operations from the <<example, example>> above in a Mule app, it is n
 ----
 <mule ...>
   <flow name="person-xml-2-json-flow">
-    <!-- create a XML Person and store it in the payload -->
+    <!-- create an XML Person and store it in the payload -->
     <ee:transform>
       <ee:set-payload><![CDATA[
         %dw 2.0
@@ -1020,7 +1020,7 @@ To use the operations from the <<example, example>> above in a Mule app, it is n
     </ee:transform>
     <!-- call the operation -->
     <module-hello:person-json-to-xml content="#[payload]"/>
-    <!-- at this point, the payload is a XML Person -->
+    <!-- at this point, the payload is an XML Person -->
   </flow>
 </mule>
 ----
@@ -1199,7 +1199,7 @@ GitHub Location: link:https://github.com/mulesoft-labs/smart-connectors-integrat
 
 This example incorporates custom XML types.
 
-GitHub Location: link:https://github.com/mulesoft-labs/smart-connectors-integration-tests/tree/master/smart-connectors/smart-connector-using-custom-types-xsd[smart-connectors/smart-connector-using-custom-types-xsd]`
+GitHub Location: link:https://github.com/mulesoft-labs/smart-connectors-integration-tests/tree/master/smart-connectors/smart-connector-using-custom-types-xsd[smart-connectors/smart-connector-using-custom-types-xsd]
 
 [source,xml,linenums]
 ----


### PR DESCRIPTION
Tested locally. Fixed typos and put the plus sign inside tic marks to make URLs not be links when they are meant to be text.