### PR TITLE
DOCS-2463 Add a description of the command palette

### DIFF
--- a/design-center/v/1.0/design-create-publish-api-raml-editor.adoc
+++ b/design-center/v/1.0/design-create-publish-api-raml-editor.adoc
@@ -40,7 +40,7 @@ You can create more than one API specification in a single project. If you want 
 
 . Draft your API specification.
 +
-As you draft, the code editor suggests RAML nodes, methods, and other elements that you can add at the location of your cursor.
+As you draft, the code editor suggests RAML nodes, methods, and other elements that you can add at the location of your cursor. While you are working in the editor, you can use a large number of commands to navigate through and manipulate the content of your specification. Press F1 at any time to see a list of them. This list also displays keyboard shortcuts for most of the commands.
 +
 You can also perform these tasks:
 +


### PR DESCRIPTION
I've added only a few sentences to mention that users can press F1 to see the command palette while they are using the code editor. This palette lists commands that can aid in using the editor, and it shows keyboard shortcuts for most of the commands.