### PR TITLE
single thread pool for runtime, instead of an app

### DIFF
--- a/mule4-user-guide/v/4.1/intro-engine.adoc
+++ b/mule4-user-guide/v/4.1/intro-engine.adoc
@@ -24,6 +24,6 @@ Mule 4 decouples thread configuration from concurrency management. To control co
 
 == Thread Pools and Tuning apps
 
-As mentioned above, there is now a single thread pool for all flows in an app. This decouples overall tuning from flow-specific behavior. Mule allocates threads in proportion to how many CPU cores your machine has. You can tune this thread count by using the self-documented `conf/scheduler-pools.conf` file.
+As mentioned above, there is now a single thread pool for all flows in the Mule runtime. This decouples overall tuning from flow-specific behavior. Mule allocates threads in proportion to how many CPU cores your machine has. You can tune this thread count by using the self-documented `conf/scheduler-pools.conf` file.
 
 Each Mule event processor can now inform the runtime if it is a CPU-intensive, CPU-light, or IO-intensive operation. This helps the runtime self-tune for different workloads dynamically, removing the need for you to manage thread pools manually. As a result, Mule 4 removes complex tuning requirements to achieve optimum performance.


### PR DESCRIPTION
based on discussion in Slack https://mulesoft.slack.com/archives/C02KJHQU0/p1536196215000100

modified from

"As mentioned above, there is now a single thread pool for all flows in an app."

to 

"As mentioned above, there is now a single thread pool for all flows in the Mule runtime."