### PR TITLE
Update migration-dataweave.adoc

### DIFF
--- a/mule4-user-guide/v/4.1/migration-dataweave.adoc
+++ b/mule4-user-guide/v/4.1/migration-dataweave.adoc
@@ -50,11 +50,12 @@ The `when otherwise` statement is replaced by `if else`, for example:
 }
 ----
 
+//TODO: Add another pair of examples to show how to migrate DataWeave 1.0's "unless otherwise" statement
 
 [[dw_flow_control_pattern_matcher]]
 === Pattern Matcher
 
-Pattern matching changed in DataWeave 2. It adds the keyword `case` and `else` (instead of `default`). You also no longer separate cases with commas (`,`) since they are now explicitley separated by the `case` keyword.
+Pattern matching changed in DataWeave 2. It adds the keyword `case` and `else` (instead of `default`). You also no longer separate cases with commas (`,`) since they are now explicitly separated by the `case` keyword.
 
 .Mule 3 Example: DataWeave 1
 [source, linenums]


### PR DESCRIPTION
Fixed a small typo.  Added a TODO suggestion to add a pair of examples to show how to migrate from DataWeave 1.0's "unless otherwise" statement.