### PR TITLE
Adding info about whitelisting hosts and ports

### DIFF
--- a/eu-control-plane/v/latest/servers-create-eu.adoc
+++ b/eu-control-plane/v/latest/servers-create-eu.adoc
@@ -13,7 +13,54 @@ The procedures for creating a server are similar to those for creating a server 
 
 This flag ensures that the server connects to Runtime Manager in the EU control plane. When you click Add Server in the  Runtime Manager > Servers tab, Runtime Manager in the EU control plane automatically inserts this flag in the generated script.
 
+== Ports IPs and hostnames to Whitelist
+
+In your network, you may need to whitelist the hostnames and ports of various parts of the Anypoint Platform to allow the Runtime Manager Agent in a customer-hosted Mule runtime to communicate with the MuleSoft-managed online Anypoint Platform APIs and services.
+
+These tables show you the ports or IPs/hostnames to add to your whitelists to allow communication between the Runtime Manager Agent and the Runtime Manager console:
+
+*Ports*
+
+[%header,cols="2*a"]
+|===
+|Name |Port
+|*eu1.anypoint.mulesoft.com* | 443
+|*mule-manager.eu1.anypoint.mulesoft.com* | 443
+|*analytics-ingest.eu1.anypoint.mulesoft.com* |  443
+|*arm-auth-proxy.prod-eu.msap.io* |  443
+|===
+
+*Static IPs*
+
+There are two Static IPs that needs to be whitelisted to access the mule-manager.eu1.anypoint.mulesoft.com hostname.
+
+[%header,cols="2*a"]
+|===
+|Name |IP Address
+|*mule-manager.anypoint.eu1.mulesoft.com* |18.194.245.32
+|*mule-manager.anypoint.eu1.mulesoft.com* |18.195.19.18
+|===
+
+*Dynamic IPs*
+
+Some of the IP addresses used by Anypoint services are assigned automatically by the underlying cloud infrastructure, and hence we can't guarantee that they are not going to change in the future.
+
+For this reason, you should not implement a whitelist based on the specific IP addresses being assigned to Anypoint services.
+
+Nowadays, many firewall devices allow you to define Layer 7 Firewall Rules, where you could be able to filter by destination name or application type.
+
+The hostnames that you should include in your Layer 7 Firewall rules include:
+
+[%header,cols="1*a"]
+|===
+|Hostname
+|*eu1.anypoint.mulesoft.com*
+|*analytics-ingest.eu1.anypoint.mulesoft.com*
+|*arm-auth-proxy.prod-eu.msap.io*
+|===
+
 == See Also
 
 * link:/runtime-manager/servers-create[To Create a Server in Runtime Manager (Hybrid)]
+* link:/runtime-manager/installing-and-configuring-runtime-manager-agent[To Install and Configure the Runtime Manager Agent]
 * link:/eu-control-plane/platform-access-eu[To Access the EU Control Plane]


### PR DESCRIPTION
Added information about whitelisting host and ports needed to add a server to EU Control Plane since the Runtime Manager Agent documentation only covers the US control plane.