### PR TITLE
Changed latest release date

### DIFF
--- a/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
+++ b/release-notes/v/latest/cloudhub-runtimes-release-notes.adoc
@@ -4,7 +4,7 @@
 These are the release notes for patches which are made to the Mule runtimes on CloudHub. In addition to these release notes, see the link:/release-notes/cloudhub-release-notes[CloudHub release notes] and complete link:/runtime-manager/cloudhub[CloudHub] documentation.
 
 
-== August 14, 2018
+== August 13, 2018
 
 4.1.2 Runtime Update:
 


### PR DESCRIPTION
The release date needs to match the same one showed in the admin UI on CloudHub when deploying an application