### PR TITLE
Change year formatting to actual year

### DIFF
--- a/mule-user-guide/v/3.9/dataweave-types.adoc
+++ b/mule-user-guide/v/3.9/dataweave-types.adoc
@@ -479,7 +479,7 @@ You can specify a date to be in any format you prefer through using *as* in the 
 %dw 1.0
 %output application/json
 ---
-formatedDate: |2003-10-01T23:57:59| as :string {format: "YYYY-MM-dd"}
+formatedDate: |2003-10-01T23:57:59| as :string {format: "yyyy-MM-dd"}
 ----------------------------------------------------------------
 
 .Output
@@ -497,7 +497,7 @@ If you are doing multiple similar conversions in your transform, you might want 
 ----------------------------------------------------------------
 %dw 1.0
 %output application/json
-%type mydate = :string { format: "YYYY/MM/dd" }
+%type mydate = :string { format: "yyyy/MM/dd" }
 ---
 {
   formatedDate1: |2003-10-01T23:57:59| as :mydate,


### PR DESCRIPTION
In Java the 'Y' formatting symbol is for week-based-year (ISO week-numbering year), instead of 'y' which is the actual year-of-era (calendar year). Using 'Y' can return a difference of 1 with respect to the calendar year. Users copying from the examples are most probably receiving unexpected results at some time.