### PR TITLE
Change create attribute to false

### DIFF
--- a/api-manager/v/2.x/api-platform-gw-attributes-3.adoc
+++ b/api-manager/v/2.x/api-platform-gw-attributes-3.adoc
@@ -30,7 +30,7 @@ The following configuration.xml is an example of an API configured for auto-disc
 [source, xml, linenums]
 ----
 <api-platform-gw:api apiName="${apiName}" version="${apiVersion}" flowRef="proxy" 
-  create="true" apikitRef="api-config" doc:name="API Autodiscovery">
+  create="false" apikitRef="api-config" doc:name="API Autodiscovery">
   <api-platform-gw:description>Consume site statistics and perform Q3 computations</api-platform-gw:description>
   <api-platform-gw:tag>Q3results</api-platform-gw:tag>
 </api-platform-gw:api>


### PR DESCRIPTION
This documentation is for API Manager 2.0, so it can't have a create="true" attribute