### PR TITLE
DOCS-2711 fix

### DIFF
--- a/anypoint-connector-devkit/v/3.8/packaging-your-connector-for-release.adoc
+++ b/anypoint-connector-devkit/v/3.8/packaging-your-connector-for-release.adoc
@@ -88,8 +88,12 @@ MuleSoft's program certifies and publishes third party connectors to be distribu
 
 == Optional - Uploading your Connector to Exchange
 
-If your connector has been certified by MuleSoft, you can publish your connector on the publicly available Anypoint Exchange, and make it accessible from Exchange for download into Anypoint Studio. Anypoint Studio identifies each connector by a *Feature ID* that spans all versions of the connector. In order to expose your connector via link:/anypoint-exchange[Anypoint Exchange], you will be prompted by Anypoint Exchange to provide a few required fields: the Feature ID, Connector version number and an Update Site URL.
+If your connector has been certified by MuleSoft, you can publish your connector on the publicly available Anypoint Exchange, and make it accessible from Exchange for download into Anypoint Studio. To publish your connector, use the Maven Facade described in link:/anypoint-exchange/to-publish-assets-maven[To Publish and Deploy Exchange Assets Using Maven]. 
+Publishing a connector requires obtaining the organization ID for the organization or business group where the connector is available in Exchange.  
 
+////
+The following only applies to the legacy Exchange 1 product. Exchange 2 only supports publishing
+a connector with the Maven Facade.
 
 [NOTE]
 ====
@@ -106,6 +110,8 @@ From Exchange, click *Add Item* > *Connector* and fill out the form before enter
 . Provide the version string, for example `version='1.0.0.201606211519'`, where it reads *Connector version*. Consumers of the connector only see the short version number. For example if the version number you provide is `2.0.1.201606101417`, they only see `2.0.1`. (The full version number displays ONLY when editing the entry in Exchange.)
 . Enter the minimum Mule runtime version required for your connector to work. 
 . Provide the *Update Site URL* for your connector, and complete any other necessary fields for the connector's entry on Anypoint Exchange, such as a link to a documentation website.
+
+////
 
 == Optional - Changing the Studio Category of your Module
 


### PR DESCRIPTION
Added link to the Exchange doc, To Publish an Asset to Exchange Using Maven at https://docs.mulesoft.com/anypoint-exchange/to-publish-assets-maven

Also commented out the extensive note and section that only dealt with the deprecated Exchange 1 product. Users should only use the Maven Facade feature described in the above Exchange doc to publish a connector.