### PR TITLE
Fixing the sentence from '#3247 Revert "Fix grammatical error in message-state.adoc"'

### DIFF
--- a/mule-user-guide/v/3.7/message-state.adoc
+++ b/mule-user-guide/v/3.7/message-state.adoc
@@ -127,7 +127,7 @@ image:keyValuePair.png[keyValuePair]
 
 ==== Properties
 
-As Mule message processors cannot add, remove, or act upon *inbound properties*, none has changed.
+Because Mule message processors cannot add, remove, or copy any *inbound properties, none of the values of these properties have changed.
 
 image:inbound2.png[inbound2]
 


### PR DESCRIPTION
PR #3247 changed "none have changed" back to the original, incorrect "none has changed" because the person who submitted a PR to change "has" to "have" had not yet agreed to the terms for contributing to our repo. The writer who created PR #3247 did not subsequently change "has" back to "have", but instead left the sentence incorrect.

We should never simply revert a change back to an ungrammatical form and leave the error in the docs. There should always be a follow-up PR submitted to again revert the ungrammatical form to a grammatical one. This PR takes care of that in this case.

Moreover, as I pointed out to the writer who submitted #3247, the antecedent of the subject -- "none" -- of the sentence in question is ambiguous. I've resolved that ambiguity.