### PR TITLE
Removing the section of OSv2 cache sharing

### DIFF
--- a/api-manager/v/2.x/caching-in-a-custom-policy-mule-4.adoc
+++ b/api-manager/v/2.x/caching-in-a-custom-policy-mule-4.adoc
@@ -6,7 +6,7 @@ Store]. Information on the https://www.anypoint.mulesoft.com/exchange/org.mule.c
 
 You can enable access to Object Store from Anypoint Platform > Runtime Manager. However, the Runtime Manager object store is only for link:https://docs.mulesoft.com/runtime-manager/cloudhub[CloudHub] and hybrid applications.
 
-An application that stores the data in the object store can, or any of its workers, retrieve the data. The object store provides the cache for your custom policy, thus avoiding making external calls multiple times. In addition, the object store can be used by multiple policies applied in different APIs running in different instances in CloudHub.
+An application that stores the data in the object store can, or any of its workers, retrieve the data. The object store provides the cache for your custom policy, thus avoiding making external calls multiple times. 
 
 == Caching with the Object Store
 
@@ -65,19 +65,6 @@ However, there is a limitation, as the configured entry time to live is
 not honored when using it, as the Object Store connector is not able to 
 create new stores, but rather it uses the default object store partition 
 that has a 30 days TTL.
-
-== Enabling an Object Store for Multiple APIs
-
-When using Object Store v2, you can share the cache between multiple API deployments. 
-To achieve this, the object store configuration needs to have the same name attribute 
-in every deployed policy and also the runtime needs to have a system property 
-named `objectstore.enable.global.sharing` that is set with the value true.
-
-After enabling this, data persisted by a policy running in that instance is also 
-available to policies running in other instances under the same environment.
-
-*Caution:* Enabling the global sharing OSv2 mode makes that object store used by 
-the application or any other policy also shared across all your organization's APIs.  
 
 == Full Example of a Policy Caching with an Object Store
 


### PR DESCRIPTION
Removing the section of OSv2 cache sharing: Since it's not GA'ed yet