### PR TITLE
apikit-for-soap-1.0.5 Release Notes

### DIFF
--- a/release-notes/v/latest/_toc.adoc
+++ b/release-notes/v/latest/_toc.adoc
@@ -284,6 +284,7 @@
 *** link:apikit-for-soap-1.1.2[APIkit for SOAP 1.1.2 Release Notes]
 *** link:apikit-for-soap-1.1.1[APIkit for SOAP 1.1.1 Release Notes]
 *** link:apikit-for-soap-1.1.0[APIkit for SOAP 1.1.0 Release Notes]
+*** link:apikit-for-soap-1.0.5[APIkit for SOAP 1.0.5 Release Notes]
 *** link:apikit-for-soap-1.0.4[APIkit for SOAP 1.0.4 Release Notes]
 *** link:apikit-for-soap-1.0.3[APIkit for SOAP 1.0.3 Release Notes]
 *** link:apikit-for-soap-1.0.2[APIkit for SOAP 1.0.2 Release Notes]

--- a/release-notes/v/latest/apikit-for-soap-1.0.5.adoc
+++ b/release-notes/v/latest/apikit-for-soap-1.0.5.adoc
@@ -1,0 +1,24 @@
+= APIkit for SOAP 1.0.5 Release Notes
+
+This version of APIkit for SOAP includes two fixes to the runtime.
+
+For Anypoint Studio, this version is distributed as Anypoint APIkit SOAP Extension 1.1.5.
+
+== Compatibility
+
+[%header%autowidth.spread]
+|===
+|Software |Version
+|Mule Runtime |3.7.3, 3.8.x, and 3.9.x
+|Anypoint Studio |6.2.3 and later
+|===
+
+== Fixed in This Release
+
+* SOAP Fault namespaces fixed according to SOAP Version (APIKITSOAP-201)
+* Routing to the correct flow when no soapAction is defined (APIKITSOAP-208)
+
+== See Also
+
+* https://forums.mulesoft.com[MuleSoft Forum].
+* https://support.mulesoft.com[Contact MuleSoft Support].

--- a/release-notes/v/latest/apikit-release-notes.adoc
+++ b/release-notes/v/latest/apikit-release-notes.adoc
@@ -4,6 +4,7 @@
 * link:/release-notes/apikit-for-soap-1.1.2[APIkit for SOAP 1.1.2 Release Notes]
 * link:/release-notes/apikit-for-soap-1.1.1[APIkit for SOAP 1.1.1 Release Notes]
 * link:/release-notes/apikit-for-soap-1.1.0[APIkit for SOAP 1.1.0 Release Notes]
+* link:/release-notes/apikit-for-soap-1.0.5[APIkit for SOAP 1.0.5 Release Notes]
 * link:/release-notes/apikit-for-soap-1.0.4[APIkit for SOAP 1.0.4 Release Notes]
 * link:/release-notes/apikit-for-soap-1.0.3[APIkit for SOAP 1.0.3 Release Notes]
 * link:/release-notes/apikit-for-soap-1.0.2[APIkit for SOAP 1.0.2 Release Notes]


### PR DESCRIPTION
Release Notes for the new version of APIKit for Soap 1.0.5