### PR TITLE
MetaDataRetriever return type miss match

### DIFF
--- a/anypoint-connector-devkit/v/3.9/multiple-level-datasense-support.adoc
+++ b/anypoint-connector-devkit/v/3.9/multiple-level-datasense-support.adoc
@@ -87,7 +87,8 @@ public class CustomSeparatorComposedKeyCategory {
                              .endDynamicObject()
                          .build();
         }
-        return new DefaultMetaData(model);
+        MetaData metaData = new DefaultMetaData(model);
+        return metaData;
     }
 }
 ----


### PR DESCRIPTION
Return type of MetaDataRetriever is metaData and it is returning DefaultMetaData so type miss match.
I have just added 1 line of code.