### PR TITLE
Anypoint Studio 7.1.x is not downloable anymore

### DIFF
--- a/anypoint-studio/v/7.1/_toc.adoc
+++ b/anypoint-studio/v/7.1/_toc.adoc
@@ -1,10 +1,10 @@
 
 * link:/anypoint-studio/v/7.1/index[About Anypoint Studio]
 
-** link:/anypoint-studio/v/7.1/to-download-and-install-studio[To Download and Install Anypoint Studio 7.1]
-*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-wx[To Download and Install Anypoint Studio 7.1 (Windows)]
-*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-ox[To Download and Install Anypoint Studio 7.1 (OSx)]
-*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-lx[To Download and Install Anypoint Studio 7.1 (Linux)]
+** link:/anypoint-studio/v/7.1/to-download-and-install-studio[To Install Anypoint Studio 7.1]
+*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-wx[To Install Anypoint Studio 7.1 (Windows)]
+*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-ox[To Install Anypoint Studio 7.1 (OSx)]
+*** link:/anypoint-studio/v/7.1/to-download-and-install-studio-lx[To Install Anypoint Studio 7.1 (Linux)]
 ** link:/anypoint-studio/v/7.1/faq-default-browser-config[FAQ: Troubleshooting Issues with Your Default OS Browser]
 *** link:/anypoint-studio/v/7.1/studio-xulrunner-wx-task[To Configure XULRunner as Studio's Default Layout Engine (Windows)]
 *** link:/anypoint-studio/v/7.1/studio-xulrunner-lnx-task[To Configure XULRunner as Studio's Default Layout Engine (Linux)]

--- a/anypoint-studio/v/7.1/to-download-and-install-studio-lx.adoc
+++ b/anypoint-studio/v/7.1/to-download-and-install-studio-lx.adoc
@@ -1,12 +1,14 @@
-= To Download and Install Anypoint Studio 7.1 (Linux)
+= To Install Anypoint Studio 7.1 (Linux)
 
 To support some of Studio Themes in Linux, it is recommended to have GTK version 2 installed.
 
 * Before downloading and launching Anypoint Studio, make sure you have the Java SE JDK 8 installed.
 
+You can only download the latest version of Anypoint Studio. These instructions are covered only if you already have the corresponding ZIP file for an older version.
+
 To install Anypoint Studio 7.1:
 
-. Download Anypoint Studio from the link:https://www.mulesoft.com/lp/dl/studio[Anypoint Studio Download Site] and extract it.
+. Extract your Anypoint Studio 7.1 ZIP file.
 . Open the extracted Anypoint Studio.
 . Click OK to accept the default workspace. +
 When setting a custom path to your workspace, keep in mind that Anypoint Studio does not expand the `~` tilde used in Unix/Linux systems. It is recommended to use the absolute path when defining your workspace.

--- a/anypoint-studio/v/7.1/to-download-and-install-studio-ox.adoc
+++ b/anypoint-studio/v/7.1/to-download-and-install-studio-ox.adoc
@@ -1,10 +1,12 @@
-= To Download and Install Anypoint Studio 7.1 (OSx)
+= To Install Anypoint Studio 7.1 (OSx)
 
-* Before downloading and launching Anypoint Studio, make sure you have the Java SE JDK 8 installed.
+* Before installing Anypoint Studio, make sure you have the Java SE JDK 8 installed.
+
+You can only download the latest version of Anypoint Studio. These instructions are covered only if you already have the corresponding ZIP file for an older version.
 
 To install Anypoint Studio 7.1:
 
-. Download Anypoint Studio from the link:https://www.mulesoft.com/lp/dl/studio[Anypoint Studio Download Site] and extract it.
+. Extract Anypoint Studio 7.1 ZIP file. +
 If you're using OS version Sierra, it's important that you move your extracted app to the `/Applications` folder before you launch it.
 . Open the extracted Anypoint Studio:
 . Click OK to accept the default workspace. +

--- a/anypoint-studio/v/7.1/to-download-and-install-studio-wx.adoc
+++ b/anypoint-studio/v/7.1/to-download-and-install-studio-wx.adoc
@@ -1,10 +1,12 @@
-= To Download and Install Anypoint Studio 7.1 (Windows)
+= To Install Anypoint Studio 7.1 (Windows)
 
-* Before downloading and launching Anypoint Studio, make sure you have the Java SE JDK 8 installed.
+* Before installing Anypoint Studio, make sure you have the Java SE JDK 8 installed.
+
+You can only download the latest version of Anypoint Studio. These instructions are covered only if you already have the corresponding ZIP file for an older version.
 
 To install Anypoint Studio 7.1:
 
-. Download Anypoint Studio from the link:https://www.mulesoft.com/lp/dl/studio[Anypoint Studio Download Site] and extract it into the 'C:\' root folder. +
+. Extract your Anypoint Studio 7.1 ZIP file into the 'C:\' root folder. +
 If you are using a Windows Anti-Virus application, ensure that the `plugin/` and `features/` directories are under the “trusted” category.
 . Open the extracted Anypoint Studio.
 . Click OK to accept the default workspace. +

--- a/anypoint-studio/v/7.1/to-download-and-install-studio.adoc
+++ b/anypoint-studio/v/7.1/to-download-and-install-studio.adoc
@@ -1,10 +1,10 @@
-= To Download and Install Anypoint Studio 7.1
+= To Install Anypoint Studio 7.1
 
-To download and install Aynpoint Studio 7.1, follow the instructions based on your operative system:
+You can only download the latest version of Anypoint Studio. These instructions are covered only if you already have the corresponding ZIP file for an older version:
 
-* link:/anypoint-studio/v/7.1/to-download-and-install-studio-wx[To Download and Install Anypoint Studio 7.1 (Windows)]
-* link:/anypoint-studio/v/7.1/to-download-and-install-studio-ox[To Download and Install Anypoint Studio 7.1 (OSx)]
-* link:/anypoint-studio/v/7.1/to-download-and-install-studio-lx[To Download and Install Anypoint Studio 7.1 (Linux)]
+* link:/anypoint-studio/v/7.1/to-download-and-install-studio-wx[To Install Anypoint Studio 7.1 (Windows)]
+* link:/anypoint-studio/v/7.1/to-download-and-install-studio-ox[To Install Anypoint Studio 7.1 (OSx)]
+* link:/anypoint-studio/v/7.1/to-download-and-install-studio-lx[To Install Anypoint Studio 7.1 (Linux)]
 
 [NOTE]
-Anypoint Studio 7.x only supports Mule 4.x projects since the structure of the project, export format, XML and scripting language are different. 
+Anypoint Studio 7.x only supports Mule 4.x projects since the structure of the project, export format, XML and scripting language are different.


### PR DESCRIPTION
This requires for us to update the instructions in the "download and install" older versions for Studio.