### PR TITLE
wee typo plus two tweaks

### DIFF
--- a/mule4-user-guide/v/4.1/dataweave-types.adoc
+++ b/mule4-user-guide/v/4.1/dataweave-types.adoc
@@ -1,14 +1,16 @@
 = DataWeave Types
 :keywords: studio, anypoint, esb, transform, transformer, format, aggregate, rename, split, filter convert, xml, json, csv, pojo, java object, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping
 
-//TODO: NEED TO MERGE THIS INFO WITH THE CORE TYPES. DISCUSS WITH MDA.
-The built-in DataWeave functions support a number of data types for elements, including arrays, Booleans, objects, dates, times, and many others.
+DataWeave functions operate on data of many types, including arrays, Booleans, objects, dates, and times.
+The types that DataWeave provide are bundled into modules that also contain the related functions. 
 
-NOTE: For a complete reference of core types, visit link:/mule4-user-guide/v/4.1/dw-core-types[Core Types].
+The `dw::Core` module types (core types) are available without having to specify the Core module. Other modules may need to be specified for their functions and types to be available.
 
-== Supported Types
+This topic provides an overview of the commonly used types. A complete reference is available in link:/dw-functions[each module's reference pages].
 
-Core types defined in the `dw::Core` module are available to most built-in DataWeave function modules. Some of the other modules define their own types.
+== Quick Reference
+
+Module reference pages provide complete data type documentation:
 
 * link:dw-core-types[Core Types (dw::Core)]
 * link:dw-runtime-types[Runtime Types (dw::Runtime)]
@@ -16,7 +18,7 @@ Core types defined in the `dw::Core` module are available to most built-in DataW
 * link:dw-diff-types[Diff Types (dw::core::Diff)]
 * link:dw-timer-types[Timer Types (dw::core::Timer)]
 
-This topic also provides information about behaviors common to many DataWeave types:
+This topic provides descriptions of common patterns of use:
 
 * Conditional elements that use `if` expressions for <<conditional_elements_array, arrays>> and <<conditional_elements_object, objects>>.
 * <<string_interpolation>>

--- a/mule4-user-guide/v/4.1/dataweave-types.adoc
+++ b/mule4-user-guide/v/4.1/dataweave-types.adoc
@@ -2,11 +2,13 @@
 :keywords: studio, anypoint, esb, transform, transformer, format, aggregate, rename, split, filter convert, xml, json, csv, pojo, java object, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping
 
 //TODO: NEED TO MERGE THIS INFO WITH THE CORE TYPES. DISCUSS WITH MDA.
-The built-in DataWeave functions support a number of data types for elements, including arrays, Booleans, objects, dates, times, and many others described here.
+The built-in DataWeave functions support a number of data types for elements, including arrays, Booleans, objects, dates, times, and many others.
+
+NOTE: For a complete reference of core types, visit link:/mule4-user-guide/v/4.1/dw-core-types[Core Types].
 
 == Supported Types
 
-Core types from the `dw::Core`) are available to most built-in DataWeave function modules. Some of the other modules define their own types.
+Core types defined in the `dw::Core` module are available to most built-in DataWeave function modules. Some of the other modules define their own types.
 
 * link:dw-core-types[Core Types (dw::Core)]
 * link:dw-runtime-types[Runtime Types (dw::Runtime)]
@@ -14,14 +16,14 @@ Core types from the `dw::Core`) are available to most built-in DataWeave functio
 * link:dw-diff-types[Diff Types (dw::core::Diff)]
 * link:dw-timer-types[Timer Types (dw::core::Timer)]
 
-The remaining sections below provide more detail on data types that are commonly used or sometimes misunderstood. They also cover some important topics that relate to the data type, for example:
+This topic also provides information about behaviors common to many DataWeave types:
 
 * Conditional elements that use `if` expressions for <<conditional_elements_array, arrays>> and <<conditional_elements_object, objects>>.
-* <<string_interpolation>>.
-* <<date_decomposition>> for accessing different parts of a date.
-* <<date_format_change>>.
-* <<dynamic_keys>> and <<dynamic_elements>>, which allow you to access parts of an object dynamically.
-* Use of <<dw_type_regex>> expressions.
+* <<string_interpolation>>
+* <<date_decomposition>> for accessing different parts of a date
+* <<date_format_change>>
+* <<dynamic_keys>> and <<dynamic_elements>>, which allow you to access parts of an object dynamically
+* Use of <<dw_type_regex>> expressions
 
 == Array (dw::Core Type)
 

--- a/mule4-user-guide/v/4.1/dataweave-types.adoc
+++ b/mule4-user-guide/v/4.1/dataweave-types.adoc
@@ -1,24 +1,11 @@
 = DataWeave Types
 :keywords: studio, anypoint, esb, transform, transformer, format, aggregate, rename, split, filter convert, xml, json, csv, pojo, java object, metadata, dataweave, data weave, datamapper, dwl, dfl, dw, output structure, input structure, map, mapping
 
-DataWeave functions operate on data of many types, including arrays, Booleans, objects, dates, and times.
-The types that DataWeave provide are bundled into modules that also contain the related functions. 
+DataWeave functions operate on data of many types, including arrays, Booleans, objects, dates, and times. The types that DataWeave provide are bundled into modules that also contain the related functions. 
 
-The `dw::Core` module types (core types) are available without having to specify the Core module. Other modules may need to be specified for their functions and types to be available.
+Types in the `dw::Core` module (Core types) are available without having to import the Core module. Other modules need to be imported for their functions and types to be available.
 
-This topic provides an overview of the commonly used types. A complete reference is available in link:/dw-functions[each module's reference pages].
-
-== Quick Reference
-
-Module reference pages provide complete data type documentation:
-
-* link:dw-core-types[Core Types (dw::Core)]
-* link:dw-runtime-types[Runtime Types (dw::Runtime)]
-* link:dw-url-types[URL Types (dw::core::URL)]
-* link:dw-diff-types[Diff Types (dw::core::Diff)]
-* link:dw-timer-types[Timer Types (dw::core::Timer)]
-
-This topic provides descriptions of common patterns of use:
+This topic provides an introduction to some DataWeave types, and descriptions of common patterns, including:
 
 * Conditional elements that use `if` expressions for <<conditional_elements_array, arrays>> and <<conditional_elements_object, objects>>.
 * <<string_interpolation>>
@@ -590,6 +577,15 @@ Evaluates the delegate and returns an object with the result or an error message
 ----
 
 == See Also
+
+You can find complete data type documentation in the Module reference pages:
+
+* link:dw-core-types[Core Types (dw::Core)]
+* link:dw-runtime-types[Runtime Types (dw::Runtime)]
+* link:dw-url-types[URL Types (dw::core::URL)]
+* link:dw-diff-types[Diff Types (dw::core::Diff)]
+* link:dw-timer-types[Timer Types (dw::core::Timer)]
+
 
 link:dataweave-language-introduction[DataWeave Language Introduction]
 


### PR DESCRIPTION
I saw a random close parens and removed it, then added a link to the ref doc and cleaned up an intro para that was a little long. It's all at the top of the topic.