### PR TITLE
Update configure-autodiscovery-3-task.adoc

### DIFF
--- a/api-manager/v/2.x/configure-autodiscovery-3-task.adoc
+++ b/api-manager/v/2.x/configure-autodiscovery-3-task.adoc
@@ -26,8 +26,6 @@ image::name-version.png[]
 +
 `<api-platform-gw:api apiName="${apiName}" version="${apiVersion}" flowRef="proxy" />`
 +
-The API name consists of a UUID, which is the group ID and the Exchange asset ID. The API version consists of the version name and the instance ID or the label.
-
 
 == Method 2: Studio 6 Configuration
 


### PR DESCRIPTION
Remove clarification around how Crowd2 API Name & Version are generated, this just confuses users as they have to use the values as they are provided.