### PR TITLE
Update installing-and-configuring-runtime-manager-agent.adoc

### DIFF
--- a/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
+++ b/runtime-manager/v/latest/installing-and-configuring-runtime-manager-agent.adoc
@@ -909,6 +909,13 @@ globalConfiguration:
     password: "examplePassword"
 ----
 
+== Known Issues
+
+[%header,cols="15a,85a"]
+|===
+|Issue |Description
+| SE-8011 | Agent setup returning '407 Proxy Authentication Required' when passing proxy information during setup.
+|===
 
 == See Also
 


### PR DESCRIPTION
Since JDK 8u111+ Oracle has disabled basic authentication for HTTPS tunneling.

Proxies requiring Basic Authentication when setting up a tunnel for HTTPS will no longer succeed by default.

The section **Installation Via Proxy** is affected by this issue.