### PR TITLE
DOCS-2461 Update deploying-to-cloudhub.adoc

### DIFF
--- a/runtime-manager/v/latest/deploying-to-cloudhub.adoc
+++ b/runtime-manager/v/latest/deploying-to-cloudhub.adoc
@@ -166,7 +166,12 @@ There are worker sizes with different compute and memory capacities:
 |16 vCores |32 GB
 |===
 
-Workers that have less than 1 vCore capacity (0.1 vCores and 0.2 vCores)  offer limited CPU and IO for smaller work loads. Each worker has 8 GB of storage, which is used for both system and application storage. 
+Workers that have less than 1 vCore capacity (0.1 vCores and 0.2 vCores) offer limited CPU and IO for smaller work loads. Each worker has 8 GB of storage, which is used for both system and application storage. 
+
+[NOTE]
+--
+Workers running on fractional vCores (0.1 vCores and 0.2 vCores) have the ability to burst to higher CPU speeds for a short duration of time. This is useful with improving application start up times and with processing infrequently large workloads. Allocating workers with 1 vCore or greater is recommended if consistency of performance is desired.
+--
 
 Applications with greater storage needs (verbose logging etc.) should use one of the larger worker sizes - 2 vCores or 4 vCores, which have additional storage as follows:
 


### PR DESCRIPTION
Added a note to address the burstable behavior of our fractional vcores.