### PR TITLE
Update workday-connector-release-notes-mule-4.adoc

### DIFF
--- a/release-notes/v/latest/workday-connector-release-notes-mule-4.adoc
+++ b/release-notes/v/latest/workday-connector-release-notes-mule-4.adoc
@@ -10,7 +10,7 @@ Workday is a software as a service (SaaS) solution developed by Workday comprisi
 The Workday connector requires an Enterprise license.
 
 [IMPORTANT]
-Depending on the Connectivity Conditions while using Workday Connector in Anypoint Studio there can be a time-out while obtaning Workday Metadata. For more details check Increasing Workday Connector Timeout in Studio.
+Depending on the connectivity conditions while using Workday connector in Anypoint Studio, there can be a timeout while obtaning Workday metadata. See link:/connectors/workday-studio#to-increase-timeout-in-studio[To Increase Timeout in Studio].
 
 == 9.2.0
 

--- a/release-notes/v/latest/workday-connector-release-notes-mule-4.adoc
+++ b/release-notes/v/latest/workday-connector-release-notes-mule-4.adoc
@@ -9,6 +9,9 @@ Workday is a software as a service (SaaS) solution developed by Workday comprisi
 
 The Workday connector requires an Enterprise license.
 
+[IMPORTANT]
+Depending on the Connectivity Conditions while using Workday Connector in Anypoint Studio there can be a time-out while obtaning Workday Metadata. For more details check Increasing Workday Connector Timeout in Studio.
+
 == 9.2.0
 
 *March 15, 2018*


### PR DESCRIPTION
@george-hoffer : I've added a warning for Workday connector. By Nathan's request (last week).

This will need editions as we need to also add.
https://github.com/mulesoft/mule-workday-connector/blob/jpestalardo-patch-2/doc/user-manual.adoc#to-increase-timeout-in-studio

As I was not sure where to add the "To increase timeout in studio" in current documention... if it was a better idea to put it as a separated article ... or part of the user manual...
Once it is documented where it corresponds, you'll need to add the link to the changes I'm commiting now.

Please, let me know if this is not clear. 
Thanks!