### PR TITLE
Update salesforce-connector-release-notes-mule-4.adoc

### DIFF
--- a/release-notes/v/latest/salesforce-connector-release-notes-mule-4.adoc
+++ b/release-notes/v/latest/salesforce-connector-release-notes-mule-4.adoc
@@ -6,7 +6,9 @@
 _Select_
 
 == 9.2.2
+
 *June 28, 2018*
+
 [%header%autowidth.spread]
 |===
 |Application/Service |Version
@@ -17,10 +19,12 @@ _Select_
 
 === Fixed in this Release
 
-* When making a call to a Salesforce Apex method, if the method doesn't have a parameter, Salesforce connector is not passing the flow payload to the Apex method. Now, the connector is passing it.
+* When making a call to a Salesforce Apex method, if the method didn't have a parameter, Salesforce connector did not pass the flow payload to the Apex method. Now, the connector passes the flow payload.
 
 == 9.2.1
+
 *May 18, 2018*
+
 [%header%autowidth.spread]
 |===
 |Application/Service |Version
@@ -31,14 +35,24 @@ _Select_
 
 === Fixed in this Release
 
-* Salesforce connector not working in EU.  When using Salesforce Connector in EU it throwed an exception:
-```
-Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
-```
+* Salesforce connector was not working in EU.  When using Salesforce Connector in EU, it threw this exception:
++
+[source,xml,linenums]
+----
+Caused by: org.springframework.beans.factory.BeanCreationException: 
+Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager 
+org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; 
+nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: 
+No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: 
+expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
+----
++
 In this version Salesforce Connector works correctly in EU.
 
-== 9.1.2 
+== 9.1.2
+
 *May 18, 2018*
+
 [%header%autowidth.spread]
 |===
 |Application/Service |Version
@@ -49,10 +63,18 @@ In this version Salesforce Connector works correctly in EU.
 
 === Fixed in this Release
 
-* Salesforce connector not working in EU.  When using Salesforce Connector in EU it throwed an exception:
-```
-Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
-```
+* Salesforce connector was not working in EU.  When using Salesforce Connector in EU, it threw this exception:
++
+[source,xml,linenums]
+----
+Caused by: org.springframework.beans.factory.BeanCreationException: 
+Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager 
+org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; 
+nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: 
+No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: 
+expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
+----
++
 In this version Salesforce Connector works correctly in EU.
 
 == 9.2.0

--- a/release-notes/v/latest/salesforce-connector-release-notes-mule-4.adoc
+++ b/release-notes/v/latest/salesforce-connector-release-notes-mule-4.adoc
@@ -1,9 +1,59 @@
 = Salesforce Connector Release Notes
 :keywords: release notes, salesforce, connector
 
-*May 2018*
+*June 2018*
 
 _Select_
+
+== 9.2.2
+*June 28, 2018*
+[%header%autowidth.spread]
+|===
+|Application/Service |Version
+|Mule Runtime |Mule Enterprise Edition 4.1.1 and later
+|Anypoint Studio |Only works with Studio 7.1.0 and later
+|Salesforce |v37.0, v38.0, v39.0, v40.0, v41.0
+|===
+
+=== Fixed in this Release
+
+* When making a call to a Salesforce Apex method, if the method doesn't have a parameter, Salesforce connector is not passing the flow payload to the Apex method. Now, the connector is passing it.
+
+== 9.2.1
+*May 18, 2018*
+[%header%autowidth.spread]
+|===
+|Application/Service |Version
+|Mule Runtime |Mule Enterprise Edition 4.1.1 and later
+|Anypoint Studio |Only works with Studio 7.1.0 and later
+|Salesforce |v37.0, v38.0, v39.0, v40.0, v41.0
+|===
+
+=== Fixed in this Release
+
+* Salesforce connector not working in EU.  When using Salesforce Connector in EU it throwed an exception:
+```
+Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
+```
+In this version Salesforce Connector works correctly in EU.
+
+== 9.1.2 
+*May 18, 2018*
+[%header%autowidth.spread]
+|===
+|Application/Service |Version
+|Mule Runtime |Mule Enterprise Edition 4.1.0 and later
+|Anypoint Studio |Only works with Studio 7.1.0 and later
+|Salesforce |v37.0, v38.0, v39.0, v40.0, v41.0
+|===
+
+=== Fixed in this Release
+
+* Salesforce connector not working in EU.  When using Salesforce Connector in EU it throwed an exception:
+```
+Caused by: org.springframework.beans.factory.BeanCreationException: Could not autowire field: private org.mule.runtime.api.store.ObjectStoreManager org.mule.extension.salesforce.internal.operation.UtilityOperations.objectStoreManager; nested exception is org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type [org.mule.runtime.api.store.ObjectStoreManager] is defined: expected single matching bean but found 2: _muleObjectStoreManager,_muleLocalObjectStoreManager
+```
+In this version Salesforce Connector works correctly in EU.
 
 == 9.2.0
 


### PR DESCRIPTION
Salesforce 9.2.2 released. Also, adding content for older versions that were published without notes.