### PR TITLE
Clarify that maven install is required

### DIFF
--- a/munit/v/1.3/munit-domain-support.adoc
+++ b/munit/v/1.3/munit-domain-support.adoc
@@ -61,14 +61,14 @@ image::munit-domain-support-6f395.png[]
 
 Mavenizing your Mule application and your Mule Domain allows you to expose both *resources* as dependencies for other Maven projects.
 
-==== Your Resources Need to be Installed in an M2 Repository
+==== Your Resources Need to be Installed in an Maven Repository
 
-Remember that when you mavenize your domain, you need to install it in an .M2 repository.
+Remember that when you mavenize your domain, you need to install it in an Maven repository. Note that building the domain and the application for testing in the same execution (eg: mvn clean test -pl 'mydomain,myapp') will not work.
 
 [CAUTION]
 --
 When working with Maven, you need to handle domains and mule apps as regular dependencies. +
-Setting them as an artifact requires for them to be installed in an .M2 repository.
+Setting them as an artifact requires for them to be installed in an Maven repository.
 --
 
 ==== Your Resources Need to be In Your Test Suite pom File


### PR DESCRIPTION
m2 replaced by Maven repository.
Clarify that building and testing in the same execution doesn't work.