### PR TITLE
Correct annotation for Stop method

### DIFF
--- a/anypoint-connector-devkit/v/3.7/annotation-reference.adoc
+++ b/anypoint-connector-devkit/v/3.7/annotation-reference.adoc
@@ -2376,7 +2376,7 @@ Mark a method to be stopped during a method's `org.mule.lifecycle.Stoppable` pha
 
 [source, code, linenums]
 ----
-@Start
+@Stop
 public void mystop() {
     if ( this.sessionId != null ) {
        serviceProvider.logout(sessionId);


### PR DESCRIPTION
Stop method was shown using the @Start annotation rather than @Stop