### PR TITLE
Fix Graph Service CURL example to fit in one page

### DIFF
--- a/anypoint-exchange/v/latest/to-search-with-graph-api.adoc
+++ b/anypoint-exchange/v/latest/to-search-with-graph-api.adoc
@@ -34,12 +34,68 @@ using the API, send a POST command containing the search string.
 
 For example:
 
-[source,xml,linenums]
+[source,json,linenums]
 ----
 curl -X POST \
   https://anypoint.mulesoft.com/graph/api/v1/graphql \
   -H 'content-type: application/json' \
-  -d '{"query": "{ assets(asset: { groupId: \"some-group-id\", assetId: \"some-asset-id\", version: \"some-version-1.2.3\" }) { groupId, assetId, version, description, name, type, tags { value, key }, createdBy { id, userName, firstName, lastName }, files { classifier, packaging, externalLink, md5 }, rating, numberOfRates, createdAt, organizationId, assetLink, runtimeVersion, productAPIVersion, dependencies { groupId, assetId, version, name, type }, related(relationshipType: OtherVersions) { groupId, assetId, version, name, type, runtimeVersion, productAPIVersion } } }"}'
+  -d '{"query": "{ assets(query: { searchTerm: \"searchTerm\" }) { groupId, assetId, version } }"}'
+----
+
+The query field contains the GraphQL query, which allows fetching a lot more asset fields.
+
+[source,json,linenums]
+----
+{
+  assets(asset: {groupId: "some-group-id", assetId: "some-asset-id", version: "some-version-1.2.3"}) {
+    # Possible fields to retrieve
+    groupId
+    assetId
+    version
+    description
+    name
+    type
+    tags {
+      value
+      key
+    }
+    createdBy {
+      id
+      userName
+      firstName
+      lastName
+    }
+    files {
+      classifier
+      packaging
+      externalLink
+      md5
+    }
+    rating
+    numberOfRates
+    createdAt
+    organizationId
+    assetLink
+    runtimeVersion
+    productAPIVersion
+    dependencies {
+      groupId
+      assetId
+      version
+      name
+      type
+    }
+    related(relationshipType: OtherVersions) {
+      groupId
+      assetId
+      version
+      name
+      type
+      runtimeVersion
+      productAPIVersion
+    }
+  }
+}
 ----
 
 == To Search Only a Private Exchange


### PR DESCRIPTION
Also, added a longer query example split into multiple lines