### PR TITLE
Add APIkit for ODATA 1.0.7 to release notes TOCs

### DIFF
--- a/release-notes/v/latest/_toc.adoc
+++ b/release-notes/v/latest/_toc.adoc
@@ -284,6 +284,7 @@
 ** link:api-mocking-service-release-notes[API Mocking Service Release Notes]
 ** link:api-notebook-release-notes[API Notebook Release Notes]
 ** link:apikit-release-notes[APIkit Release Notes]
+*** link:apikit-for-odata-1.0.7[APIkit for OData 1.0.7 Release Notes]
 *** link:apikit-for-odata-1.0.6[APIkit for OData 1.0.6 Release Notes]
 *** link:apikit-for-soap-1.1.3[APIkit for SOAP 1.1.3 Release Notes]
 *** link:apikit-for-soap-1.1.2[APIkit for SOAP 1.1.2 Release Notes]

--- a/release-notes/v/latest/apikit-release-notes.adoc
+++ b/release-notes/v/latest/apikit-release-notes.adoc
@@ -1,5 +1,6 @@
 = APIkit Release Notes
 
+* link:/release-notes/apikit-for-odata-1.0.7[APIkit for OData 1.0.7 Release Notes]
 * link:/release-notes/apikit-for-odata-1.0.6[APIkit for OData 1.0.6 Release Notes]
 * link:/release-notes/apikit-for-soap-1.1.3[APIkit for SOAP 1.1.3 Release Notes]
 * link:/release-notes/apikit-for-soap-1.1.2[APIkit for SOAP 1.1.2 Release Notes]


### PR DESCRIPTION
This adds the files in PR #3116 to the table of contents of our documentation structure